### PR TITLE
Add XBackBone bulk import feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -57,6 +57,7 @@ app.post('/upload', uploadMiddleware.single('upload'), requireApiKey, async (req
 
 // JSON API routes
 app.use('/api/auth', require('./src/routes/auth'));
+app.use('/api/admin/import', require('./src/routes/import'));
 app.use('/api', require('./src/routes/api'));
 
 // Raw file serving (not JSON)

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -12,6 +12,7 @@ import FileView from '@/pages/FileView';
 import AdminDashboard from '@/pages/admin/Dashboard';
 import AdminUsers from '@/pages/admin/Users';
 import AdminFiles from '@/pages/admin/Files';
+import AdminImport from '@/pages/admin/Import';
 
 function App() {
   return (
@@ -31,6 +32,7 @@ function App() {
           <Route path="/admin" element={<ProtectedRoute adminOnly><Layout><AdminDashboard /></Layout></ProtectedRoute>} />
           <Route path="/admin/users" element={<ProtectedRoute adminOnly><Layout><AdminUsers /></Layout></ProtectedRoute>} />
           <Route path="/admin/files" element={<ProtectedRoute adminOnly><Layout><AdminFiles /></Layout></ProtectedRoute>} />
+          <Route path="/admin/import" element={<ProtectedRoute adminOnly><Layout><AdminImport /></Layout></ProtectedRoute>} />
 
           {/* Fallback */}
           <Route path="*" element={<Navigate to="/gallery" replace />} />

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -6,7 +6,7 @@ import {
   DropdownMenu, DropdownMenuContent, DropdownMenuItem,
   DropdownMenuSeparator, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Images, Upload, Settings, LogOut, User, LayoutDashboard, ChevronDown } from 'lucide-react';
+import { Images, Upload, Settings, LogOut, User, LayoutDashboard, ChevronDown, PackageOpen } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 function NavLink({ to, children, icon: Icon }) {
@@ -74,6 +74,11 @@ export function Layout({ children }) {
                   <DropdownMenuItem asChild>
                     <Link to="/admin/users" className="flex items-center gap-2 cursor-pointer">
                       <User className="h-4 w-4" />Users
+                    </Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
+                    <Link to="/admin/import" className="flex items-center gap-2 cursor-pointer">
+                      <PackageOpen className="h-4 w-4" />Import XBackBone
                     </Link>
                   </DropdownMenuItem>
                 </>

--- a/client/src/pages/admin/Import.jsx
+++ b/client/src/pages/admin/Import.jsx
@@ -1,0 +1,353 @@
+import { useState, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useToast } from '@/hooks/use-toast';
+import { Upload, FileSearch, CheckCircle2, AlertCircle, SkipForward, ArrowRight } from 'lucide-react';
+
+// ── Step indicator ─────────────────────────────────────────────────────────────
+
+function Step({ n, label, active, done }) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold shrink-0 ${
+        done ? 'bg-primary text-primary-foreground' :
+        active ? 'bg-primary/20 text-primary border border-primary' :
+        'bg-muted text-muted-foreground'
+      }`}>
+        {done ? <CheckCircle2 className="h-4 w-4" /> : n}
+      </div>
+      <span className={`text-sm ${active ? 'font-medium' : 'text-muted-foreground'}`}>{label}</span>
+    </div>
+  );
+}
+
+// ── Result badge ───────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }) {
+  if (status === 'imported') return <Badge className="bg-green-500/15 text-green-700 border-green-200 hover:bg-green-500/15">Imported</Badge>;
+  if (status === 'skipped') return <Badge variant="secondary">Skipped</Badge>;
+  return <Badge variant="destructive">Error</Badge>;
+}
+
+// ── Main component ─────────────────────────────────────────────────────────────
+
+export default function AdminImport() {
+  const { toast } = useToast();
+  const dbInputRef = useRef(null);
+
+  // Step 1: DB upload + preview
+  const [dbFile, setDbFile] = useState(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [preview, setPreview] = useState(null); // { users, localUsers }
+
+  // Step 2: configure mapping
+  const [storagePath, setStoragePath] = useState('');
+  const [userMapping, setUserMapping] = useState({}); // xbbId → localUsername | ''
+  const [defaultUser, setDefaultUser] = useState('');
+
+  // Step 3: import results
+  const [importing, setImporting] = useState(false);
+  const [result, setResult] = useState(null); // { imported, skipped, errors, details }
+
+  const step = result ? 3 : preview ? 2 : 1;
+
+  // ── Step 1: load preview from DB ───────────────────────────────────────────
+
+  async function handlePreview() {
+    if (!dbFile) return;
+    setPreviewing(true);
+    setPreview(null);
+    setResult(null);
+    try {
+      const form = new FormData();
+      form.append('db', dbFile);
+
+      const r = await fetch('/api/admin/import/xbackbone/preview', { method: 'POST', body: form });
+      const data = await r.json();
+      if (!r.ok) throw new Error(data.error);
+
+      // Pre-fill mapping with auto-matched users
+      const initialMapping = {};
+      for (const xu of data.users) {
+        initialMapping[xu.xbbId] = xu.matchedLocalUser || '';
+      }
+      setUserMapping(initialMapping);
+      setPreview(data);
+    } catch (err) {
+      toast({ title: err.message, variant: 'destructive' });
+    } finally {
+      setPreviewing(false);
+    }
+  }
+
+  // ── Step 2 → 3: run import ─────────────────────────────────────────────────
+
+  async function handleImport() {
+    if (!dbFile || !storagePath.trim()) {
+      toast({ title: 'Storage path is required', variant: 'destructive' });
+      return;
+    }
+    setImporting(true);
+    setResult(null);
+    try {
+      const form = new FormData();
+      form.append('db', dbFile);
+      form.append('storagePath', storagePath.trim());
+      if (defaultUser) form.append('defaultUser', defaultUser);
+
+      const r = await fetch('/api/admin/import/xbackbone', { method: 'POST', body: form });
+      const data = await r.json();
+      if (!r.ok) throw new Error(data.error);
+
+      setResult(data);
+      toast({ title: `Import complete — ${data.imported} file(s) imported` });
+    } catch (err) {
+      toast({ title: err.message, variant: 'destructive' });
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  function reset() {
+    setDbFile(null);
+    setPreview(null);
+    setResult(null);
+    setStoragePath('');
+    setUserMapping({});
+    setDefaultUser('');
+    if (dbInputRef.current) dbInputRef.current.value = '';
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-6 max-w-4xl">
+      <div>
+        <h1 className="text-2xl font-bold">Import from XBackBone</h1>
+        <p className="text-sm text-muted-foreground mt-0.5">
+          Migrate files and metadata from an existing XBackBone instance.
+        </p>
+      </div>
+
+      {/* Steps */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <Step n={1} label="Upload database" active={step === 1} done={step > 1} />
+        <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
+        <Step n={2} label="Configure &amp; map users" active={step === 2} done={step > 2} />
+        <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
+        <Step n={3} label="Results" active={step === 3} done={false} />
+      </div>
+
+      {/* ── STEP 1 ── */}
+      {step === 1 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Upload XBackBone database</CardTitle>
+            <CardDescription>
+              Select the <code className="font-mono text-xs bg-muted px-1 py-0.5 rounded">database.db</code> file
+              from your XBackBone installation. This is only used to read metadata — no data is modified.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="db-file">database.db</Label>
+              <Input
+                id="db-file"
+                ref={dbInputRef}
+                type="file"
+                accept=".db,application/octet-stream"
+                onChange={(e) => setDbFile(e.target.files[0] || null)}
+              />
+            </div>
+            <Button onClick={handlePreview} disabled={!dbFile || previewing}>
+              {previewing ? (
+                <><span className="animate-spin mr-2">⟳</span>Analysing…</>
+              ) : (
+                <><FileSearch className="h-4 w-4 mr-2" />Analyse database</>
+              )}
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── STEP 2 ── */}
+      {step === 2 && preview && (
+        <div className="space-y-4">
+          {/* User mapping table */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">User mapping</CardTitle>
+              <CardDescription>
+                Users auto-matched by username are pre-filled. Adjust as needed.
+                Files whose XBackBone user has no mapping will be assigned to the fallback user (if set).
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>XBackBone user</TableHead>
+                    <TableHead>Files</TableHead>
+                    <TableHead>Map to local user</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {preview.users.map((xu) => (
+                    <TableRow key={xu.xbbId}>
+                      <TableCell>
+                        <div className="font-medium">{xu.xbbUsername || <span className="text-muted-foreground">(no username)</span>}</div>
+                        <div className="text-xs text-muted-foreground">{xu.xbbEmail}</div>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">{xu.fileCount}</TableCell>
+                      <TableCell>
+                        <select
+                          value={userMapping[xu.xbbId] || ''}
+                          onChange={(e) => setUserMapping((m) => ({ ...m, [xu.xbbId]: e.target.value }))}
+                          className="h-8 w-full rounded-md border border-input bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                        >
+                          <option value="">— use fallback —</option>
+                          {preview.localUsers.map((lu) => (
+                            <option key={lu} value={lu}>{lu}</option>
+                          ))}
+                        </select>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+
+          {/* Storage path + fallback + action */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Storage configuration</CardTitle>
+              <CardDescription>
+                The storage directory must be accessible from this server's filesystem.
+                For Docker, mount XBackBone's storage volume, e.g.:
+                <code className="block font-mono text-xs bg-muted px-2 py-1 rounded mt-1">
+                  volumes:<br />
+                  &nbsp;&nbsp;- /path/to/xbackbone/storage:/xbackbone/storage:ro
+                </code>
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="storage-path">Storage directory path (server-side)</Label>
+                <Input
+                  id="storage-path"
+                  placeholder="/xbackbone/storage"
+                  value={storagePath}
+                  onChange={(e) => setStoragePath(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="default-user">Fallback user (for unmatched XBackBone users)</Label>
+                <select
+                  id="default-user"
+                  value={defaultUser}
+                  onChange={(e) => setDefaultUser(e.target.value)}
+                  className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                >
+                  <option value="">— skip unmatched files —</option>
+                  {preview.localUsers.map((lu) => (
+                    <option key={lu} value={lu}>{lu}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex gap-2">
+                <Button onClick={handleImport} disabled={!storagePath.trim() || importing}>
+                  {importing ? (
+                    <><span className="animate-spin mr-2">⟳</span>Importing…</>
+                  ) : (
+                    <><Upload className="h-4 w-4 mr-2" />Run import</>
+                  )}
+                </Button>
+                <Button variant="outline" onClick={reset} disabled={importing}>Start over</Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* ── STEP 3 ── */}
+      {step === 3 && result && (
+        <div className="space-y-4">
+          {/* Summary cards */}
+          <div className="grid grid-cols-3 gap-4">
+            <Card>
+              <CardContent className="pt-4">
+                <div className="flex items-center gap-2">
+                  <CheckCircle2 className="h-5 w-5 text-green-600" />
+                  <div>
+                    <div className="text-2xl font-bold">{result.imported}</div>
+                    <div className="text-xs text-muted-foreground">Imported</div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="pt-4">
+                <div className="flex items-center gap-2">
+                  <SkipForward className="h-5 w-5 text-muted-foreground" />
+                  <div>
+                    <div className="text-2xl font-bold">{result.skipped}</div>
+                    <div className="text-xs text-muted-foreground">Skipped</div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="pt-4">
+                <div className="flex items-center gap-2">
+                  <AlertCircle className="h-5 w-5 text-destructive" />
+                  <div>
+                    <div className="text-2xl font-bold">{result.errors}</div>
+                    <div className="text-xs text-muted-foreground">Errors</div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Details table */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Details</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              <div className="max-h-[480px] overflow-y-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>File</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Info</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {result.details.map((d, i) => (
+                      <TableRow key={i}>
+                        <TableCell className="font-mono text-xs max-w-[260px] truncate">{d.file}</TableCell>
+                        <TableCell><StatusBadge status={d.status} /></TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {d.status === 'imported' ? `→ ${d.user}` : d.reason}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Button variant="outline" onClick={reset}>New import</Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "express-session": "^1.18.0",
         "mime-types": "^2.1.35",
         "mongoose": "^8.4.0",
-        "multer": "^1.4.5-lts.1"
+        "multer": "^1.4.5-lts.1",
+        "sql.js": "^1.14.1"
       },
       "devDependencies": {
         "nodemon": "^3.1.3"
@@ -1616,6 +1617,12 @@
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
+    },
+    "node_modules/sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "express-session": "^1.18.0",
     "mime-types": "^2.1.35",
     "mongoose": "^8.4.0",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "sql.js": "^1.14.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.3"

--- a/src/routes/import.js
+++ b/src/routes/import.js
@@ -1,0 +1,268 @@
+/**
+ * XBackBone import endpoint.
+ *
+ * POST /api/admin/import/xbackbone
+ *   multipart fields:
+ *     db          — XBackBone's database.db file (required)
+ *     storagePath — absolute path to XBackBone's storage directory on this
+ *                   server (required, e.g. /xbackbone/storage)
+ *     defaultUser — our username to assign files when no XBackBone user can
+ *                   be matched by username (optional)
+ *
+ * XBackBone user matching: the import tries to find a local user whose
+ * username matches the XBackBone user's username (case-insensitive).
+ * Files belonging to unmatched XBackBone users are assigned to defaultUser;
+ * if no defaultUser is given those files are skipped.
+ *
+ * File discovery: looks for {storagePath}/{xbb_filename}, then searches one
+ * level of subdirectories as fallback (covers user-token-bucketed layouts).
+ *
+ * The operation is idempotent with respect to shortId: if a File document
+ * with the same storedName already exists it is skipped.
+ */
+
+const express = require('express');
+const router = express.Router();
+const path = require('path');
+const fs = require('fs');
+const crypto = require('crypto');
+const multer = require('multer');
+const initSqlJs = require('sql.js');
+const mime = require('mime-types');
+const { requireAdmin } = require('../middleware/auth');
+const File = require('../models/File');
+const User = require('../models/User');
+
+const UPLOAD_DIR = path.join(__dirname, '../../uploads');
+
+// Multer for the SQLite DB upload — temp file, deleted after processing
+const dbUpload = multer({ dest: '/tmp/xbb-import/' });
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Resolve a SQL.js result-set row to a plain object using column names. */
+function rowsToObjects(result) {
+  if (!result || result.length === 0) return [];
+  const { columns, values } = result[0];
+  return values.map((row) =>
+    Object.fromEntries(columns.map((col, i) => [col, row[i]])),
+  );
+}
+
+/**
+ * Find a file in storagePath.
+ * Checks flat layout first (storagePath/filename), then one subdirectory deep.
+ */
+function findFile(storagePath, filename) {
+  const flat = path.join(storagePath, filename);
+  if (fs.existsSync(flat)) return flat;
+
+  // Search one level of subdirectories (user-token-bucketed layouts)
+  try {
+    const entries = fs.readdirSync(storagePath, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const candidate = path.join(storagePath, entry.name, filename);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+  } catch {
+    // storagePath unreadable — handled by caller
+  }
+  return null;
+}
+
+// ── Route ─────────────────────────────────────────────────────────────────────
+
+router.post('/xbackbone', requireAdmin, dbUpload.single('db'), async (req, res) => {
+  const tmpDbPath = req.file?.path;
+
+  try {
+    // ── Validate inputs ──────────────────────────────────────────────────────
+    if (!req.file) {
+      return res.status(400).json({ error: 'database.db file is required' });
+    }
+
+    const storagePath = (req.body.storagePath || '').trim();
+    if (!storagePath) {
+      return res.status(400).json({ error: 'storagePath is required' });
+    }
+    if (!fs.existsSync(storagePath)) {
+      return res.status(400).json({ error: `storagePath not found: ${storagePath}` });
+    }
+
+    // ── Parse SQLite ─────────────────────────────────────────────────────────
+    const SQL = await initSqlJs();
+    const dbBuffer = fs.readFileSync(tmpDbPath);
+    const db = new SQL.Database(new Uint8Array(dbBuffer));
+
+    const xbbUsers = rowsToObjects(db.exec('SELECT id, username, email FROM users'));
+    const xbbMedia = rowsToObjects(
+      db.exec('SELECT id, user_id, filename, mimetype, name, created_at, download_count FROM media'),
+    );
+    db.close();
+
+    // ── Build XBackBone userId → local User map ──────────────────────────────
+    const localUsers = await User.find({}, 'username folderName');
+    const localByUsername = new Map(
+      localUsers.map((u) => [u.username.toLowerCase(), u]),
+    );
+
+    // Optional fallback user
+    let defaultLocalUser = null;
+    if (req.body.defaultUser) {
+      defaultLocalUser = localByUsername.get(req.body.defaultUser.trim().toLowerCase()) || null;
+    }
+
+    const xbbUserMap = new Map(); // xbbUserId (number) → local User doc
+    for (const xu of xbbUsers) {
+      const match = xu.username ? localByUsername.get(xu.username.toLowerCase()) : null;
+      xbbUserMap.set(xu.id, match || defaultLocalUser);
+    }
+
+    // ── Import files ─────────────────────────────────────────────────────────
+    const results = { imported: 0, skipped: 0, errors: 0, details: [] };
+
+    for (const media of xbbMedia) {
+      const localUser = xbbUserMap.get(media.user_id);
+
+      if (!localUser) {
+        results.skipped++;
+        results.details.push({
+          file: media.name || media.filename,
+          status: 'skipped',
+          reason: 'no matching local user and no defaultUser set',
+        });
+        continue;
+      }
+
+      // Locate file on disk
+      const srcPath = findFile(storagePath, media.filename);
+      if (!srcPath) {
+        results.skipped++;
+        results.details.push({
+          file: media.name || media.filename,
+          status: 'skipped',
+          reason: 'file not found in storagePath',
+        });
+        continue;
+      }
+
+      // Determine target folder
+      const folder = localUser.folderName || localUser.username;
+      const destDir = path.join(UPLOAD_DIR, folder);
+
+      // Generate a new unique stored filename
+      const ext = path.extname(media.filename) || path.extname(media.name || '') || '';
+      const newFilename = `${crypto.randomBytes(4).toString('hex')}${ext}`;
+      const newStoredName = path.posix.join(folder, newFilename);
+      const destPath = path.join(destDir, newFilename);
+
+      // Skip if already imported (same storedName pattern check via original name + size)
+      const existingCheck = await File.findOne({
+        uploader: localUser._id,
+        originalName: media.name || media.filename,
+        size: fs.statSync(srcPath).size,
+      });
+      if (existingCheck) {
+        results.skipped++;
+        results.details.push({
+          file: media.name || media.filename,
+          status: 'skipped',
+          reason: 'already imported',
+        });
+        continue;
+      }
+
+      try {
+        fs.mkdirSync(destDir, { recursive: true });
+        fs.copyFileSync(srcPath, destPath);
+
+        const stat = fs.statSync(destPath);
+        const mimeType =
+          media.mimetype ||
+          mime.lookup(media.filename) ||
+          'application/octet-stream';
+
+        await File.create({
+          originalName: media.name || media.filename,
+          storedName: newStoredName,
+          mimeType,
+          size: stat.size,
+          uploader: localUser._id,
+          views: media.download_count || 0,
+          createdAt: media.created_at ? new Date(media.created_at) : new Date(),
+        });
+
+        results.imported++;
+        results.details.push({
+          file: media.name || media.filename,
+          status: 'imported',
+          user: localUser.username,
+        });
+      } catch (err) {
+        results.errors++;
+        results.details.push({
+          file: media.name || media.filename,
+          status: 'error',
+          reason: err.message,
+        });
+      }
+    }
+
+    res.json(results);
+  } finally {
+    // Always clean up the temp SQLite file
+    if (tmpDbPath) {
+      try { fs.unlinkSync(tmpDbPath); } catch { /* ignore */ }
+    }
+  }
+});
+
+// ── Preview: return XBackBone users + match status ───────────────────────────
+
+router.post('/xbackbone/preview', requireAdmin, dbUpload.single('db'), async (req, res) => {
+  const tmpDbPath = req.file?.path;
+
+  try {
+    if (!req.file) {
+      return res.status(400).json({ error: 'database.db file is required' });
+    }
+
+    const SQL = await initSqlJs();
+    const dbBuffer = fs.readFileSync(tmpDbPath);
+    const db = new SQL.Database(new Uint8Array(dbBuffer));
+
+    const xbbUsers = rowsToObjects(db.exec('SELECT id, username, email FROM users'));
+    const countResult = db.exec(
+      'SELECT user_id, COUNT(*) as cnt FROM media GROUP BY user_id',
+    );
+    db.close();
+
+    const fileCounts = new Map(
+      rowsToObjects(countResult).map((r) => [r.user_id, r.cnt]),
+    );
+
+    const localUsers = await User.find({}, 'username');
+    const localByUsername = new Map(
+      localUsers.map((u) => [u.username.toLowerCase(), u.username]),
+    );
+
+    const users = xbbUsers.map((xu) => ({
+      xbbId: xu.id,
+      xbbUsername: xu.username || null,
+      xbbEmail: xu.email,
+      fileCount: fileCounts.get(xu.id) || 0,
+      matchedLocalUser: xu.username
+        ? (localByUsername.get(xu.username.toLowerCase()) || null)
+        : null,
+    }));
+
+    res.json({ users, localUsers: localUsers.map((u) => u.username) });
+  } finally {
+    if (tmpDbPath) {
+      try { fs.unlinkSync(tmpDbPath); } catch { /* ignore */ }
+    }
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
Adds a 3-step admin UI and API endpoint to import files and metadata from an existing XBackBone instance.

Backend (src/routes/import.js):
- POST /api/admin/import/xbackbone — runs the import Accepts multipart: database.db + storagePath + optional defaultUser Parses XBackBone SQLite with sql.js (pure JS, no native deps) Matches users by username, copies files into user subfolders, creates File documents preserving originalName, mimeType, view count and creation date. Skips already-imported files (same name+size+user). File discovery supports flat and one-level-bucketed storage layouts.
- POST /api/admin/import/xbackbone/preview — analyse DB without importing Returns XBackBone users with file counts and auto-matched local users.

Frontend (client/src/pages/admin/Import.jsx):
- Step 1: upload database.db → analyse and show user table with auto-match
- Step 2: configure storage path, adjust user mapping, choose fallback user
- Step 3: import results with per-file status table (imported/skipped/error)

Routing / nav:
- /admin/import route added to App.jsx
- "Import XBackBone" entry added to the admin dropdown in Layout.jsx

Dependencies:
- sql.js ^1.14.1 added (pure-JS/WASM SQLite, no Alpine build tools needed)

https://claude.ai/code/session_01GDvJaUWosXqx3QSgNJRX1c