### PR TITLE
Fix ReDoS, auth middleware responses, and add app healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,12 @@ services:
     depends_on:
       mongo:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3000/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
     restart: unless-stopped
 
   mongo:

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -3,7 +3,7 @@ const User = require('../models/User');
 // Require session-based login
 function requireLogin(req, res, next) {
   if (!req.session.user) {
-    return res.redirect('/auth/login');
+    return res.status(401).json({ error: 'Authentication required' });
   }
   next();
 }
@@ -11,10 +11,10 @@ function requireLogin(req, res, next) {
 // Require admin role
 function requireAdmin(req, res, next) {
   if (!req.session.user) {
-    return res.redirect('/auth/login');
+    return res.status(401).json({ error: 'Authentication required' });
   }
   if (req.session.user.role !== 'admin') {
-    return res.status(403).render('error', { code: 403, message: 'Admin access required' });
+    return res.status(403).json({ error: 'Admin access required' });
   }
   next();
 }

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -19,6 +19,11 @@ const uploadLimiter = rateLimit({
 const UPLOAD_DIR = path.resolve(__dirname, '../../uploads');
 const BASE_URL = () => process.env.BASE_URL || 'http://localhost:3000';
 
+/** Escape special regex characters to prevent ReDoS via user-supplied search terms. */
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /** Resolve storedName to an absolute path and guard against path traversal. */
 function resolveUploadPath(storedName) {
   const resolved = path.resolve(UPLOAD_DIR, storedName);
@@ -129,7 +134,7 @@ router.get('/gallery', requireLogin, async (req, res) => {
 
   const filter = {};
   if (!isAdmin) filter.uploader = req.session.user.id;
-  if (q) filter.originalName = { $regex: q, $options: 'i' };
+  if (q) filter.originalName = { $regex: escapeRegex(q), $options: 'i' };
 
   if (type && type !== 'all') {
     const typeMap = { image: /^image\//, video: /^video\//, audio: /^audio\//, pdf: /^application\/pdf$/ };
@@ -330,7 +335,7 @@ router.get('/admin/files', requireAdmin, async (req, res) => {
   const page = Math.max(1, parseInt(pageStr || '1', 10));
   const PAGE_SIZE = 30;
 
-  const filter = q ? { originalName: { $regex: q, $options: 'i' } } : {};
+  const filter = q ? { originalName: { $regex: escapeRegex(q), $options: 'i' } } : {};
   const total = await File.countDocuments(filter);
   const pages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const files = await File.find(filter)


### PR DESCRIPTION
- Escape regex special characters in gallery and admin file search to prevent ReDoS via user-supplied $regex patterns
- Replace res.render() with res.json() in requireAdmin (no template engine is configured; render() would throw an internal error)
- Replace res.redirect() with 401 JSON in requireLogin and requireAdmin so API consumers receive a proper error response
- Add healthcheck for the app container in docker-compose.yml

https://claude.ai/code/session_01DPdCeyFA9Vw2e3NFM1ayD4