### PR TITLE
claude/chunked-uploads-large-files-ReDXP

### DIFF
--- a/client/src/pages/Upload.jsx
+++ b/client/src/pages/Upload.jsx
@@ -7,6 +7,60 @@ import { useToast } from '@/hooks/use-toast';
 import { fmtSize } from '@/lib/utils';
 import { Upload as UploadIcon, X, Download, RefreshCw, Copy } from 'lucide-react';
 
+const CHUNK_THRESHOLD = 100 * 1024 * 1024; // 100 MB
+const CHUNK_SIZE = 10 * 1024 * 1024;       // 10 MB per chunk
+
+async function uploadChunked(file, onProgress) {
+  const totalChunks = Math.ceil(file.size / CHUNK_SIZE);
+
+  // 1. Init session
+  const initRes = await fetch('/api/chunk/init', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      filename: file.name,
+      mimeType: file.type || 'application/octet-stream',
+      totalSize: file.size,
+      totalChunks,
+    }),
+  });
+  const initData = await initRes.json();
+  if (!initRes.ok) throw new Error(initData.error || 'Failed to init upload');
+  const { uploadId } = initData;
+
+  // 2. Upload chunks sequentially
+  try {
+    for (let i = 0; i < totalChunks; i++) {
+      const start = i * CHUNK_SIZE;
+      const end = Math.min(start + CHUNK_SIZE, file.size);
+      const chunk = file.slice(start, end);
+
+      const fd = new FormData();
+      fd.append('chunk', chunk);
+      fd.append('chunkIndex', i);
+      fd.append('totalChunks', totalChunks);
+
+      const r = await fetch(`/api/chunk/${uploadId}`, { method: 'POST', body: fd });
+      if (!r.ok) {
+        const err = await r.json().catch(() => ({}));
+        throw new Error(err.error || `Failed to upload chunk ${i}`);
+      }
+
+      onProgress(Math.round(((i + 1) / totalChunks) * 100));
+    }
+
+    // 3. Assemble
+    const completeRes = await fetch(`/api/chunk/${uploadId}/complete`, { method: 'POST' });
+    const completeData = await completeRes.json();
+    if (!completeRes.ok) throw new Error(completeData.error || 'Failed to complete upload');
+    return completeData;
+  } catch (err) {
+    // Best-effort cleanup
+    fetch(`/api/chunk/${uploadId}`, { method: 'DELETE' }).catch(() => {});
+    throw err;
+  }
+}
+
 export default function Upload() {
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -14,6 +68,7 @@ export default function Upload() {
   const [uploading, setUploading] = useState(false);
   const [dragging, setDragging] = useState(false);
   const [apiKey, setApiKey] = useState('');
+  const [progress, setProgress] = useState({}); // key: name+size → 0-100
   const fileInputRef = useRef(null);
 
   const addFiles = useCallback((incoming) => {
@@ -37,19 +92,41 @@ export default function Upload() {
   async function handleUpload() {
     if (files.length === 0) return;
     setUploading(true);
-    const fd = new FormData();
-    files.forEach((f) => fd.append('files', f));
+    setProgress({});
+
+    const smallFiles = files.filter((f) => f.size < CHUNK_THRESHOLD);
+    const largeFiles = files.filter((f) => f.size >= CHUNK_THRESHOLD);
+    const allResults = [];
 
     try {
-      const r = await fetch('/api/web-upload', { method: 'POST', body: fd });
-      const data = await r.json();
-      if (!r.ok) throw new Error(data.error || 'Upload failed');
+      // Upload small files in one batch (existing behaviour)
+      if (smallFiles.length > 0) {
+        const fd = new FormData();
+        smallFiles.forEach((f) => fd.append('files', f));
+        const r = await fetch('/api/web-upload', { method: 'POST', body: fd });
+        const data = await r.json();
+        if (!r.ok) throw new Error(data.error || 'Upload failed');
+        allResults.push(...data.files);
+      }
 
-      toast({ title: `Uploaded ${data.files.length} file${data.files.length !== 1 ? 's' : ''}` });
+      // Upload large files one by one via chunked API
+      for (const file of largeFiles) {
+        const key = file.name + file.size;
+        setProgress((prev) => ({ ...prev, [key]: 0 }));
+
+        const data = await uploadChunked(file, (pct) => {
+          setProgress((prev) => ({ ...prev, [key]: pct }));
+        });
+
+        allResults.push(...data.files);
+      }
+
+      toast({ title: `Uploaded ${allResults.length} file${allResults.length !== 1 ? 's' : ''}` });
       setFiles([]);
+      setProgress({});
 
-      if (data.files.length === 1) {
-        navigate(`/f/${data.files[0].shortId}`);
+      if (allResults.length === 1) {
+        navigate(`/f/${allResults[0].shortId}`);
       } else {
         navigate('/gallery');
       }
@@ -109,17 +186,39 @@ export default function Upload() {
             <CardTitle className="text-base">{files.length} file{files.length !== 1 ? 's' : ''} selected</CardTitle>
           </CardHeader>
           <CardContent className="space-y-2">
-            {files.map((f, i) => (
-              <div key={i} className="flex items-center justify-between text-sm border rounded-md px-3 py-2">
-                <span className="truncate max-w-[70%]">{f.name}</span>
-                <div className="flex items-center gap-3 shrink-0">
-                  <span className="text-muted-foreground">{fmtSize(f.size)}</span>
-                  <button onClick={() => removeFile(i)} className="text-muted-foreground hover:text-destructive">
-                    <X className="h-4 w-4" />
-                  </button>
+            {files.map((f, i) => {
+              const key = f.name + f.size;
+              const pct = progress[key];
+              const isLarge = f.size >= CHUNK_THRESHOLD;
+              const isUploading = uploading && isLarge && pct !== undefined;
+
+              return (
+                <div key={i} className="border rounded-md px-3 py-2 text-sm space-y-1">
+                  <div className="flex items-center justify-between">
+                    <span className="truncate max-w-[70%]">{f.name}</span>
+                    <div className="flex items-center gap-3 shrink-0">
+                      <span className="text-muted-foreground">{fmtSize(f.size)}</span>
+                      {!uploading && (
+                        <button onClick={() => removeFile(i)} className="text-muted-foreground hover:text-destructive">
+                          <X className="h-4 w-4" />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                  {isUploading && (
+                    <div className="w-full bg-muted rounded-full h-1.5 overflow-hidden">
+                      <div
+                        className="bg-primary h-1.5 rounded-full transition-all duration-300"
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
+                  )}
+                  {isUploading && (
+                    <p className="text-xs text-muted-foreground">{pct}%</p>
+                  )}
                 </div>
-              </div>
-            ))}
+              );
+            })}
             <Button className="w-full mt-2" onClick={handleUpload} disabled={uploading}>
               {uploading ? 'Uploading…' : `Upload ${files.length} file${files.length !== 1 ? 's' : ''}`}
             </Button>

--- a/src/middleware/upload.js
+++ b/src/middleware/upload.js
@@ -70,4 +70,10 @@ const upload = multer({
   fileFilter,
 });
 
+function isBlockedFile(mimeType, filename) {
+  const ext = path.extname(filename).toLowerCase();
+  return BLOCKED_MIME_TYPES.has(mimeType) || BLOCKED_EXTENSIONS.has(ext);
+}
+
 module.exports = upload;
+module.exports.isBlockedFile = isBlockedFile;

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -2,9 +2,12 @@ const express = require('express');
 const router = express.Router();
 const path = require('path');
 const fs = require('fs');
+const crypto = require('crypto');
+const multer = require('multer');
 const { rateLimit } = require('express-rate-limit');
 const { requireLogin, requireAdmin, requireApiKey } = require('../middleware/auth');
 const upload = require('../middleware/upload');
+const { isBlockedFile } = require('../middleware/upload');
 const File = require('../models/File');
 const User = require('../models/User');
 
@@ -15,6 +18,23 @@ const uploadLimiter = rateLimit({
   legacyHeaders: false,
   message: { error: 'Too many uploads, please try again later.' },
 });
+
+// ── Chunk upload helpers ────────────────────────────────────────────────────
+const CHUNK_DIR = path.resolve(__dirname, '../../uploads/.chunks');
+fs.mkdirSync(CHUNK_DIR, { recursive: true });
+
+// Multer for individual chunks (memory storage, max 11 MB to accommodate 10 MB chunks)
+const chunkMulter = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 11 * 1024 * 1024 },
+});
+
+function resolveChunkDir(uploadId) {
+  if (!/^[a-f0-9]{32}$/.test(uploadId)) {
+    throw new Error('Invalid upload ID');
+  }
+  return path.join(CHUNK_DIR, uploadId);
+}
 
 const UPLOAD_DIR = path.resolve(__dirname, '../../uploads');
 const BASE_URL = () => process.env.BASE_URL || 'http://localhost:3000';
@@ -326,6 +346,177 @@ router.patch('/user/password', requireLogin, async (req, res) => {
   if (!valid) return res.status(401).json({ error: 'Current password is incorrect' });
   user.password = newPassword;
   await user.save();
+  res.json({ success: true });
+});
+
+// ── Chunked upload: init session ───────────────────────────────────────────
+router.post('/chunk/init', requireLogin, (req, res) => {
+  const { filename, mimeType, totalSize, totalChunks } = req.body;
+
+  if (!filename || !mimeType || !totalSize || !totalChunks) {
+    return res.status(400).json({ error: 'Missing required fields' });
+  }
+
+  const totalChunksInt = parseInt(totalChunks, 10);
+  if (!Number.isInteger(totalChunksInt) || totalChunksInt < 1 || totalChunksInt > 10000) {
+    return res.status(400).json({ error: 'Invalid totalChunks' });
+  }
+
+  const totalSizeInt = parseInt(totalSize, 10);
+  if (!Number.isInteger(totalSizeInt) || totalSizeInt < 1) {
+    return res.status(400).json({ error: 'Invalid totalSize' });
+  }
+
+  if (isBlockedFile(mimeType, filename)) {
+    return res.status(400).json({ error: 'File type not allowed' });
+  }
+
+  const uploadId = crypto.randomBytes(16).toString('hex');
+  const sessionDir = resolveChunkDir(uploadId);
+  fs.mkdirSync(sessionDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(sessionDir, 'meta.json'),
+    JSON.stringify({
+      filename,
+      mimeType,
+      totalSize: totalSizeInt,
+      totalChunks: totalChunksInt,
+      userId: req.session.user.id,
+      createdAt: Date.now(),
+    }),
+  );
+
+  res.json({ uploadId });
+});
+
+// ── Chunked upload: receive one chunk ──────────────────────────────────────
+router.post('/chunk/:uploadId', requireLogin, chunkMulter.single('chunk'), (req, res) => {
+  let sessionDir;
+  try {
+    sessionDir = resolveChunkDir(req.params.uploadId);
+  } catch {
+    return res.status(400).json({ error: 'Invalid upload ID' });
+  }
+
+  if (!fs.existsSync(sessionDir)) {
+    return res.status(404).json({ error: 'Upload session not found' });
+  }
+
+  let meta;
+  try {
+    meta = JSON.parse(fs.readFileSync(path.join(sessionDir, 'meta.json'), 'utf8'));
+  } catch {
+    return res.status(500).json({ error: 'Failed to read session metadata' });
+  }
+
+  if (meta.userId !== req.session.user.id.toString()) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  const chunkIndex = parseInt(req.body.chunkIndex, 10);
+  if (!Number.isInteger(chunkIndex) || chunkIndex < 0 || chunkIndex >= meta.totalChunks) {
+    return res.status(400).json({ error: 'Invalid chunkIndex' });
+  }
+
+  if (!req.file) {
+    return res.status(400).json({ error: 'No chunk data' });
+  }
+
+  fs.writeFileSync(path.join(sessionDir, `chunk-${chunkIndex}`), req.file.buffer);
+  res.json({ received: chunkIndex });
+});
+
+// ── Chunked upload: assemble final file ────────────────────────────────────
+router.post('/chunk/:uploadId/complete', requireLogin, async (req, res) => {
+  let sessionDir;
+  try {
+    sessionDir = resolveChunkDir(req.params.uploadId);
+  } catch {
+    return res.status(400).json({ error: 'Invalid upload ID' });
+  }
+
+  if (!fs.existsSync(sessionDir)) {
+    return res.status(404).json({ error: 'Upload session not found' });
+  }
+
+  let meta;
+  try {
+    meta = JSON.parse(fs.readFileSync(path.join(sessionDir, 'meta.json'), 'utf8'));
+  } catch {
+    return res.status(500).json({ error: 'Failed to read session metadata' });
+  }
+
+  if (meta.userId !== req.session.user.id.toString()) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  for (let i = 0; i < meta.totalChunks; i++) {
+    if (!fs.existsSync(path.join(sessionDir, `chunk-${i}`))) {
+      return res.status(400).json({ error: `Missing chunk ${i}` });
+    }
+  }
+
+  const user = await User.findById(meta.userId).select('folderName username');
+  if (!user) return res.status(404).json({ error: 'User not found' });
+
+  const folder = user.folderName || user.username;
+  const userDir = path.join(UPLOAD_DIR, folder);
+  fs.mkdirSync(userDir, { recursive: true });
+
+  const ext = path.extname(meta.filename);
+  const fileId = crypto.randomBytes(4).toString('hex');
+  const finalPath = path.join(userDir, `${fileId}${ext}`);
+
+  if (!finalPath.startsWith(UPLOAD_DIR + path.sep)) {
+    return res.status(400).json({ error: 'Invalid file path' });
+  }
+
+  // Stream-assemble chunks into the final file
+  await new Promise((resolve, reject) => {
+    const writeStream = fs.createWriteStream(finalPath);
+    writeStream.on('error', reject);
+    writeStream.on('finish', resolve);
+
+    let i = 0;
+    function writeNext() {
+      if (i >= meta.totalChunks) { writeStream.end(); return; }
+      const readStream = fs.createReadStream(path.join(sessionDir, `chunk-${i}`));
+      readStream.on('error', reject);
+      readStream.on('end', () => { i++; writeNext(); });
+      readStream.pipe(writeStream, { end: false });
+    }
+    writeNext();
+  });
+
+  try { fs.rmSync(sessionDir, { recursive: true, force: true }); } catch { /* ignore */ }
+
+  const storedName = path.relative(UPLOAD_DIR, finalPath);
+  const doc = await File.create({
+    originalName: meta.filename,
+    storedName,
+    mimeType: meta.mimeType,
+    size: meta.totalSize,
+    uploader: meta.userId,
+  });
+
+  res.json({ files: [doc.toObject()] });
+});
+
+// ── Chunked upload: cancel / cleanup ───────────────────────────────────────
+router.delete('/chunk/:uploadId', requireLogin, (req, res) => {
+  try {
+    const sessionDir = resolveChunkDir(req.params.uploadId);
+    if (fs.existsSync(sessionDir)) {
+      const metaPath = path.join(sessionDir, 'meta.json');
+      if (fs.existsSync(metaPath)) {
+        const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+        if (meta.userId === req.session.user.id.toString()) {
+          fs.rmSync(sessionDir, { recursive: true, force: true });
+        }
+      }
+    }
+  } catch { /* ignore invalid IDs */ }
   res.json({ success: true });
 });
 


### PR DESCRIPTION
Files under 100 MB continue to use the existing single-request upload.
Files >= 100 MB are split into 10 MB chunks and uploaded sequentially
via three new API routes:

  POST /api/chunk/init           – creates a server-side upload session
  POST /api/chunk/:uploadId      – receives and persists one chunk
  POST /api/chunk/:uploadId/complete – stream-assembles chunks into the
                                       final file and registers it in DB
  DELETE /api/chunk/:uploadId    – cancels and cleans up a session

Security:
- uploadId is validated as 32-char lowercase hex (prevents path traversal)
- Ownership checked via userId stored in session metadata
- File-type blocking (blocked MIME types + extensions) applied at init
- Path-traversal guard on the assembled final path
- Chunk multer limited to 11 MB per request

Frontend (Upload.jsx):
- Large files are detected and routed through uploadChunked()
- Per-file progress bar (0–100 %) shown during chunk upload
- On error: best-effort cleanup request sent to DELETE route

https://claude.ai/code/session_01Nj9fJSxBqGNVvfEnppCKxw