### PR TITLE
Extract UserAvatar component and add avatar display across app

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -11,6 +11,7 @@ import { faImages, faUpload, faGear, faRightFromBracket, faUser, faTableCellsLar
 import { cn } from '@/lib/utils';
 import { LanguageSelector } from '@/components/LanguageSelector';
 import { useTranslation } from 'react-i18next';
+import { UserAvatar } from '@/components/UserAvatar';
 
 function NavLink({ to, children, icon }) {
   const { pathname } = useLocation();
@@ -31,18 +32,8 @@ function NavLink({ to, children, icon }) {
   );
 }
 
-function UserAvatar({ user, size = 'sm' }) {
-  const dim = size === 'sm' ? 'h-6 w-6' : 'h-8 w-8';
-  const iconSize = size === 'sm' ? 'h-3.5 w-3.5' : 'h-4 w-4';
-  return (
-    <div className={`${dim} rounded-full overflow-hidden bg-muted flex items-center justify-center shrink-0`}>
-      {user?.avatarUrl ? (
-        <img src={user.avatarUrl} alt="" className="h-full w-full object-cover" />
-      ) : (
-        <FontAwesomeIcon icon={faUser} className={iconSize} />
-      )}
-    </div>
-  );
+function NavUserAvatar({ user, size = 'sm' }) {
+  return <UserAvatar avatarUrl={user?.avatarUrl} size={size} />;
 }
 
 export function Layout({ children }) {
@@ -78,7 +69,7 @@ export function Layout({ children }) {
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="sm" className="gap-2">
-                  <UserAvatar user={user} size="sm" />
+                  <NavUserAvatar user={user} size="sm" />
                   <span className="hidden sm:inline">{user?.username}</span>
                   <FontAwesomeIcon icon={faChevronDown} className="h-3 w-3 opacity-50" />
                 </Button>
@@ -86,7 +77,7 @@ export function Layout({ children }) {
               <DropdownMenuContent align="end" className="w-52">
                 {/* User header */}
                 <div className="flex items-center gap-3 px-2 py-2">
-                  <UserAvatar user={user} size="md" />
+                  <NavUserAvatar user={user} size="md" />
                   <div className="flex flex-col min-w-0">
                     <span className="text-sm font-medium truncate">{user?.username}</span>
                     <span className="text-xs text-muted-foreground capitalize">{user?.role}</span>

--- a/client/src/components/UserAvatar.jsx
+++ b/client/src/components/UserAvatar.jsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faUser } from '@fortawesome/free-solid-svg-icons';
+
+const SIZES = {
+  xs: { dim: 'h-5 w-5', icon: 'h-3 w-3' },
+  sm: { dim: 'h-6 w-6', icon: 'h-3.5 w-3.5' },
+  md: { dim: 'h-8 w-8', icon: 'h-4 w-4' },
+};
+
+export function UserAvatar({ userId, avatarUrl, size = 'sm' }) {
+  const [error, setError] = useState(false);
+  const { dim, icon } = SIZES[size] || SIZES.sm;
+  const src = avatarUrl || (userId ? `/api/user/avatar/${userId}` : null);
+
+  return (
+    <div className={`${dim} rounded-full overflow-hidden bg-muted flex items-center justify-center shrink-0`}>
+      {src && !error ? (
+        <img src={src} alt="" className="h-full w-full object-cover" onError={() => setError(true)} />
+      ) : (
+        <FontAwesomeIcon icon={faUser} className={icon} />
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/FileView.jsx
+++ b/client/src/pages/FileView.jsx
@@ -63,8 +63,9 @@ import {
 import { useToast } from '@/hooks/use-toast';
 import { fmtSize, fmtDate } from '@/lib/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faDownload, faTrash, faCopy, faArrowUpRightFromSquare, faEye, faCalendar, faUser } from '@fortawesome/free-solid-svg-icons';
+import { faDownload, faTrash, faCopy, faArrowUpRightFromSquare, faEye, faCalendar } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+import { UserAvatar } from '@/components/UserAvatar';
 
 function CodeViewer({ shortId, lang }) {
   const [code, setCode] = useState('');
@@ -219,7 +220,7 @@ function FileViewInner() {
                 <Badge variant="secondary">{file.displayType}</Badge>
                 <span>{fmtSize(file.size)}</span>
                 <span className="flex items-center gap-1"><FontAwesomeIcon icon={faEye} className="h-3.5 w-3.5" />{file.views}</span>
-                {file.uploader && <span className="flex items-center gap-1"><FontAwesomeIcon icon={faUser} className="h-3.5 w-3.5" />{file.uploader.username}</span>}
+                {file.uploader && <span className="flex items-center gap-1"><UserAvatar userId={file.uploader._id} size="xs" />{file.uploader.username}</span>}
                 <span className="flex items-center gap-1"><FontAwesomeIcon icon={faCalendar} className="h-3.5 w-3.5" />{fmtDate(file.createdAt)}</span>
               </div>
             </div>

--- a/client/src/pages/Gallery.jsx
+++ b/client/src/pages/Gallery.jsx
@@ -30,6 +30,7 @@ import { fmtSize } from '@/lib/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUpload, faMagnifyingGlass, faXmark, faImage, faVideo, faMusic, faFileLines, faCode, faFile, faLink, faDownload, faArrowUpRightFromSquare, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+import { UserAvatar } from '@/components/UserAvatar';
 
 function buildPageItems(page, pages) {
   if (pages <= 7) {
@@ -162,7 +163,10 @@ function FileCard({ file, user, onDelete }) {
                 <span className="text-xs text-muted-foreground">{fmtSize(file.size)}</span>
               </div>
               {file.uploader && (
-                <p className="text-xs text-muted-foreground truncate">{t('gallery.by')} {file.uploader.username}</p>
+                <div className="flex items-center gap-1.5 mt-0.5">
+                  <UserAvatar userId={file.uploader._id} size="xs" />
+                  <p className="text-xs text-muted-foreground truncate">{file.uploader.username}</p>
+                </div>
               )}
             </div>
           </Link>

--- a/client/src/pages/admin/Users.jsx
+++ b/client/src/pages/admin/Users.jsx
@@ -19,6 +19,7 @@ import { fmtSize, fmtDate } from '@/lib/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faRotate, faTrash, faUserPlus, faPowerOff, faPencil, faCheck, faXmark, faKey } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+import { UserAvatar } from '@/components/UserAvatar';
 
 export default function AdminUsers() {
   const { user: me } = useAuth();
@@ -213,7 +214,12 @@ export default function AdminUsers() {
             <TableBody>
               {users.map((u) => (
                 <TableRow key={u._id} className={!u.isActive ? 'opacity-50' : ''}>
-                  <TableCell className="font-medium">{u.username}</TableCell>
+                  <TableCell className="font-medium">
+                    <div className="flex items-center gap-2">
+                      <UserAvatar userId={u._id} size="sm" />
+                      {u.username}
+                    </div>
+                  </TableCell>
                   <TableCell>
                     {editingFolder?.id === u._id ? (
                       <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
Refactored the `UserAvatar` component from being inline in `Layout.jsx` into a reusable, standalone component. This enables consistent user avatar display across the application with support for multiple sizes and fallback handling.

## Key Changes
- **New Component**: Created `UserAvatar.jsx` with enhanced functionality:
  - Supports three sizes: `xs`, `sm`, and `md` with responsive icon scaling
  - Accepts either `avatarUrl` directly or `userId` to fetch avatar from API endpoint
  - Includes error handling with fallback to user icon when image fails to load
  - Uses `FontAwesomeIcon` for consistent icon styling

- **Layout.jsx**: 
  - Removed inline `UserAvatar` component definition
  - Created wrapper `NavUserAvatar` component for navigation-specific usage
  - Updated all avatar references to use the new wrapper

- **Admin Users Page**: 
  - Added user avatars in the users table next to usernames
  - Displays avatars using the `userId` prop for API-based loading

- **Gallery Page**: 
  - Added uploader avatars to file cards with `xs` size
  - Displays avatars alongside uploader username

- **File View Page**: 
  - Added uploader avatar in file metadata section
  - Replaced standalone user icon with `UserAvatar` component
  - Removed unused `faUser` icon import

## Implementation Details
- The component gracefully handles missing avatar URLs by falling back to a user icon
- Image load errors are caught and trigger the fallback icon display
- Avatar sizing is managed through a `SIZES` configuration object for consistency
- The component is fully self-contained and doesn't require parent state management

https://claude.ai/code/session_01X6QXsfHMKvGm9pty9ZHxcK