### PR TITLE
Improve register page using shadcn signup-01 block design

### DIFF
--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -4,9 +4,10 @@ import { useAuth } from '@/context/AuthContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
 
-export default function Register() {
+function SignupForm({ className, ...props }) {
   const { register } = useAuth();
   const navigate = useNavigate();
   const [error, setError] = useState('');
@@ -28,50 +29,84 @@ export default function Register() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center px-4">
-      <div className="w-full max-w-sm">
-        <div className="text-center mb-8">
-          <h1 className="text-2xl font-bold text-primary tracking-widest uppercase">IST</h1>
-          <p className="text-sm text-muted-foreground mt-1">sharely</p>
-        </div>
-        <Card>
-          <CardHeader>
-            <CardTitle>Create account</CardTitle>
-            <CardDescription>The first account gets admin access</CardDescription>
-          </CardHeader>
-          <form onSubmit={handleSubmit}>
-            <CardContent className="space-y-4">
-              {error && (
-                <div className="rounded-md bg-destructive/10 border border-destructive/30 px-3 py-2 text-sm text-destructive">
-                  {error}
-                </div>
-              )}
-              <div className="space-y-2">
-                <Label htmlFor="username">Username</Label>
-                <Input id="username" name="username" minLength={3} maxLength={32} required autoFocus />
+    <Card className={cn(className)} {...props}>
+      <CardHeader>
+        <CardTitle className="text-2xl">Create an account</CardTitle>
+        <CardDescription>
+          Enter your information below to create your account
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit}>
+          <div className="flex flex-col gap-6">
+            {error && (
+              <div className="rounded-md bg-destructive/10 border border-destructive/30 px-3 py-2 text-sm text-destructive">
+                {error}
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="password">Password</Label>
-                <Input id="password" name="password" type="password" minLength={6} required />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="confirmPassword">Confirm password</Label>
-                <Input id="confirmPassword" name="confirmPassword" type="password" minLength={6} required />
-              </div>
-            </CardContent>
-            <CardFooter className="flex flex-col gap-3">
-              <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? 'Creating account…' : 'Create account'}
-              </Button>
-              <p className="text-sm text-muted-foreground text-center">
-                Have an account?{' '}
-                <Link to="/auth/login" className="text-primary underline-offset-4 hover:underline">
-                  Sign in
-                </Link>
+            )}
+            <div className="grid gap-2">
+              <Label htmlFor="username">Username</Label>
+              <Input
+                id="username"
+                name="username"
+                type="text"
+                placeholder="johndoe"
+                minLength={3}
+                maxLength={32}
+                autoComplete="username"
+                required
+                autoFocus
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                name="password"
+                type="password"
+                minLength={6}
+                autoComplete="new-password"
+                required
+              />
+              <p className="text-sm text-muted-foreground">
+                Must be at least 6 characters long.
               </p>
-            </CardFooter>
-          </form>
-        </Card>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="confirmPassword">Confirm Password</Label>
+              <Input
+                id="confirmPassword"
+                name="confirmPassword"
+                type="password"
+                minLength={6}
+                autoComplete="new-password"
+                required
+              />
+              <p className="text-sm text-muted-foreground">
+                Please confirm your password.
+              </p>
+            </div>
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? 'Creating account…' : 'Create account'}
+            </Button>
+          </div>
+          <div className="mt-4 text-center text-sm">
+            Already have an account?{' '}
+            <Link to="/auth/login" className="underline underline-offset-4">
+              Login
+            </Link>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function Register() {
+  return (
+    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
+      <div className="w-full max-w-sm">
+        <SignupForm />
       </div>
     </div>
   );


### PR DESCRIPTION
Refactors Register.jsx to match the shadcn signup-01 block layout:
- Same min-h-svh centered page wrapper as login-01 for visual consistency
- SignupForm directly extends Card (signup-01 pattern vs login-01 wrapping div)
- Uses flex flex-col gap-6 and grid gap-2 field spacing
- Adds FieldDescription-style hint text below password fields
- Replaces CardFooter with inline button + login link inside CardContent
- Consistent "underline underline-offset-4" link styling matching login page

https://claude.ai/code/session_01GxFcWgEBBN2Mw6cVt2T5hs