### PR TITLE
Add profile picture upload and consolidate Settings dropdown

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -3,11 +3,11 @@ import { useAuth } from '@/context/AuthContext';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import {
-  DropdownMenu, DropdownMenuContent, DropdownMenuItem,
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel,
   DropdownMenuSeparator, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faImages, faUpload, faGear, faRightFromBracket, faUser, faTableCellsLarge, faChevronDown, faBoxOpen, faKey } from '@fortawesome/free-solid-svg-icons';
+import { faImages, faUpload, faGear, faRightFromBracket, faUser, faTableCellsLarge, faChevronDown, faBoxOpen } from '@fortawesome/free-solid-svg-icons';
 import { cn } from '@/lib/utils';
 
 function NavLink({ to, children, icon }) {
@@ -26,6 +26,20 @@ function NavLink({ to, children, icon }) {
       {icon && <FontAwesomeIcon icon={icon} className="h-4 w-4" />}
       {children}
     </Link>
+  );
+}
+
+function UserAvatar({ user, size = 'sm' }) {
+  const dim = size === 'sm' ? 'h-6 w-6' : 'h-8 w-8';
+  const iconSize = size === 'sm' ? 'h-3.5 w-3.5' : 'h-4 w-4';
+  return (
+    <div className={`${dim} rounded-full overflow-hidden bg-muted flex items-center justify-center shrink-0`}>
+      {user?.avatarUrl ? (
+        <img src={user.avatarUrl} alt="" className="h-full w-full object-cover" />
+      ) : (
+        <FontAwesomeIcon icon={faUser} className={iconSize} />
+      )}
+    </div>
   );
 }
 
@@ -58,25 +72,34 @@ export function Layout({ children }) {
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" size="sm" className="gap-2">
-                <FontAwesomeIcon icon={faUser} className="h-4 w-4" />
+                <UserAvatar user={user} size="sm" />
                 <span className="hidden sm:inline">{user?.username}</span>
                 <FontAwesomeIcon icon={faChevronDown} className="h-3 w-3 opacity-50" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-48">
-              <DropdownMenuItem asChild>
-                <Link to="/upload" className="flex items-center gap-2 cursor-pointer">
-                  <FontAwesomeIcon icon={faGear} className="h-4 w-4" />API & ShareX
-                </Link>
-              </DropdownMenuItem>
+            <DropdownMenuContent align="end" className="w-52">
+              {/* User header */}
+              <div className="flex items-center gap-3 px-2 py-2">
+                <UserAvatar user={user} size="md" />
+                <div className="flex flex-col min-w-0">
+                  <span className="text-sm font-medium truncate">{user?.username}</span>
+                  <span className="text-xs text-muted-foreground capitalize">{user?.role}</span>
+                </div>
+              </div>
+              <DropdownMenuSeparator />
+
+              {/* Settings */}
               <DropdownMenuItem asChild>
                 <Link to="/settings" className="flex items-center gap-2 cursor-pointer">
-                  <FontAwesomeIcon icon={faKey} className="h-4 w-4" />Change Password
+                  <FontAwesomeIcon icon={faGear} className="h-4 w-4" />Settings
                 </Link>
               </DropdownMenuItem>
+
+              {/* Admin section */}
               {user?.role === 'admin' && (
                 <>
                   <DropdownMenuSeparator />
+                  <DropdownMenuLabel className="text-xs text-muted-foreground font-normal py-1">Admin</DropdownMenuLabel>
                   <DropdownMenuItem asChild>
                     <Link to="/admin/users" className="flex items-center gap-2 cursor-pointer">
                       <FontAwesomeIcon icon={faUser} className="h-4 w-4" />Users
@@ -89,6 +112,7 @@ export function Layout({ children }) {
                   </DropdownMenuItem>
                 </>
               )}
+
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={handleLogout} className="flex items-center gap-2 cursor-pointer text-destructive focus:text-destructive">
                 <FontAwesomeIcon icon={faRightFromBracket} className="h-4 w-4" />Logout

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -37,13 +37,21 @@ export function AuthProvider({ children }) {
     return data.user;
   }
 
+  async function refreshUser() {
+    const r = await fetch('/api/auth/me');
+    if (r.ok) {
+      const data = await r.json();
+      setUser(data.user ?? null);
+    }
+  }
+
   async function logout() {
     await fetch('/api/auth/logout', { method: 'POST' });
     setUser(null);
   }
 
   return (
-    <AuthContext.Provider value={{ user, loading, login, register, logout }}>
+    <AuthContext.Provider value={{ user, loading, login, register, logout, refreshUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -1,18 +1,26 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useToast } from '@/hooks/use-toast';
+import { useAuth } from '@/context/AuthContext';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faKey } from '@fortawesome/free-solid-svg-icons';
+import { faKey, faUser, faTrash, faUpload } from '@fortawesome/free-solid-svg-icons';
 
 export default function Settings() {
   const { toast } = useToast();
+  const { user, refreshUser } = useAuth();
+
+  // Password form
   const [form, setForm] = useState({ currentPassword: '', newPassword: '', confirmPassword: '' });
   const [saving, setSaving] = useState(false);
 
-  async function handleSubmit(e) {
+  // Avatar
+  const avatarInputRef = useRef(null);
+  const [uploadingAvatar, setUploadingAvatar] = useState(false);
+
+  async function handlePasswordSubmit(e) {
     e.preventDefault();
     if (form.newPassword !== form.confirmPassword) {
       toast({ title: 'New passwords do not match', variant: 'destructive' });
@@ -43,10 +51,104 @@ export default function Settings() {
     }
   }
 
+  async function handleAvatarUpload(e) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    e.target.value = '';
+
+    setUploadingAvatar(true);
+    try {
+      const fd = new FormData();
+      fd.append('avatar', file);
+      const r = await fetch('/api/user/avatar', { method: 'POST', body: fd });
+      const data = await r.json();
+      if (!r.ok) throw new Error(data.error);
+      await refreshUser();
+      toast({ title: 'Profile picture updated' });
+    } catch (err) {
+      toast({ title: err.message, variant: 'destructive' });
+    } finally {
+      setUploadingAvatar(false);
+    }
+  }
+
+  async function handleAvatarRemove() {
+    setUploadingAvatar(true);
+    try {
+      const r = await fetch('/api/user/avatar', { method: 'DELETE' });
+      const data = await r.json();
+      if (!r.ok) throw new Error(data.error);
+      await refreshUser();
+      toast({ title: 'Profile picture removed' });
+    } catch (err) {
+      toast({ title: err.message, variant: 'destructive' });
+    } finally {
+      setUploadingAvatar(false);
+    }
+  }
+
   return (
     <div className="max-w-md space-y-6">
       <h1 className="text-2xl font-bold">Settings</h1>
 
+      {/* Profile Picture */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <FontAwesomeIcon icon={faUser} className="h-4 w-4" />Profile Picture
+          </CardTitle>
+          <CardDescription>Visible in the navigation bar</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-4">
+            <div className="h-16 w-16 rounded-full overflow-hidden bg-muted flex items-center justify-center shrink-0 border">
+              {user?.avatarUrl ? (
+                <img
+                  src={`${user.avatarUrl}?t=${Date.now()}`}
+                  alt="Profile picture"
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <FontAwesomeIcon icon={faUser} className="h-7 w-7 text-muted-foreground" />
+              )}
+            </div>
+            <div className="flex flex-col gap-2">
+              <input
+                ref={avatarInputRef}
+                type="file"
+                accept="image/*"
+                hidden
+                onChange={handleAvatarUpload}
+              />
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-2"
+                onClick={() => avatarInputRef.current?.click()}
+                disabled={uploadingAvatar}
+              >
+                <FontAwesomeIcon icon={faUpload} className="h-3.5 w-3.5" />
+                {uploadingAvatar ? 'Uploading…' : 'Upload picture'}
+              </Button>
+              {user?.avatarUrl && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="gap-2 text-destructive hover:text-destructive"
+                  onClick={handleAvatarRemove}
+                  disabled={uploadingAvatar}
+                >
+                  <FontAwesomeIcon icon={faTrash} className="h-3.5 w-3.5" />
+                  Remove picture
+                </Button>
+              )}
+              <p className="text-xs text-muted-foreground">Max 2 MB · Images only</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Change Password */}
       <Card>
         <CardHeader>
           <CardTitle className="text-base flex items-center gap-2">
@@ -55,7 +157,7 @@ export default function Settings() {
           <CardDescription>Update your account password</CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={handlePasswordSubmit} className="space-y-4">
             <div className="space-y-1.5">
               <Label htmlFor="currentPassword">Current password</Label>
               <Input

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -32,6 +32,10 @@ const userSchema = new mongoose.Schema({
     trim: true,
     maxlength: 64,
   },
+  avatarExt: {
+    type: String,
+    default: null,
+  },
   isActive: {
     type: Boolean,
     default: true,

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -19,6 +19,21 @@ const uploadLimiter = rateLimit({
   message: { error: 'Too many uploads, please try again later.' },
 });
 
+// ── Avatar helpers ──────────────────────────────────────────────────────────
+const AVATAR_DIR = path.resolve(__dirname, '../../uploads/.avatars');
+fs.mkdirSync(AVATAR_DIR, { recursive: true });
+
+const avatarMulter = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 2 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    if (!file.mimetype.startsWith('image/')) {
+      return cb(new Error('Only image files are allowed'));
+    }
+    cb(null, true);
+  },
+});
+
 // ── Chunk upload helpers ────────────────────────────────────────────────────
 const CHUNK_DIR = path.resolve(__dirname, '../../uploads/.chunks');
 fs.mkdirSync(CHUNK_DIR, { recursive: true });
@@ -521,6 +536,58 @@ router.delete('/chunk/:uploadId', requireLogin, (req, res) => {
     }
   } catch { /* ignore invalid IDs */ }
   res.json({ success: true });
+});
+
+// ── Avatar: upload ──────────────────────────────────────────────────────────
+router.post('/user/avatar', requireLogin, avatarMulter.single('avatar'), async (req, res) => {
+  if (!req.file) return res.status(400).json({ error: 'No file provided' });
+
+  const mimeToExt = { 'image/jpeg': '.jpg', 'image/png': '.png', 'image/gif': '.gif', 'image/webp': '.webp' };
+  const ext = path.extname(req.file.originalname).toLowerCase() || mimeToExt[req.file.mimetype] || '.jpg';
+
+  const userId = req.session.user.id;
+  const user = await User.findById(userId);
+  if (!user) return res.status(404).json({ error: 'Not found' });
+
+  if (user.avatarExt) {
+    try { fs.unlinkSync(path.join(AVATAR_DIR, `${userId}${user.avatarExt}`)); } catch (e) { if (e.code !== 'ENOENT') throw e; }
+  }
+
+  fs.writeFileSync(path.join(AVATAR_DIR, `${userId}${ext}`), req.file.buffer);
+  user.avatarExt = ext;
+  await user.save();
+
+  res.json({ avatarUrl: `/api/user/avatar/${userId}` });
+});
+
+// ── Avatar: delete ──────────────────────────────────────────────────────────
+router.delete('/user/avatar', requireLogin, async (req, res) => {
+  const userId = req.session.user.id;
+  const user = await User.findById(userId);
+  if (!user) return res.status(404).json({ error: 'Not found' });
+
+  if (user.avatarExt) {
+    try { fs.unlinkSync(path.join(AVATAR_DIR, `${userId}${user.avatarExt}`)); } catch (e) { if (e.code !== 'ENOENT') throw e; }
+    user.avatarExt = null;
+    await user.save();
+  }
+
+  res.json({ success: true });
+});
+
+// ── Avatar: serve ───────────────────────────────────────────────────────────
+router.get('/user/avatar/:userId', async (req, res) => {
+  if (!/^[a-f0-9]{24}$/i.test(req.params.userId)) {
+    return res.status(400).json({ error: 'Invalid user ID' });
+  }
+
+  const user = await User.findById(req.params.userId).select('avatarExt');
+  if (!user || !user.avatarExt) return res.status(404).json({ error: 'No avatar' });
+
+  const avatarPath = path.join(AVATAR_DIR, `${req.params.userId}${user.avatarExt}`);
+  if (!fs.existsSync(avatarPath)) return res.status(404).json({ error: 'Avatar not found' });
+
+  res.sendFile(avatarPath);
 });
 
 // ── Admin: all files ────────────────────────────────────────────────────────

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -5,9 +5,18 @@ const User = require('../models/User');
 const allowRegistration = () => process.env.ALLOW_REGISTRATION !== 'false';
 
 // GET /api/auth/me
-router.get('/me', (req, res) => {
+router.get('/me', async (req, res) => {
   if (!req.session.user) return res.status(401).json({ error: 'Not authenticated' });
-  res.json({ user: req.session.user });
+  const dbUser = await User.findById(req.session.user.id).select('username role avatarExt');
+  if (!dbUser) return res.status(401).json({ error: 'Not authenticated' });
+  res.json({
+    user: {
+      id: dbUser._id,
+      username: dbUser.username,
+      role: dbUser.role,
+      avatarUrl: dbUser.avatarExt ? `/api/user/avatar/${dbUser._id}` : null,
+    },
+  });
 });
 
 // POST /api/auth/login


### PR DESCRIPTION
- User model: add avatarExt field to store avatar file extension
- API: add POST/DELETE /api/user/avatar endpoints and GET /api/user/avatar/:userId to serve avatars (stored in uploads/.avatars/, 2 MB image-only limit)
- Auth /me: fetch user from DB to include avatarUrl in response
- AuthContext: expose refreshUser() so Settings page can refresh after avatar changes
- Settings page: add Profile Picture card with upload/remove support above the Change Password card
- Layout dropdown: replace individual "API & ShareX" + "Change Password" links with a single "Settings" entry; show user avatar + name/role header at top of dropdown; avatar thumbnail replaces the generic user icon in the trigger button

https://claude.ai/code/session_01H8W67o4tQBe7AjLebYTe1q