### PR TITLE
Add password change for admins and regular users

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -13,6 +13,7 @@ import AdminDashboard from '@/pages/admin/Dashboard';
 import AdminUsers from '@/pages/admin/Users';
 import AdminFiles from '@/pages/admin/Files';
 import AdminImport from '@/pages/admin/Import';
+import Settings from '@/pages/Settings';
 
 function App() {
   return (
@@ -27,6 +28,7 @@ function App() {
           {/* Protected */}
           <Route path="/gallery" element={<ProtectedRoute><Layout><Gallery /></Layout></ProtectedRoute>} />
           <Route path="/upload" element={<ProtectedRoute><Layout><Upload /></Layout></ProtectedRoute>} />
+          <Route path="/settings" element={<ProtectedRoute><Layout><Settings /></Layout></ProtectedRoute>} />
 
           {/* Admin */}
           <Route path="/admin" element={<ProtectedRoute adminOnly><Layout><AdminDashboard /></Layout></ProtectedRoute>} />

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -6,7 +6,7 @@ import {
   DropdownMenu, DropdownMenuContent, DropdownMenuItem,
   DropdownMenuSeparator, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Images, Upload, Settings, LogOut, User, LayoutDashboard, ChevronDown, PackageOpen } from 'lucide-react';
+import { Images, Upload, Settings, LogOut, User, LayoutDashboard, ChevronDown, PackageOpen, KeyRound } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 function NavLink({ to, children, icon: Icon }) {
@@ -66,6 +66,11 @@ export function Layout({ children }) {
               <DropdownMenuItem asChild>
                 <Link to="/upload" className="flex items-center gap-2 cursor-pointer">
                   <Settings className="h-4 w-4" />API & ShareX
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link to="/settings" className="flex items-center gap-2 cursor-pointer">
+                  <KeyRound className="h-4 w-4" />Change Password
                 </Link>
               </DropdownMenuItem>
               {user?.role === 'admin' && (

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useToast } from '@/hooks/use-toast';
+import { KeyRound } from 'lucide-react';
+
+export default function Settings() {
+  const { toast } = useToast();
+  const [form, setForm] = useState({ currentPassword: '', newPassword: '', confirmPassword: '' });
+  const [saving, setSaving] = useState(false);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (form.newPassword !== form.confirmPassword) {
+      toast({ title: 'New passwords do not match', variant: 'destructive' });
+      return;
+    }
+    if (form.newPassword.length < 6) {
+      toast({ title: 'New password must be at least 6 characters', variant: 'destructive' });
+      return;
+    }
+    setSaving(true);
+    try {
+      const r = await fetch('/api/user/password', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          currentPassword: form.currentPassword,
+          newPassword: form.newPassword,
+        }),
+      });
+      const data = await r.json();
+      if (!r.ok) throw new Error(data.error);
+      toast({ title: 'Password changed successfully' });
+      setForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
+    } catch (err) {
+      toast({ title: err.message, variant: 'destructive' });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="max-w-md space-y-6">
+      <h1 className="text-2xl font-bold">Settings</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <KeyRound className="h-4 w-4" />Change Password
+          </CardTitle>
+          <CardDescription>Update your account password</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="currentPassword">Current password</Label>
+              <Input
+                id="currentPassword"
+                type="password"
+                value={form.currentPassword}
+                onChange={(e) => setForm((p) => ({ ...p, currentPassword: e.target.value }))}
+                required
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="newPassword">New password</Label>
+              <Input
+                id="newPassword"
+                type="password"
+                value={form.newPassword}
+                onChange={(e) => setForm((p) => ({ ...p, newPassword: e.target.value }))}
+                minLength={6}
+                required
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="confirmPassword">Confirm new password</Label>
+              <Input
+                id="confirmPassword"
+                type="password"
+                value={form.confirmPassword}
+                onChange={(e) => setForm((p) => ({ ...p, confirmPassword: e.target.value }))}
+                minLength={6}
+                required
+              />
+            </div>
+            <Button type="submit" disabled={saving}>
+              {saving ? 'Saving…' : 'Change password'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/pages/admin/Users.jsx
+++ b/client/src/pages/admin/Users.jsx
@@ -11,9 +11,12 @@ import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
+} from '@/components/ui/dialog';
 import { useToast } from '@/hooks/use-toast';
 import { fmtSize, fmtDate } from '@/lib/utils';
-import { RefreshCw, Trash2, UserPlus, Power, Pencil, Check, X } from 'lucide-react';
+import { RefreshCw, Trash2, UserPlus, Power, Pencil, Check, X, KeyRound } from 'lucide-react';
 
 export default function AdminUsers() {
   const { user: me } = useAuth();
@@ -23,6 +26,9 @@ export default function AdminUsers() {
   const [newUser, setNewUser] = useState({ username: '', password: '', role: 'user' });
   const [editingFolder, setEditingFolder] = useState(null); // { id, value }
   const folderInputRef = useRef(null);
+  const [pwDialog, setPwDialog] = useState(null); // { id, username }
+  const [newPw, setNewPw] = useState('');
+  const [savingPw, setSavingPw] = useState(false);
 
   async function load() {
     const r = await fetch('/api/admin/users');
@@ -88,6 +94,34 @@ export default function AdminUsers() {
 
   function cancelEditFolder() {
     setEditingFolder(null);
+  }
+
+  function openPwDialog(id, username) {
+    setNewPw('');
+    setPwDialog({ id, username });
+  }
+
+  async function savePassword() {
+    if (newPw.length < 6) {
+      toast({ title: 'Password must be at least 6 characters', variant: 'destructive' });
+      return;
+    }
+    setSavingPw(true);
+    try {
+      const r = await fetch(`/api/admin/users/${pwDialog.id}/password`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: newPw }),
+      });
+      const data = await r.json();
+      if (!r.ok) throw new Error(data.error);
+      toast({ title: `Password changed for "${pwDialog.username}"` });
+      setPwDialog(null);
+    } catch (err) {
+      toast({ title: err.message, variant: 'destructive' });
+    } finally {
+      setSavingPw(false);
+    }
   }
 
   async function saveFolder(id) {
@@ -238,6 +272,13 @@ export default function AdminUsers() {
                         </Button>
                         <Button
                           variant="ghost" size="icon" className="h-8 w-8"
+                          title="Change password"
+                          onClick={() => openPwDialog(u._id, u.username)}
+                        >
+                          <KeyRound className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button
+                          variant="ghost" size="icon" className="h-8 w-8"
                           title="Regenerate API key"
                           onClick={() => regenKey(u._id, u.username)}
                         >
@@ -274,6 +315,31 @@ export default function AdminUsers() {
           </Table>
         </CardContent>
       </Card>
+      {/* Change password dialog */}
+      <Dialog open={!!pwDialog} onOpenChange={(open) => { if (!open) setPwDialog(null); }}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Change password for "{pwDialog?.username}"</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-1.5 py-2">
+            <Label>New password</Label>
+            <Input
+              type="password"
+              value={newPw}
+              onChange={(e) => setNewPw(e.target.value)}
+              minLength={6}
+              autoFocus
+              onKeyDown={(e) => { if (e.key === 'Enter') savePassword(); }}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPwDialog(null)}>Cancel</Button>
+            <Button onClick={savePassword} disabled={savingPw}>
+              {savingPw ? 'Saving…' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -254,6 +254,21 @@ router.post('/admin/users/:id/regen-key', requireAdmin, async (req, res) => {
   res.json({ apiKey: user.apiKey });
 });
 
+router.patch('/admin/users/:id/password', requireAdmin, async (req, res) => {
+  const { password } = req.body;
+  if (!password || typeof password !== 'string') {
+    return res.status(400).json({ error: 'Password required' });
+  }
+  if (password.length < 6) {
+    return res.status(400).json({ error: 'Password must be at least 6 characters' });
+  }
+  const user = await User.findById(req.params.id);
+  if (!user) return res.status(404).json({ error: 'Not found' });
+  user.password = password;
+  await user.save();
+  res.json({ success: true });
+});
+
 router.patch('/admin/users/:id/folder', requireAdmin, async (req, res) => {
   const { folderName } = req.body;
   if (!folderName || typeof folderName !== 'string') {
@@ -269,6 +284,24 @@ router.patch('/admin/users/:id/folder', requireAdmin, async (req, res) => {
   const user = await User.findByIdAndUpdate(req.params.id, { folderName: trimmed }, { new: true });
   if (!user) return res.status(404).json({ error: 'Not found' });
   res.json({ folderName: user.folderName });
+});
+
+// ── User: change own password ───────────────────────────────────────────────
+router.patch('/user/password', requireLogin, async (req, res) => {
+  const { currentPassword, newPassword } = req.body;
+  if (!currentPassword || !newPassword) {
+    return res.status(400).json({ error: 'Current and new password required' });
+  }
+  if (newPassword.length < 6) {
+    return res.status(400).json({ error: 'New password must be at least 6 characters' });
+  }
+  const user = await User.findById(req.session.user.id);
+  if (!user) return res.status(404).json({ error: 'Not found' });
+  const valid = await user.comparePassword(currentPassword);
+  if (!valid) return res.status(401).json({ error: 'Current password is incorrect' });
+  user.password = newPassword;
+  await user.save();
+  res.json({ success: true });
 });
 
 // ── Admin: all files ────────────────────────────────────────────────────────


### PR DESCRIPTION
- Admin can change any user's password via PATCH /api/admin/users/:id/password
  and a key icon button with dialog in the Users admin page
- Regular users can change their own password via PATCH /api/user/password
  (requires current password verification) on a new /settings page
- Added "Change Password" link in the user dropdown navigation

https://claude.ai/code/session_01RPxHzJLHoxXy7mXqd1EdYq