### PR TITLE
Fix TypeError: cast media.id to string before passing to path.join

### DIFF
--- a/src/routes/import.js
+++ b/src/routes/import.js
@@ -234,7 +234,7 @@ router.post('/xbackbone', requireAdmin, async (req, res, next) => {
         continue;
       }
 
-      const srcPath = findFile(storagePath, media.id, media.filename);
+      const srcPath = findFile(storagePath, String(media.id), media.filename);
       if (!srcPath) {
         results.skipped++;
         results.details.push({


### PR DESCRIPTION
SQLite returns integer IDs as numbers; path.join requires strings.

https://claude.ai/code/session_01GDvJaUWosXqx3QSgNJRX1c