### PR TITLE
claude/cleanup-project-YKcBW

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const session = require('express-session');
 const MongoStore = require('connect-mongo');
 const path = require('path');
 const fs = require('fs');
+const { rateLimit } = require('express-rate-limit');
 const connectDB = require('./src/config/db');
 const uploadMiddleware = require('./src/middleware/upload');
 const { requireApiKey } = require('./src/middleware/auth');
@@ -11,25 +12,53 @@ const File = require('./src/models/File');
 
 const migrateUserFolders = require('./src/migrations/migrateUserFolders');
 
+if (!process.env.SESSION_SECRET) {
+  console.error('FATAL: SESSION_SECRET environment variable is not set.');
+  process.exit(1);
+}
+
 const UPLOAD_DIR = path.join(__dirname, 'uploads');
 
 const app = express();
 
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
+app.use(express.json({ limit: '1mb' }));
+app.use(express.urlencoded({ extended: true, limit: '1mb' }));
+
+app.use((_req, res, next) => {
+  res.setHeader('X-Frame-Options', 'DENY');
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader(
+    'Content-Security-Policy',
+    "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self';",
+  );
+  next();
+});
 
 app.use(session({
-  secret: process.env.SESSION_SECRET || 'changeme',
+  secret: process.env.SESSION_SECRET,
   resave: false,
   saveUninitialized: false,
   store: MongoStore.create({ mongoUrl: process.env.MONGODB_URI }),
-  cookie: { maxAge: 1000 * 60 * 60 * 24 * 7 },
+  cookie: {
+    maxAge: 1000 * 60 * 60 * 24 * 7,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+  },
 }));
+
+const uploadLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many uploads, please try again later.' },
+});
 
 // ShareX upload endpoint — multer runs first so req.body.token is available for auth.
 // Because auth runs after multer, the file lands in the root uploads dir initially;
 // we move it into the user's subfolder once the user identity is known.
-app.post('/upload', uploadMiddleware.single('upload'), requireApiKey, async (req, res) => {
+app.post('/upload', uploadLimiter, uploadMiddleware.single('upload'), requireApiKey, async (req, res) => {
   if (!req.file) return res.status(400).json({ error: 'No file provided' });
 
   const user = req.apiUser;
@@ -55,10 +84,25 @@ app.post('/upload', uploadMiddleware.single('upload'), requireApiKey, async (req
   res.json({ url: `${base}/f/${file.shortId}` });
 });
 
+// CSRF protection: reject cross-origin requests by comparing Origin to Host.
+// sameSite:'strict' cookies already block most CSRF; this is an additional layer.
+function requireSameOrigin(req, res, next) {
+  const origin = req.headers.origin;
+  if (!origin) return next(); // no Origin header → same-origin or non-browser request
+  try {
+    if (new URL(origin).host !== req.headers.host) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+  } catch {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  next();
+}
+
 // JSON API routes
-app.use('/api/auth', require('./src/routes/auth'));
+app.use('/api/auth', requireSameOrigin, require('./src/routes/auth'));
 app.use('/api/admin/import', require('./src/routes/import'));
-app.use('/api', require('./src/routes/api'));
+app.use('/api', requireSameOrigin, require('./src/routes/api'));
 
 // Raw file serving (not JSON)
 app.use('/f', require('./src/routes/files'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "connect-mongo": "^5.1.0",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "express-rate-limit": "^8.3.2",
         "express-session": "^1.18.0",
         "mime-types": "^2.1.35",
         "mongoose": "^8.4.0",
@@ -531,6 +532,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express-session": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
@@ -812,6 +831,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "connect-mongo": "^5.1.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "express-rate-limit": "^8.3.2",
     "express-session": "^1.18.0",
     "mime-types": "^2.1.35",
     "mongoose": "^8.4.0",

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -2,16 +2,34 @@ const express = require('express');
 const router = express.Router();
 const path = require('path');
 const fs = require('fs');
+const { rateLimit } = require('express-rate-limit');
 const { requireLogin, requireAdmin, requireApiKey } = require('../middleware/auth');
 const upload = require('../middleware/upload');
 const File = require('../models/File');
 const User = require('../models/User');
 
-const UPLOAD_DIR = path.join(__dirname, '../../uploads');
+const uploadLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many uploads, please try again later.' },
+});
+
+const UPLOAD_DIR = path.resolve(__dirname, '../../uploads');
 const BASE_URL = () => process.env.BASE_URL || 'http://localhost:3000';
 
+/** Resolve storedName to an absolute path and guard against path traversal. */
+function resolveUploadPath(storedName) {
+  const resolved = path.resolve(UPLOAD_DIR, storedName);
+  if (resolved !== UPLOAD_DIR && !resolved.startsWith(UPLOAD_DIR + path.sep)) {
+    throw new Error('Invalid file path');
+  }
+  return resolved;
+}
+
 // ── File upload (API key — ShareX) ─────────────────────────────────────────
-router.post('/upload', requireApiKey, upload.single('file'), async (req, res) => {
+router.post('/upload', uploadLimiter, requireApiKey, upload.single('file'), async (req, res) => {
   if (!req.file) return res.status(400).json({ error: 'No file provided' });
 
   // storedName is relative to UPLOAD_DIR (e.g. "username/a1b2c3d4.jpg")
@@ -37,7 +55,7 @@ router.post('/upload', requireApiKey, upload.single('file'), async (req, res) =>
 });
 
 // ── Web upload (session auth) ───────────────────────────────────────────────
-router.post('/web-upload', requireLogin, upload.array('files', 20), async (req, res) => {
+router.post('/web-upload', uploadLimiter, requireLogin, upload.array('files', 20), async (req, res) => {
   if (!req.files || req.files.length === 0) {
     return res.status(400).json({ error: 'No files provided' });
   }
@@ -69,7 +87,7 @@ router.delete('/delete/:shortId', requireApiKey, async (req, res) => {
     return res.status(403).json({ error: 'Forbidden' });
   }
 
-  const fp = path.join(UPLOAD_DIR, file.storedName);
+  const fp = resolveUploadPath(file.storedName);
   if (fs.existsSync(fp)) fs.unlinkSync(fp);
   await file.deleteOne();
   res.json({ success: true });
@@ -85,7 +103,7 @@ router.delete('/file/:shortId', requireLogin, async (req, res) => {
     return res.status(403).json({ error: 'Forbidden' });
   }
 
-  const fp = path.join(UPLOAD_DIR, file.storedName);
+  const fp = resolveUploadPath(file.storedName);
   if (fs.existsSync(fp)) fs.unlinkSync(fp);
   await file.deleteOne();
   res.json({ success: true });
@@ -239,8 +257,10 @@ router.delete('/admin/users/:id', requireAdmin, async (req, res) => {
   }
   const userFiles = await File.find({ uploader: user._id });
   for (const f of userFiles) {
-    const fp = path.join(UPLOAD_DIR, f.storedName);
-    if (fs.existsSync(fp)) fs.unlinkSync(fp);
+    try {
+      const fp = resolveUploadPath(f.storedName);
+      if (fs.existsSync(fp)) fs.unlinkSync(fp);
+    } catch { /* skip invalid paths */ }
   }
   await File.deleteMany({ uploader: user._id });
   await user.deleteOne();

--- a/src/routes/files.js
+++ b/src/routes/files.js
@@ -6,14 +6,23 @@ const fs = require('fs');
 const File = require('../models/File');
 const User = require('../models/User');
 
-const UPLOAD_DIR = path.join(__dirname, '../../uploads');
+const UPLOAD_DIR = path.resolve(__dirname, '../../uploads');
+
+/** Resolve storedName to an absolute path and guard against path traversal. */
+function resolveUploadPath(storedName) {
+  const resolved = path.resolve(UPLOAD_DIR, storedName);
+  if (resolved !== UPLOAD_DIR && !resolved.startsWith(UPLOAD_DIR + path.sep)) {
+    throw new Error('Invalid file path');
+  }
+  return resolved;
+}
 
 // GET /f/:shortId/raw — serve file inline
 router.get('/:shortId/raw', async (req, res) => {
   const file = await File.findOne({ shortId: req.params.shortId });
   if (!file) return res.status(404).send('Not found');
 
-  const filePath = path.join(UPLOAD_DIR, file.storedName);
+  const filePath = resolveUploadPath(file.storedName);
   if (!fs.existsSync(filePath)) return res.status(404).send('File data missing');
 
   const type = file.displayType;
@@ -40,7 +49,7 @@ router.get('/:shortId/delete/:token', async (req, res) => {
     return res.status(403).json({ error: 'Forbidden' });
   }
 
-  const fp = path.join(UPLOAD_DIR, file.storedName);
+  const fp = resolveUploadPath(file.storedName);
   if (fs.existsSync(fp)) fs.unlinkSync(fp);
   await file.deleteOne();
   res.json({ success: true });
@@ -51,7 +60,7 @@ router.get('/:shortId/download', async (req, res) => {
   const file = await File.findOne({ shortId: req.params.shortId });
   if (!file) return res.status(404).send('Not found');
 
-  const filePath = path.join(UPLOAD_DIR, file.storedName);
+  const filePath = resolveUploadPath(file.storedName);
   if (!fs.existsSync(filePath)) return res.status(404).send('File data missing');
 
   res.setHeader('Content-Type', file.mimeType);

--- a/src/routes/import.js
+++ b/src/routes/import.js
@@ -36,6 +36,13 @@ const UPLOAD_DIR = path.join(__dirname, '../../uploads');
 
 // ── SQLite helpers ────────────────────────────────────────────────────────────
 
+/** Validate that a string is a safe SQL identifier (letters, digits, underscores). */
+function assertSafeIdentifier(name) {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(`Unsafe identifier: ${name}`);
+  }
+}
+
 /** Resolve a SQL.js result-set to an array of plain objects. */
 function rowsToObjects(result) {
   if (!result || result.length === 0) return [];
@@ -53,6 +60,7 @@ function getTableNames(db) {
 
 /** Return the column names of a table using PRAGMA. */
 function getColumnNames(db, table) {
+  assertSafeIdentifier(table);
   const result = db.exec(`PRAGMA table_info(${table})`);
   return rowsToObjects(result).map((r) => r.name);
 }
@@ -119,6 +127,7 @@ function buildMediaSelect(db, mediaTable) {
       : '0 AS download_count',
   ];
 
+  assertSafeIdentifier(mediaTable);
   return `SELECT ${parts.join(', ')} FROM ${mediaTable}`;
 }
 
@@ -175,7 +184,7 @@ router.post('/xbackbone', requireAdmin, async (req, res, next) => {
       return res.status(400).json({ error: 'dbPath (path to database.db) is required' });
     }
     if (!fs.existsSync(dbPath)) {
-      return res.status(400).json({ error: `dbPath not found: ${dbPath}` });
+      return res.status(400).json({ error: 'dbPath not found' });
     }
 
     const storagePath = (req.body.storagePath || '').trim();
@@ -183,7 +192,7 @@ router.post('/xbackbone', requireAdmin, async (req, res, next) => {
       return res.status(400).json({ error: 'storagePath is required' });
     }
     if (!fs.existsSync(storagePath)) {
-      return res.status(400).json({ error: `storagePath not found: ${storagePath}` });
+      return res.status(400).json({ error: 'storagePath not found' });
     }
 
     // ── Parse SQLite ─────────────────────────────────────────────────────────
@@ -325,7 +334,7 @@ router.post('/xbackbone/preview', requireAdmin, async (req, res, next) => {
       return res.status(400).json({ error: 'dbPath (path to database.db) is required' });
     }
     if (!fs.existsSync(dbPath)) {
-      return res.status(400).json({ error: `dbPath not found: ${dbPath}` });
+      return res.status(400).json({ error: 'dbPath not found' });
     }
 
     const SQL = await initSqlJs();
@@ -340,6 +349,7 @@ router.post('/xbackbone/preview', requireAdmin, async (req, res, next) => {
     }
 
     const xbbUsers = rowsToObjects(db.exec(buildUsersSelect(db)));
+    assertSafeIdentifier(mediaTable);
     const countResult = db.exec(
       `SELECT user_id, COUNT(*) AS cnt FROM ${mediaTable} GROUP BY user_id`,
     );


### PR DESCRIPTION
- Require SESSION_SECRET env var (no insecure fallback)
- Add httpOnly, secure, sameSite:strict to session cookies
- Add X-Frame-Options, X-Content-Type-Options, CSP security headers
- Enforce 1 MB body size limit on JSON and URL-encoded requests
- Add assertSafeIdentifier() to prevent SQL injection via table name
  interpolation in import.js PRAGMA and SELECT queries
- Add resolveUploadPath() to guard against path traversal via
  storedName in files.js and api.js
- Add express-rate-limit (60 req/15 min) on all upload endpoints
- Add CSRF origin-check middleware on session-based API routes

https://claude.ai/code/session_01DPdCeyFA9Vw2e3NFM1ayD4