### PR TITLE
fix: add author email required for deb packaging; pin action versions

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -25,11 +25,11 @@ jobs:
     name: Build (${{ matrix.label }})
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: electron/package.json
 
@@ -44,7 +44,7 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: false
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: sharely-${{ matrix.label }}
           path: ${{ matrix.artifact }}
@@ -59,7 +59,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v4.3.0
         with:
           path: dist
           merge-multiple: true

--- a/electron/package.json
+++ b/electron/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "Sharely Desktop – upload files to your Sharely instance from the system tray",
   "main": "main.js",
+  "author": {
+    "name": "Sharely",
+    "email": "noreply@sharely.app"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Christianoooooo/sharely"


### PR DESCRIPTION
- Add author.email to electron/package.json (required by electron-builder for .deb maintainer field)
- Pin all GitHub Actions to specific versions to silence Node.js 20 deprecation warnings and use Node.js 22

https://claude.ai/code/session_01H5vtqySzX1eHzaNAqgsLhP