### PR TITLE
fix: restore chunk multer limit to 51 MB for compatibility with curre…

### DIFF
--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -23,10 +23,13 @@ const uploadLimiter = rateLimit({
 const CHUNK_DIR = path.resolve(__dirname, '../../uploads/.chunks');
 fs.mkdirSync(CHUNK_DIR, { recursive: true });
 
-// Multer for individual chunks (memory storage, max 21 MB to accommodate 20 MB chunks)
+// Multer for individual chunks (memory storage).
+// Limit is 51 MB to handle clients still using 50 MB chunks.
+// Once the Docker image is rebuilt with the new client (max 20 MB chunks),
+// this limit is still safely above the 20 MB maximum.
 const chunkMulter = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: 21 * 1024 * 1024 },
+  limits: { fileSize: 51 * 1024 * 1024 },
 });
 
 function resolveChunkDir(uploadId) {


### PR DESCRIPTION
…nt image

The running Docker image was built with the old 50 MB client chunk size. Lowering the limit to 21 MB caused MulterError: File too large on every chunk.

Keep the limit at 51 MB so the current client continues to work. After rebuilding the Docker image the new client will send ≤20 MB chunks, at which point the 51 MB limit is still well above the maximum.

https://claude.ai/code/session_01PezVhDj2pGuZpEdZgTh3wP