### PR TITLE
fix: copy scripts/ directory into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apk add --no-cache ffmpeg ghostscript
 
 COPY app.js ./
 COPY src/ ./src/
+COPY scripts/ ./scripts/
 COPY --from=builder /app/client/dist ./client/dist/
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup \


### PR DESCRIPTION
Required for npm run migrate:thumbnails (and other scripts) to work inside the container.

https://claude.ai/code/session_01ADJseLe5JVgjmskTajqJWh