### PR TITLE
claude/add-video-pdf-thumbnails-dp7w1

### DIFF
--- a/client/src/pages/Gallery.jsx
+++ b/client/src/pages/Gallery.jsx
@@ -56,6 +56,42 @@ const TYPE_ICONS = {
   file: faFile,
 };
 
+function FileThumbnail({ file, icon }) {
+  const [thumbError, setThumbError] = useState(false);
+
+  if (file.displayType === 'image') {
+    return (
+      <img
+        src={`/f/${file.shortId}/raw`}
+        alt={file.originalName}
+        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200"
+        loading="lazy"
+      />
+    );
+  }
+
+  if ((file.displayType === 'video' || file.displayType === 'pdf') && !thumbError) {
+    return (
+      <div className="relative w-full h-full">
+        <img
+          src={`/f/${file.shortId}/thumb`}
+          alt={file.originalName}
+          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200"
+          loading="lazy"
+          onError={() => setThumbError(true)}
+        />
+        {file.displayType === 'video' && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/20">
+            <FontAwesomeIcon icon={icon} className="h-8 w-8 text-white drop-shadow" />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return <FontAwesomeIcon icon={icon} className="h-12 w-12 text-muted-foreground/50" />;
+}
+
 function FileCard({ file, user, onDelete }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -88,16 +124,7 @@ function FileCard({ file, user, onDelete }) {
             className="group rounded-lg border bg-card overflow-hidden flex flex-col hover:border-primary/60 transition-colors"
           >
             <div className="aspect-square bg-muted/30 flex items-center justify-center overflow-hidden">
-              {file.displayType === 'image' ? (
-                <img
-                  src={`/f/${file.shortId}/raw`}
-                  alt={file.originalName}
-                  className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200"
-                  loading="lazy"
-                />
-              ) : (
-                <FontAwesomeIcon icon={icon} className="h-12 w-12 text-muted-foreground/50" />
-              )}
+              <FileThumbnail file={file} icon={icon} />
             </div>
             <div className="p-3 space-y-1">
               <p className="text-sm font-medium truncate" title={file.originalName}>

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -11,6 +11,7 @@ const { isBlockedFile } = require('../middleware/upload');
 const File = require('../models/File');
 const User = require('../models/User');
 const sanitizeFilename = require('../utils/sanitizeFilename');
+const { generateThumbnail, deleteThumbnail } = require('../utils/generateThumbnail');
 
 const uploadLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -87,6 +88,8 @@ router.post('/upload', uploadLimiter, requireApiKey, upload.single('file'), asyn
     uploader: req.apiUser._id,
   });
 
+  generateThumbnail(req.file.path, req.file.mimetype, file.shortId).catch(() => {});
+
   const base = BASE_URL();
   res.json({
     url: `${base}/f/${file.shortId}`,
@@ -115,6 +118,7 @@ router.post('/web-upload', uploadLimiter, requireLogin, upload.array('files', 50
       size: f.size,
       uploader: req.session.user.id,
     });
+    generateThumbnail(f.path, f.mimetype, doc.shortId).catch(() => {});
     created.push(doc.toObject());
   }
 
@@ -133,6 +137,7 @@ router.delete('/delete/:shortId', requireApiKey, async (req, res) => {
 
   const fp = resolveUploadPath(file.storedName);
   try { fs.unlinkSync(fp); } catch (e) { if (e.code !== 'ENOENT') throw e; }
+  deleteThumbnail(file.shortId);
   await file.deleteOne();
   res.json({ success: true });
 });
@@ -149,6 +154,7 @@ router.delete('/file/:shortId', requireLogin, async (req, res) => {
 
   const fp = resolveUploadPath(file.storedName);
   try { fs.unlinkSync(fp); } catch (e) { if (e.code !== 'ENOENT') throw e; }
+  deleteThumbnail(file.shortId);
   await file.deleteOne();
   res.json({ success: true });
 });
@@ -584,6 +590,8 @@ router.post('/chunk/:uploadId/complete', requireLogin, async (req, res) => {
     size: meta.totalSize,
     uploader: meta.userId,
   });
+
+  generateThumbnail(finalPath, meta.mimeType, doc.shortId).catch(() => {});
 
   res.json({ files: [doc.toObject()] });
 });

--- a/src/routes/files.js
+++ b/src/routes/files.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const path = require('path');
 const fs = require('fs');
 const File = require('../models/File');
+const { deleteThumbnail, thumbPath } = require('../utils/generateThumbnail');
 
 const UPLOAD_DIR = path.resolve(__dirname, '../../uploads');
 
@@ -134,6 +135,15 @@ router.get('/:shortId', async (req, res, next) => {
   res.send(html);
 });
 
+// GET /f/:shortId/thumb — serve generated thumbnail (video / PDF)
+router.get('/:shortId/thumb', async (req, res) => {
+  const fp = thumbPath(req.params.shortId);
+  if (!fs.existsSync(fp)) return res.status(404).send('No thumbnail');
+  res.setHeader('Content-Type', 'image/jpeg');
+  res.setHeader('Cache-Control', 'public, max-age=86400');
+  fs.createReadStream(fp).pipe(res);
+});
+
 // GET /f/:shortId/raw — serve file inline
 router.get('/:shortId/raw', async (req, res) => {
   const file = await File.findOne({ shortId: req.params.shortId });
@@ -156,6 +166,7 @@ router.get('/:shortId/delete/:token', async (req, res) => {
 
   const fp = resolveUploadPath(file.storedName);
   try { fs.unlinkSync(fp); } catch (e) { if (e.code !== 'ENOENT') throw e; }
+  deleteThumbnail(file.shortId);
   await file.deleteOne();
   res.json({ success: true });
 });

--- a/src/utils/generateThumbnail.js
+++ b/src/utils/generateThumbnail.js
@@ -1,0 +1,52 @@
+const { execFile } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const THUMB_DIR = path.resolve(__dirname, '../../uploads/.thumbnails');
+fs.mkdirSync(THUMB_DIR, { recursive: true });
+
+function thumbPath(shortId) {
+  return path.join(THUMB_DIR, `${shortId}.jpg`);
+}
+
+function generateVideoThumb(filePath, shortId) {
+  return new Promise((resolve) => {
+    execFile('ffmpeg', [
+      '-y', '-i', filePath,
+      '-ss', '00:00:01',
+      '-vframes', '1',
+      '-vf', 'scale=320:320:force_original_aspect_ratio=increase,crop=320:320',
+      '-q:v', '3',
+      thumbPath(shortId),
+    ], { timeout: 30000 }, (err) => resolve(!err));
+  });
+}
+
+function generatePdfThumb(filePath, shortId) {
+  return new Promise((resolve) => {
+    execFile('gs', [
+      '-dNOPAUSE', '-dBATCH', '-dSAFER',
+      '-sDEVICE=jpeg',
+      '-dFirstPage=1', '-dLastPage=1',
+      '-r72', '-dJPEGQ=85',
+      `-sOutputFile=${thumbPath(shortId)}`,
+      filePath,
+    ], { timeout: 30000 }, (err) => resolve(!err));
+  });
+}
+
+async function generateThumbnail(filePath, mimeType, shortId) {
+  try {
+    if (mimeType.startsWith('video/')) return await generateVideoThumb(filePath, shortId);
+    if (mimeType === 'application/pdf') return await generatePdfThumb(filePath, shortId);
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+function deleteThumbnail(shortId) {
+  try { fs.unlinkSync(thumbPath(shortId)); } catch { /* ignore */ }
+}
+
+module.exports = { generateThumbnail, deleteThumbnail, thumbPath };


### PR DESCRIPTION
- New src/utils/generateThumbnail.js calls ffmpeg (video) or gs (PDF)
  via child_process with a 30 s timeout and graceful fallback on failure
- Thumbnails stored in uploads/.thumbnails/{shortId}.jpg
- GET /f/:shortId/thumb endpoint serves the JPEG with 24 h cache header
- Thumbnail generation triggered (non-blocking) after every upload path:
  ShareX API, web upload, and chunked upload completion
- Thumbnails deleted alongside the source file in all three delete routes
- Gallery.jsx: new FileThumbnail component renders the thumb for video/PDF
  with an onError fallback to the icon; video cards show a play-icon overlay

https://claude.ai/code/session_01ADJseLe5JVgjmskTajqJWh