### PR TITLE
Add user role management to admin panel

### DIFF
--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -200,6 +200,8 @@
     "titleChangePassword": "Passwort ändern",
     "titleRegenKey": "API-Schlüssel neu generieren",
     "titleRenameFolder": "Ordner umbenennen",
+    "titleChangeRole": "Rolle ändern",
+    "roleChanged": "Rolle von \"{{username}}\" auf {{role}} geändert",
     "selfLabel": "(du)",
     "deleteUser": "Benutzer löschen?",
     "deleteUserDesc": "Benutzer \"{{username}}\" und alle seine Dateien ({{count}}) werden dauerhaft gelöscht.",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -200,6 +200,8 @@
     "titleChangePassword": "Change password",
     "titleRegenKey": "Regenerate API key",
     "titleRenameFolder": "Rename folder",
+    "titleChangeRole": "Change role",
+    "roleChanged": "Role of \"{{username}}\" changed to {{role}}",
     "selfLabel": "(you)",
     "deleteUser": "Delete user?",
     "deleteUserDesc": "User \"{{username}}\" and all their files ({{count}}) will be permanently deleted.",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -200,6 +200,8 @@
     "titleChangePassword": "Cambiar contraseña",
     "titleRegenKey": "Regenerar clave API",
     "titleRenameFolder": "Renombrar carpeta",
+    "titleChangeRole": "Cambiar rol",
+    "roleChanged": "Rol de \"{{username}}\" cambiado a {{role}}",
     "selfLabel": "(tú)",
     "deleteUser": "¿Eliminar usuario?",
     "deleteUserDesc": "El usuario \"{{username}}\" y todos sus archivos ({{count}}) serán eliminados permanentemente.",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -200,6 +200,8 @@
     "titleChangePassword": "Changer le mot de passe",
     "titleRegenKey": "Régénérer la clé API",
     "titleRenameFolder": "Renommer le dossier",
+    "titleChangeRole": "Changer le rôle",
+    "roleChanged": "Rôle de \"{{username}}\" changé en {{role}}",
     "selfLabel": "(vous)",
     "deleteUser": "Supprimer l'utilisateur ?",
     "deleteUserDesc": "L'utilisateur \"{{username}}\" et tous ses fichiers ({{count}}) seront supprimés définitivement.",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -200,6 +200,8 @@
     "titleChangePassword": "Cambia password",
     "titleRegenKey": "Rigenera chiave API",
     "titleRenameFolder": "Rinomina cartella",
+    "titleChangeRole": "Cambia ruolo",
+    "roleChanged": "Ruolo di \"{{username}}\" cambiato in {{role}}",
     "selfLabel": "(tu)",
     "deleteUser": "Eliminare l'utente?",
     "deleteUserDesc": "L'utente \"{{username}}\" e tutti i suoi file ({{count}}) verranno eliminati definitivamente.",

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -200,6 +200,8 @@
     "titleChangePassword": "パスワードを変更",
     "titleRegenKey": "APIキーを再生成",
     "titleRenameFolder": "フォルダーを名前変更",
+    "titleChangeRole": "ロールを変更",
+    "roleChanged": "「{{username}}」のロールを{{role}}に変更しました",
     "selfLabel": "(あなた)",
     "deleteUser": "ユーザーを削除しますか？",
     "deleteUserDesc": "ユーザー \"{{username}}\" とすべてのファイル ({{count}} 件) が完全に削除されます。",

--- a/client/src/i18n/locales/pt.json
+++ b/client/src/i18n/locales/pt.json
@@ -200,6 +200,8 @@
     "titleChangePassword": "Alterar palavra-passe",
     "titleRegenKey": "Regenerar chave API",
     "titleRenameFolder": "Renomear pasta",
+    "titleChangeRole": "Alterar função",
+    "roleChanged": "Função de \"{{username}}\" alterada para {{role}}",
     "selfLabel": "(você)",
     "deleteUser": "Eliminar utilizador?",
     "deleteUserDesc": "O utilizador \"{{username}}\" e todos os seus ficheiros ({{count}}) serão eliminados permanentemente.",

--- a/client/src/i18n/locales/zh.json
+++ b/client/src/i18n/locales/zh.json
@@ -200,6 +200,8 @@
     "titleChangePassword": "修改密码",
     "titleRegenKey": "重新生成 API 密钥",
     "titleRenameFolder": "重命名文件夹",
+    "titleChangeRole": "更改角色",
+    "roleChanged": "\"{{username}}\" 的角色已更改为 {{role}}",
     "selfLabel": "（您）",
     "deleteUser": "删除用户？",
     "deleteUserDesc": "用户 \"{{username}}\" 及其所有文件（{{count}} 个）将被永久删除。",

--- a/client/src/pages/admin/Users.jsx
+++ b/client/src/pages/admin/Users.jsx
@@ -30,6 +30,7 @@ export default function AdminUsers() {
   const [newUser, setNewUser] = useState({ username: '', password: '', role: 'user' });
   const [editingFolder, setEditingFolder] = useState(null); // { id, value }
   const folderInputRef = useRef(null);
+  const [editingRole, setEditingRole] = useState(null); // { id, value }
   const [pwDialog, setPwDialog] = useState(null); // { id, username }
   const [newPw, setNewPw] = useState('');
   const [savingPw, setSavingPw] = useState(false);
@@ -98,6 +99,23 @@ export default function AdminUsers() {
 
   function cancelEditFolder() {
     setEditingFolder(null);
+  }
+
+  async function saveRole(id) {
+    const { value } = editingRole;
+    const r = await fetch(`/api/admin/users/${id}/role`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ role: value }),
+    });
+    const data = await r.json();
+    if (r.ok) {
+      toast({ title: t('adminUsers.roleChanged', { username: users.find((u) => u._id === id)?.username, role: value }) });
+      setEditingRole(null);
+      load();
+    } else {
+      toast({ title: data.error, variant: 'destructive' });
+    }
   }
 
   function openPwDialog(id, username) {
@@ -254,7 +272,36 @@ export default function AdminUsers() {
                     )}
                   </TableCell>
                   <TableCell>
-                    <Badge variant={u.role === 'admin' ? 'default' : 'secondary'}>{u.role}</Badge>
+                    {editingRole?.id === u._id ? (
+                      <div className="flex items-center gap-1">
+                        <Select value={editingRole.value} onValueChange={(v) => setEditingRole((p) => ({ ...p, value: v }))}>
+                          <SelectTrigger className="h-7 w-24 text-xs"><SelectValue /></SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="user">{t('adminUsers.roleUser')}</SelectItem>
+                            <SelectItem value="admin">{t('adminUsers.roleAdmin')}</SelectItem>
+                          </SelectContent>
+                        </Select>
+                        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => saveRole(u._id)}>
+                          <FontAwesomeIcon icon={faCheck} className="h-3.5 w-3.5 text-green-500" />
+                        </Button>
+                        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setEditingRole(null)}>
+                          <FontAwesomeIcon icon={faXmark} className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    ) : (
+                      <div className="flex items-center gap-1 group">
+                        <Badge variant={u.role === 'admin' ? 'default' : 'secondary'}>{u.role}</Badge>
+                        {u._id !== me?.id && (
+                          <Button
+                            variant="ghost" size="icon" className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+                            title={t('adminUsers.titleChangeRole')}
+                            onClick={() => setEditingRole({ id: u._id, value: u.role })}
+                          >
+                            <FontAwesomeIcon icon={faPencil} className="h-3 w-3" />
+                          </Button>
+                        )}
+                      </div>
+                    )}
                   </TableCell>
                   <TableCell className="text-muted-foreground">{u.fileCount}</TableCell>
                   <TableCell className="text-muted-foreground">{fmtSize(u.storageUsed)}</TableCell>

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -329,6 +329,21 @@ router.patch('/admin/users/:id/toggle', requireAdmin, async (req, res) => {
   res.json({ isActive: user.isActive });
 });
 
+router.patch('/admin/users/:id/role', requireAdmin, async (req, res) => {
+  const { role } = req.body;
+  if (!['admin', 'user'].includes(role)) {
+    return res.status(400).json({ error: 'Invalid role' });
+  }
+  const user = await User.findById(req.params.id);
+  if (!user) return res.status(404).json({ error: 'Not found' });
+  if (user._id.toString() === req.session.user.id.toString()) {
+    return res.status(400).json({ error: 'Cannot change your own role' });
+  }
+  user.role = role;
+  await user.save();
+  res.json({ role: user.role });
+});
+
 router.delete('/admin/users/:id', requireAdmin, async (req, res) => {
   const user = await User.findById(req.params.id);
   if (!user) return res.status(404).json({ error: 'Not found' });


### PR DESCRIPTION
## Summary
This PR adds the ability for administrators to change user roles directly from the admin users panel. Previously, user roles could only be modified through direct database access.

## Key Changes
- **Backend API**: Added new `PATCH /api/admin/users/:id/role` endpoint to update user roles with validation:
  - Validates that the role is either 'admin' or 'user'
  - Prevents users from changing their own role
  - Returns appropriate error messages for invalid requests

- **Frontend UI**: Enhanced the admin users table to support inline role editing:
  - Added edit mode for role field with a dropdown selector
  - Displays a pencil icon on hover to initiate role changes (hidden for current user)
  - Includes confirm/cancel buttons for save/discard operations
  - Shows success toast notification with updated role information

- **Internationalization**: Added translations for new UI elements across 8 languages (English, German, Spanish, French, Italian, Japanese, Portuguese, Chinese):
  - `titleChangeRole`: Tooltip text for the edit role button
  - `roleChanged`: Success message template showing username and new role

## Implementation Details
- Role editing state is managed similarly to existing folder rename functionality using `editingRole` state
- The edit UI only appears for users other than the current admin (prevents self-modification)
- API validation prevents admins from accidentally removing their own admin privileges
- Changes trigger a full user list reload to ensure UI consistency

https://claude.ai/code/session_01Njvf2KJ6DRE4euAgMYbkJF