### PR TITLE
Expose MongoDB port 27017 on localhost for local access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
 
   mongo:
     image: mongo:7
+    ports:
+      - "127.0.0.1:27017:27017"
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: "${MONGO_ROOT_PASSWORD}"


### PR DESCRIPTION
Binds only to 127.0.0.1 to avoid public exposure.

https://claude.ai/code/session_015bzrQyhoTpeyhVxKrWxGX1