### PR TITLE
Organize uploaded files into user-specific directories

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,10 +3,13 @@ const express = require('express');
 const session = require('express-session');
 const MongoStore = require('connect-mongo');
 const path = require('path');
+const fs = require('fs');
 const connectDB = require('./src/config/db');
 const uploadMiddleware = require('./src/middleware/upload');
 const { requireApiKey } = require('./src/middleware/auth');
 const File = require('./src/models/File');
+
+const UPLOAD_DIR = path.join(__dirname, 'uploads');
 
 const app = express();
 
@@ -23,15 +26,30 @@ app.use(session({
   cookie: { maxAge: 1000 * 60 * 60 * 24 * 7 },
 }));
 
-// ShareX upload endpoint — multer runs first so req.body.token is available for auth
+// ShareX upload endpoint — multer runs first so req.body.token is available for auth.
+// Because auth runs after multer, the file lands in the root uploads dir initially;
+// we move it into the user's subfolder once the user identity is known.
 app.post('/upload', uploadMiddleware.single('upload'), requireApiKey, async (req, res) => {
   if (!req.file) return res.status(400).json({ error: 'No file provided' });
+
+  const user = req.apiUser;
+  const folder = user.folderName || user.username;
+  let storedName = req.file.filename;
+
+  if (folder) {
+    const userDir = path.join(UPLOAD_DIR, folder);
+    fs.mkdirSync(userDir, { recursive: true });
+    const newPath = path.join(userDir, req.file.filename);
+    fs.renameSync(req.file.path, newPath);
+    storedName = path.join(folder, req.file.filename);
+  }
+
   const file = await File.create({
     originalName: req.file.originalname,
-    storedName: req.file.filename,
+    storedName,
     mimeType: req.file.mimetype,
     size: req.file.size,
-    uploader: req.apiUser._id,
+    uploader: user._id,
   });
   const base = process.env.BASE_URL || 'http://localhost:3000';
   res.json({ url: `${base}/f/${file.shortId}` });

--- a/src/middleware/upload.js
+++ b/src/middleware/upload.js
@@ -1,12 +1,33 @@
 const multer = require('multer');
 const path = require('path');
 const crypto = require('crypto');
+const fs = require('fs');
+const User = require('../models/User');
 
 const UPLOAD_DIR = path.join(__dirname, '../../uploads');
 const MAX_MB = parseInt(process.env.MAX_FILE_SIZE_MB || '100', 10);
 
 const storage = multer.diskStorage({
-  destination: (_req, _file, cb) => cb(null, UPLOAD_DIR),
+  destination: async (req, _file, cb) => {
+    try {
+      // req.apiUser is set by requireApiKey; req.session.user by requireLogin.
+      // Both are available here only when auth middleware runs BEFORE multer.
+      const userId = req.apiUser?._id || req.session?.user?.id;
+      if (userId) {
+        const user = await User.findById(userId).select('folderName username');
+        const folder = user?.folderName || user?.username;
+        if (folder) {
+          const dir = path.join(UPLOAD_DIR, folder);
+          fs.mkdirSync(dir, { recursive: true });
+          return cb(null, dir);
+        }
+      }
+      // Fallback: root uploads dir (e.g. when auth runs after multer in app.js)
+      cb(null, UPLOAD_DIR);
+    } catch (err) {
+      cb(err);
+    }
+  },
   filename: (_req, file, cb) => {
     const ext = path.extname(file.originalname);
     const id = crypto.randomBytes(4).toString('hex');

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -14,9 +14,12 @@ const BASE_URL = () => process.env.BASE_URL || 'http://localhost:3000';
 router.post('/upload', requireApiKey, upload.single('file'), async (req, res) => {
   if (!req.file) return res.status(400).json({ error: 'No file provided' });
 
+  // storedName is relative to UPLOAD_DIR (e.g. "username/a1b2c3d4.jpg")
+  const storedName = path.relative(UPLOAD_DIR, req.file.path);
+
   const file = await File.create({
     originalName: req.file.originalname,
-    storedName: req.file.filename,
+    storedName,
     mimeType: req.file.mimetype,
     size: req.file.size,
     uploader: req.apiUser._id,
@@ -41,9 +44,11 @@ router.post('/web-upload', requireLogin, upload.array('files', 20), async (req, 
 
   const created = [];
   for (const f of req.files) {
+    // storedName is relative to UPLOAD_DIR (e.g. "username/a1b2c3d4.jpg")
+    const storedName = path.relative(UPLOAD_DIR, f.path);
     const doc = await File.create({
       originalName: f.originalname,
-      storedName: f.filename,
+      storedName,
       mimeType: f.mimetype,
       size: f.size,
       uploader: req.session.user.id,


### PR DESCRIPTION
## Summary
This PR implements user-specific directory organization for uploaded files. Instead of storing all uploads in a single directory, files are now organized into subdirectories based on each user's folder name or username.

## Key Changes

- **app.js**: 
  - Added `fs` module and `UPLOAD_DIR` constant
  - Updated `/upload` endpoint to move files into user-specific subdirectories after authentication
  - Modified file storage to use relative paths (e.g., `username/filename.jpg`)

- **src/middleware/upload.js**:
  - Enhanced multer storage configuration to determine destination directory based on authenticated user
  - Automatically creates user subdirectories with `fs.mkdirSync()`
  - Falls back to root uploads directory when user context is unavailable
  - Handles both API key authentication (`req.apiUser`) and session-based authentication (`req.session.user`)

- **src/routes/api.js**:
  - Updated both `/upload` and `/web-upload` endpoints to store relative paths in the database
  - Uses `path.relative()` to convert absolute file paths to paths relative to `UPLOAD_DIR`

## Implementation Details

- The solution handles the timing of authentication middleware by supporting both scenarios:
  - When auth runs before multer: files are placed directly in user directories
  - When auth runs after multer: files are moved to user directories after authentication
- User directory names are determined by `folderName` (if set) or `username` as fallback
- Stored file paths in the database are now relative (e.g., `"username/a1b2c3d4.jpg"`) rather than just filenames, enabling proper file retrieval from user-specific directories

https://claude.ai/code/session_01GDvJaUWosXqx3QSgNJRX1c