### PR TITLE
claude/improve-login-page-ND7gH

### DIFF
--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -4,9 +4,10 @@ import { useAuth } from '@/context/AuthContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
 
-export default function Login() {
+function LoginForm({ className, ...props }) {
   const { login } = useAuth();
   const navigate = useNavigate();
   const [error, setError] = useState('');
@@ -28,46 +29,68 @@ export default function Login() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center px-4">
-      <div className="w-full max-w-sm">
-        <div className="text-center mb-8">
-          <h1 className="text-2xl font-bold text-primary tracking-widest uppercase">IST</h1>
-          <p className="text-sm text-muted-foreground mt-1">sharely</p>
-        </div>
-        <Card>
-          <CardHeader>
-            <CardTitle>Sign in</CardTitle>
-            <CardDescription>Enter your credentials to continue</CardDescription>
-          </CardHeader>
+    <div className={cn('flex flex-col gap-6', className)} {...props}>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-2xl">Login</CardTitle>
+          <CardDescription>
+            Enter your username below to login to your account
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
           <form onSubmit={handleSubmit}>
-            <CardContent className="space-y-4">
+            <div className="flex flex-col gap-6">
               {error && (
                 <div className="rounded-md bg-destructive/10 border border-destructive/30 px-3 py-2 text-sm text-destructive">
                   {error}
                 </div>
               )}
-              <div className="space-y-2">
+              <div className="grid gap-2">
                 <Label htmlFor="username">Username</Label>
-                <Input id="username" name="username" autoComplete="username" required autoFocus />
+                <Input
+                  id="username"
+                  name="username"
+                  type="text"
+                  placeholder="johndoe"
+                  autoComplete="username"
+                  required
+                  autoFocus
+                />
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="password">Password</Label>
-                <Input id="password" name="password" type="password" autoComplete="current-password" required />
+              <div className="grid gap-2">
+                <div className="flex items-center">
+                  <Label htmlFor="password">Password</Label>
+                </div>
+                <Input
+                  id="password"
+                  name="password"
+                  type="password"
+                  autoComplete="current-password"
+                  required
+                />
               </div>
-            </CardContent>
-            <CardFooter className="flex flex-col gap-3">
               <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? 'Signing in…' : 'Sign in'}
+                {loading ? 'Logging in…' : 'Login'}
               </Button>
-              <p className="text-sm text-muted-foreground text-center">
-                No account?{' '}
-                <Link to="/auth/register" className="text-primary underline-offset-4 hover:underline">
-                  Register
-                </Link>
-              </p>
-            </CardFooter>
+            </div>
+            <div className="mt-4 text-center text-sm">
+              Don&apos;t have an account?{' '}
+              <Link to="/auth/register" className="underline underline-offset-4">
+                Sign up
+              </Link>
+            </div>
           </form>
-        </Card>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default function Login() {
+  return (
+    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
+      <div className="w-full max-w-sm">
+        <LoginForm />
       </div>
     </div>
   );


### PR DESCRIPTION
Refactors Login.jsx to match the shadcn login-01 block layout:
- Centered full-viewport layout with min-h-svh and responsive padding
- Extracts LoginForm as a composable component with cn() className support
- Uses flex flex-col gap-6 and grid gap-2 field spacing (login-01 pattern)
- Replaces CardFooter with inline button + sign-up link inside CardContent
- Adds username placeholder and cleaner label/input structure

https://claude.ai/code/session_01GxFcWgEBBN2Mw6cVt2T5hs