### PR TITLE
claude/fix-upload-size-limit-2n8jP

### DIFF
--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -23,10 +23,10 @@ const uploadLimiter = rateLimit({
 const CHUNK_DIR = path.resolve(__dirname, '../../uploads/.chunks');
 fs.mkdirSync(CHUNK_DIR, { recursive: true });
 
-// Multer for individual chunks (memory storage, max 11 MB to accommodate 10 MB chunks)
+// Multer for individual chunks (memory storage, max 51 MB to accommodate 50 MB chunks)
 const chunkMulter = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: 11 * 1024 * 1024 },
+  limits: { fileSize: 51 * 1024 * 1024 },
 });
 
 function resolveChunkDir(uploadId) {


### PR DESCRIPTION
The client CHUNK_SIZE was increased to 50 MB but the server-side multer
limit for chunk uploads was still 11 MB (for the old 10 MB chunks),
causing MulterError: File too large on every chunk upload.

https://claude.ai/code/session_01PezVhDj2pGuZpEdZgTh3wP