### PR TITLE
Improve API key copy UX with tooltips and visual feedback

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { AuthProvider } from '@/context/AuthContext';
 import { Toaster } from '@/components/ui/toaster';
+import { TooltipProvider } from '@/components/ui/tooltip';
 import { ProtectedRoute } from '@/components/ProtectedRoute';
 import { Layout } from '@/components/Layout';
 
@@ -41,6 +42,7 @@ function App() {
   return (
     <BrowserRouter>
       <AuthProvider>
+        <TooltipProvider>
         <TitleUpdater />
         <Routes>
           {/* Public */}
@@ -63,6 +65,7 @@ function App() {
           <Route path="*" element={<Navigate to="/gallery" replace />} />
         </Routes>
         <Toaster />
+        </TooltipProvider>
       </AuthProvider>
     </BrowserRouter>
   );

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -262,6 +262,7 @@
   },
   "common": {
     "copiedToClipboard": "In Zwischenablage kopiert",
+    "copyToClipboard": "Klicken zum Kopieren",
     "apiKeyRegenerated": "API-Schlüssel neu generiert",
     "or": "oder"
   },

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -262,6 +262,7 @@
   },
   "common": {
     "copiedToClipboard": "Copied to clipboard",
+    "copyToClipboard": "Click to copy",
     "apiKeyRegenerated": "API key regenerated",
     "or": "or"
   },

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -262,6 +262,7 @@
   },
   "common": {
     "copiedToClipboard": "Copiado al portapapeles",
+    "copyToClipboard": "Clic para copiar",
     "apiKeyRegenerated": "Clave API regenerada",
     "or": "o"
   },

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -262,6 +262,7 @@
   },
   "common": {
     "copiedToClipboard": "Copié dans le presse-papiers",
+    "copyToClipboard": "Cliquer pour copier",
     "apiKeyRegenerated": "Clé API régénérée",
     "or": "ou"
   },

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -262,6 +262,7 @@
   },
   "common": {
     "copiedToClipboard": "Copiato negli appunti",
+    "copyToClipboard": "Clicca per copiare",
     "apiKeyRegenerated": "Chiave API rigenerata",
     "or": "o"
   },

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -262,6 +262,7 @@
   },
   "common": {
     "copiedToClipboard": "クリップボードにコピーしました",
+    "copyToClipboard": "クリックしてコピー",
     "apiKeyRegenerated": "APIキーを再生成しました",
     "or": "または"
   },

--- a/client/src/i18n/locales/pt.json
+++ b/client/src/i18n/locales/pt.json
@@ -262,6 +262,7 @@
   },
   "common": {
     "copiedToClipboard": "Copiado para a área de transferência",
+    "copyToClipboard": "Clique para copiar",
     "apiKeyRegenerated": "Chave API regenerada",
     "or": "ou"
   },

--- a/client/src/i18n/locales/zh.json
+++ b/client/src/i18n/locales/zh.json
@@ -262,6 +262,7 @@
   },
   "common": {
     "copiedToClipboard": "已复制到剪贴板",
+    "copyToClipboard": "点击复制",
     "apiKeyRegenerated": "API 密钥已重新生成",
     "or": "或"
   },

--- a/client/src/pages/Upload.jsx
+++ b/client/src/pages/Upload.jsx
@@ -3,10 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useToast } from '@/hooks/use-toast';
 import { fmtSize } from '@/lib/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUpload, faXmark, faDownload, faRotate, faCopy } from '@fortawesome/free-solid-svg-icons';
+import { faUpload, faXmark, faDownload, faRotate } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 
 const MB = 1024 * 1024;
@@ -154,6 +155,7 @@ export default function Upload() {
   const [uploading, setUploading] = useState(false);
   const [dragging, setDragging] = useState(false);
   const [apiKey, setApiKey] = useState('');
+  const [keyCopied, setKeyCopied] = useState(false);
   const [progress, setProgress] = useState({}); // key: name+size → 0-100
   const fileInputRef = useRef(null);
 
@@ -270,7 +272,8 @@ export default function Upload() {
 
   function copyToClipboard(text) {
     navigator.clipboard.writeText(text);
-    toast({ title: t('common.copiedToClipboard') });
+    setKeyCopied(true);
+    setTimeout(() => setKeyCopied(false), 2000);
   }
 
   return (
@@ -391,12 +394,19 @@ export default function Upload() {
               <FontAwesomeIcon icon={faRotate} className="h-3.5 w-3.5" />{t('upload.regenKey')}
             </Button>
             {apiKey && (
-              <div className="flex items-center gap-2 flex-1 min-w-0">
-                <code className="text-xs bg-muted px-2 py-1 rounded truncate flex-1">{apiKey}</code>
-                <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" onClick={() => copyToClipboard(apiKey)}>
-                  <FontAwesomeIcon icon={faCopy} className="h-3.5 w-3.5" />
-                </Button>
-              </div>
+              <Tooltip open={keyCopied || undefined}>
+                <TooltipTrigger asChild>
+                  <code
+                    className="text-xs bg-muted px-2 py-1 rounded truncate flex-1 cursor-pointer hover:bg-muted/70 transition-colors"
+                    onClick={() => copyToClipboard(apiKey)}
+                  >
+                    {apiKey}
+                  </code>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {keyCopied ? t('common.copiedToClipboard') : t('common.copyToClipboard')}
+                </TooltipContent>
+              </Tooltip>
             )}
           </div>
         </CardContent>

--- a/client/src/pages/admin/Users.jsx
+++ b/client/src/pages/admin/Users.jsx
@@ -14,6 +14,7 @@ import {
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
 } from '@/components/ui/dialog';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useToast } from '@/hooks/use-toast';
 import { fmtSize, fmtDate } from '@/lib/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -312,9 +313,17 @@ export default function AdminUsers() {
                   </TableCell>
                   <TableCell className="text-muted-foreground">{fmtDate(u.createdAt)}</TableCell>
                   <TableCell>
-                    <code className="text-xs bg-muted px-1.5 py-0.5 rounded" title={u.apiKey}>
-                      {u.apiKey?.slice(0, 8)}…
-                    </code>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <code
+                          className="text-xs bg-muted px-1.5 py-0.5 rounded cursor-pointer hover:bg-muted/70 transition-colors"
+                          onClick={() => { navigator.clipboard.writeText(u.apiKey); toast({ title: t('common.copiedToClipboard') }); }}
+                        >
+                          {u.apiKey?.slice(0, 8)}…
+                        </code>
+                      </TooltipTrigger>
+                      <TooltipContent>{u.apiKey}</TooltipContent>
+                    </Tooltip>
                   </TableCell>
                   <TableCell>
                     {u._id !== me?.id && (


### PR DESCRIPTION
## Summary
Enhanced the user experience for copying API keys by replacing toast notifications with interactive tooltips and making the copy action more discoverable through visual affordances.

## Key Changes
- **Upload page**: Refactored API key display to use clickable code element with tooltip feedback instead of separate copy button
  - Removed `faCopy` icon import and dedicated copy button
  - Added state tracking (`keyCopied`) for tooltip visibility with 2-second auto-dismiss
  - Made the API key code block itself clickable with hover effects
  - Tooltip shows "Click to copy" by default and "Copied to clipboard" after clicking

- **Admin Users page**: Improved API key display in user table with tooltip
  - Replaced `title` attribute with interactive Tooltip component
  - Made truncated API key clickable to copy full key to clipboard
  - Tooltip displays full API key on hover
  - Added inline copy functionality with toast notification

- **App root**: Added `TooltipProvider` wrapper to enable tooltip functionality across the application

- **Internationalization**: Added "copyToClipboard" translation key across all 8 supported languages (en, de, es, fr, it, ja, pt, zh)

## Implementation Details
- Uses Radix UI's Tooltip component for consistent, accessible tooltip behavior
- Tooltip state is controlled via `open` prop to show/hide based on copy action
- Visual feedback includes hover state changes (`hover:bg-muted/70`) and smooth transitions
- Copy action is now more intuitive as the clickable element itself provides the affordance

https://claude.ai/code/session_019Z3bUD9WcdhM6NbrWuvjmf