### PR TITLE
Add Docker deployment with authenticated MongoDB

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+client/node_modules
+client/dist
+.env
+.git
+.gitignore
+uploads
+*.log
+.DS_Store

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,10 @@
 # Server
 PORT=3000
 
-# MongoDB (credentials required – see scripts/setup-db.js for user creation)
-MONGODB_URI=mongodb://appuser:CHANGE_ME_PASSWORD@localhost:27017/instant-sharing-tool?authSource=instant-sharing-tool
+# MongoDB – docker-compose constructs MONGODB_URI from these automatically
+MONGO_ROOT_PASSWORD=change-me-root-password
+MONGO_APP_USER=appuser
+MONGO_APP_PASSWORD=change-me-app-password
 
 # Session secret (generate a long random string)
 SESSION_SECRET=change-me-to-a-long-random-secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# ---- Stage 1: Build React client ----
+FROM node:20-alpine AS builder
+WORKDIR /app/client
+COPY client/package*.json ./
+RUN npm ci
+COPY client/ ./
+RUN npm run build
+
+# ---- Stage 2: Production server ----
+FROM node:20-alpine AS production
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY app.js ./
+COPY src/ ./src/
+COPY --from=builder /app/client/dist ./client/dist/
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup \
+  && mkdir -p uploads \
+  && chown appuser:appgroup uploads
+
+USER appuser
+
+EXPOSE 3000
+CMD ["node", "app.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  app:
+    build: .
+    ports:
+      - "${PORT:-3000}:3000"
+    environment:
+      MONGODB_URI: "mongodb://${MONGO_APP_USER:-appuser}:${MONGO_APP_PASSWORD}@mongo:27017/instant-sharing-tool?authSource=instant-sharing-tool"
+      SESSION_SECRET: "${SESSION_SECRET}"
+      BASE_URL: "${BASE_URL:-http://localhost:3000}"
+      MAX_FILE_SIZE_MB: "${MAX_FILE_SIZE_MB:-100}"
+      ALLOW_REGISTRATION: "${ALLOW_REGISTRATION:-true}"
+    volumes:
+      - uploads:/app/uploads
+    depends_on:
+      mongo:
+        condition: service_healthy
+    restart: unless-stopped
+
+  mongo:
+    image: mongo:7
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: "${MONGO_ROOT_PASSWORD}"
+      MONGO_INITDB_DATABASE: instant-sharing-tool
+      MONGO_APP_USER: "${MONGO_APP_USER:-appuser}"
+      MONGO_APP_PASSWORD: "${MONGO_APP_PASSWORD}"
+    volumes:
+      - mongo_data:/data/db
+      - ./scripts/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >
+          mongosh --quiet --eval "db.adminCommand('ping').ok"
+          -u $$MONGO_INITDB_ROOT_USERNAME
+          -p $$MONGO_INITDB_ROOT_PASSWORD
+          --authenticationDatabase admin
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  uploads:
+  mongo_data:

--- a/scripts/mongo-init.js
+++ b/scripts/mongo-init.js
@@ -1,0 +1,19 @@
+/**
+ * Executed by mongosh on first container start via docker-entrypoint-initdb.d.
+ * Creates the application database user with least-privilege access.
+ */
+
+const appUser = process.env.MONGO_APP_USER || 'appuser';
+const appPass = process.env.MONGO_APP_PASSWORD;
+
+if (!appPass) {
+  throw new Error('MONGO_APP_PASSWORD is not set – cannot create app user.');
+}
+
+db.getSiblingDB('instant-sharing-tool').createUser({
+  user: appUser,
+  pwd: appPass,
+  roles: [{ role: 'readWrite', db: 'instant-sharing-tool' }],
+});
+
+print(`MongoDB: created user '${appUser}' on database 'instant-sharing-tool'.`);


### PR DESCRIPTION
- Dockerfile: multi-stage build (Vite client → Node production image), runs as non-root user
- docker-compose.yml: app + mongo:7 services; app waits for healthy mongo; MONGODB_URI is constructed from MONGO_APP_USER/MONGO_APP_PASSWORD
- scripts/mongo-init.js: creates least-privilege app user on first start
- .dockerignore: keeps image lean
- .env.example: replaced MONGODB_URI with separate credential vars

https://claude.ai/code/session_01J7C8n7aPQyTeRQ7eovMNXR