### PR TITLE
Make image viewer larger and open raw on double-click

### DIFF
--- a/client/src/pages/FileView.jsx
+++ b/client/src/pages/FileView.jsx
@@ -108,8 +108,13 @@ function FileViewer({ file }) {
 
   if (displayType === 'image') {
     return (
-      <div className="flex items-center justify-center p-4 min-h-[40vh]">
-        <img src={`/f/${shortId}/raw`} alt={file.originalName} className="max-w-full max-h-[80vh] object-contain rounded" />
+      <div className="flex items-center justify-center p-4 min-h-[60vh]">
+        <img
+          src={`/f/${shortId}/raw`}
+          alt={file.originalName}
+          className="max-w-full max-h-[90vh] object-contain rounded cursor-zoom-in"
+          onDoubleClick={() => window.open(`/f/${shortId}/raw`, '_blank')}
+        />
       </div>
     );
   }


### PR DESCRIPTION
- Increase min-height from 40vh to 60vh
- Increase max-height from 80vh to 90vh
- Double-click opens the raw image in a new tab

https://claude.ai/code/session_01Aeqefmiye5LZ4AVNoBzTJe