### PR TITLE
claude/fix-mongo-auth-error-h2UsY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ PORT=3000
 MONGO_ROOT_PASSWORD=change-me-root-password
 MONGO_APP_USER=appuser
 MONGO_APP_PASSWORD=change-me-app-password
+MONGO_DB_NAME=sharely
 
 # Session secret (generate a long random string)
 SESSION_SECRET=change-me-to-a-long-random-secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     ports:
       - "${PORT:-3000}:3000"
     environment:
-      MONGODB_URI: "mongodb://${MONGO_APP_USER:-appuser}:${MONGO_APP_PASSWORD}@mongo:27017/sharely?authSource=sharely"
+      MONGODB_URI: "mongodb://${MONGO_APP_USER:-appuser}:${MONGO_APP_PASSWORD}@mongo:27017/${MONGO_DB_NAME:-sharely}?authSource=${MONGO_DB_NAME:-sharely}"
       SESSION_SECRET: "${SESSION_SECRET}"
       BASE_URL: "${BASE_URL:-http://localhost:3000}"
       MAX_FILE_SIZE_MB: "${MAX_FILE_SIZE_MB:-100}"
@@ -23,9 +23,10 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: "${MONGO_ROOT_PASSWORD}"
-      MONGO_INITDB_DATABASE: sharely
+      MONGO_INITDB_DATABASE: "${MONGO_DB_NAME:-sharely}"
       MONGO_APP_USER: "${MONGO_APP_USER:-appuser}"
       MONGO_APP_PASSWORD: "${MONGO_APP_PASSWORD}"
+      MONGO_DB_NAME: "${MONGO_DB_NAME:-sharely}"
     volumes:
       - mongo_data:/data/db
       - ./scripts/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro

--- a/scripts/mongo-init.js
+++ b/scripts/mongo-init.js
@@ -5,15 +5,16 @@
 
 const appUser = process.env.MONGO_APP_USER || 'appuser';
 const appPass = process.env.MONGO_APP_PASSWORD;
+const dbName = process.env.MONGO_DB_NAME || 'sharely';
 
 if (!appPass) {
   throw new Error('MONGO_APP_PASSWORD is not set – cannot create app user.');
 }
 
-db.getSiblingDB('sharely').createUser({
+db.getSiblingDB(dbName).createUser({
   user: appUser,
   pwd: appPass,
-  roles: [{ role: 'readWrite', db: 'sharely' }],
+  roles: [{ role: 'readWrite', db: dbName }],
 });
 
-print(`MongoDB: created user '${appUser}' on database 'sharely'.`);
+print(`MongoDB: created user '${appUser}' on database '${dbName}'.`);


### PR DESCRIPTION
Previously the database name 'sharely' was hardcoded in three places
(MONGODB_URI authSource, MONGO_INITDB_DATABASE, and mongo-init.js),
causing AuthenticationFailed errors when the name was changed in only
one location. MONGO_DB_NAME now controls all three consistently,
defaulting to 'sharely' for backwards compatibility.

https://claude.ai/code/session_01Nb2sRhCcrVghM44hUnaFFR