### PR TITLE
feat: add cookie consent banner for Cloudflare Analytics

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,6 +5,7 @@ import { Toaster } from '@/components/ui/toaster';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { ProtectedRoute } from '@/components/ProtectedRoute';
 import { Layout } from '@/components/Layout';
+import { CookieBanner } from '@/components/CookieBanner';
 
 import Login from '@/pages/Login';
 import Register from '@/pages/Register';
@@ -68,6 +69,7 @@ function App() {
           {/* Fallback */}
           <Route path="*" element={<Navigate to="/gallery" replace />} />
         </Routes>
+        <CookieBanner />
         <Toaster />
         </TooltipProvider>
       </AuthProvider>

--- a/client/src/components/CookieBanner.jsx
+++ b/client/src/components/CookieBanner.jsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCloud } from '@fortawesome/free-solid-svg-icons';
+
+const STORAGE_KEY = 'cookie-consent-cf';
+
+export function CookieBanner() {
+  const { t } = useTranslation();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (localStorage.getItem(STORAGE_KEY)) return;
+
+    fetch('/api/site-settings')
+      .then((r) => r.ok ? r.json() : {})
+      .then((data) => { if (data.cloudflareAnalytics) setVisible(true); })
+      .catch(() => {});
+  }, []);
+
+  function accept() {
+    localStorage.setItem(STORAGE_KEY, 'accepted');
+    setVisible(false);
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 border-t bg-card/95 backdrop-blur-sm shadow-lg">
+      <div className="max-w-7xl mx-auto px-4 py-3 flex flex-col sm:flex-row items-start sm:items-center gap-3">
+        <FontAwesomeIcon icon={faCloud} className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5 sm:mt-0" />
+        <p className="text-sm text-muted-foreground flex-1">
+          {t('cookieBanner.text')}{' '}
+          <Link to="/privacy" className="underline underline-offset-2 hover:text-foreground transition-colors">
+            {t('cookieBanner.privacyLink')}
+          </Link>
+          .
+        </p>
+        <Button size="sm" onClick={accept} className="shrink-0">
+          {t('cookieBanner.accept')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -253,7 +253,11 @@
     "placeholderEmail": "z. B. datenschutz@beispiel.de",
     "save": "Speichern",
     "saving": "Speichern…",
-    "saved": "Einstellungen gespeichert"
+    "saved": "Einstellungen gespeichert",
+    "analyticsSection": "Analyse",
+    "analyticsDescription": "Aktiviere den Cookie-Hinweis, wenn Cloudflare Web Analytics auf dieser Instanz aktiv ist.",
+    "analyticsLabel": "Cloudflare Web Analytics ist auf dieser Instanz aktiv",
+    "analyticsHint": "Cloudflare Web Analytics verwendet keine Cookies. Wenn diese Option aktiviert ist, wird Benutzern ein Informationsbanner angezeigt, das sie über die Datenerhebung informiert (gem. DSGVO Art. 13)."
   },
   "adminImport": {
     "title": "Von XBackBone migrieren",
@@ -353,6 +357,11 @@
     "s7Title": "7. Änderungen dieser Erklärung",
     "s7Body": "Der Betreiber kann diese Erklärung jederzeit aktualisieren. Das Datum der letzten Überarbeitung wird oben vermerkt. Die weitere Nutzung des Dienstes nach Änderungen gilt als Zustimmung zur aktualisierten Erklärung.",
     "version": "Sharely – Open-Source-Dateifreigabe · Vorlage Datenschutzerklärung"
+  },
+  "cookieBanner": {
+    "text": "Diese Website verwendet Cloudflare Web Analytics (ohne Cookies) zur Analyse des Datenverkehrs.",
+    "privacyLink": "Datenschutzerklärung",
+    "accept": "OK"
   },
   "common": {
     "copiedToClipboard": "In Zwischenablage kopiert",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -253,7 +253,11 @@
     "placeholderEmail": "e.g. privacy@example.com",
     "save": "Save",
     "saving": "Saving…",
-    "saved": "Settings saved"
+    "saved": "Settings saved",
+    "analyticsSection": "Analytics",
+    "analyticsDescription": "Enable the cookie consent notice when Cloudflare Web Analytics is active on this instance.",
+    "analyticsLabel": "Cloudflare Web Analytics is enabled on this instance",
+    "analyticsHint": "Cloudflare Web Analytics is cookie-free. Enabling this shows an informational banner to users so they are aware of the data collection, as required by GDPR Art. 13."
   },
   "adminImport": {
     "title": "Migrate from XBackBone",
@@ -353,6 +357,11 @@
     "s7Title": "7. Changes to this Policy",
     "s7Body": "The operator may update this policy at any time. The date of the latest revision will be noted above. Continued use of the service after changes constitutes acceptance of the updated policy.",
     "version": "Sharely – open-source file sharing · Template privacy policy"
+  },
+  "cookieBanner": {
+    "text": "This site uses Cloudflare Web Analytics (cookie-free) to understand traffic.",
+    "privacyLink": "Privacy Policy",
+    "accept": "OK"
   },
   "common": {
     "copiedToClipboard": "Copied to clipboard",

--- a/client/src/pages/admin/SiteSettings.jsx
+++ b/client/src/pages/admin/SiteSettings.jsx
@@ -6,13 +6,13 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { useToast } from '@/hooks/use-toast';
 import { useTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faShield } from '@fortawesome/free-solid-svg-icons';
+import { faShield, faCloud } from '@fortawesome/free-solid-svg-icons';
 
 export default function AdminSiteSettings() {
   const { t } = useTranslation();
   const { toast } = useToast();
 
-  const [form, setForm] = useState({ operatorName: '', operatorAddress: '', operatorEmail: '' });
+  const [form, setForm] = useState({ operatorName: '', operatorAddress: '', operatorEmail: '', cloudflareAnalytics: false });
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
@@ -24,6 +24,7 @@ export default function AdminSiteSettings() {
           operatorName: data.operatorName ?? '',
           operatorAddress: data.operatorAddress ?? '',
           operatorEmail: data.operatorEmail ?? '',
+          cloudflareAnalytics: data.cloudflareAnalytics ?? false,
         });
       })
       .finally(() => setLoading(false));
@@ -98,6 +99,30 @@ export default function AdminSiteSettings() {
               {saving ? t('adminSiteSettings.saving') : t('adminSiteSettings.save')}
             </Button>
           </form>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <FontAwesomeIcon icon={faCloud} className="h-4 w-4" />
+            {t('adminSiteSettings.analyticsSection')}
+          </CardTitle>
+          <CardDescription>{t('adminSiteSettings.analyticsDescription')}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <label className="flex items-center gap-3 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              className="h-4 w-4 rounded border-input accent-primary cursor-pointer"
+              checked={form.cloudflareAnalytics}
+              onChange={(e) => setForm((p) => ({ ...p, cloudflareAnalytics: e.target.checked }))}
+            />
+            <span className="text-sm">{t('adminSiteSettings.analyticsLabel')}</span>
+          </label>
+          <p className="text-xs text-muted-foreground mt-2">{t('adminSiteSettings.analyticsHint')}</p>
+          <Button className="mt-4" disabled={saving} onClick={handleSubmit}>
+            {saving ? t('adminSiteSettings.saving') : t('adminSiteSettings.save')}
+          </Button>
         </CardContent>
       </Card>
     </div>

--- a/src/models/SiteSettings.js
+++ b/src/models/SiteSettings.js
@@ -5,6 +5,7 @@ const siteSettingsSchema = new mongoose.Schema({
   operatorName: { type: String, default: '' },
   operatorAddress: { type: String, default: '' },
   operatorEmail: { type: String, default: '' },
+  cloudflareAnalytics: { type: Boolean, default: false },
 });
 
 siteSettingsSchema.statics.get = async function () {

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -271,13 +271,14 @@ router.post('/regen-key', requireLogin, async (req, res) => {
   res.json({ apiKey: user.apiKey });
 });
 
-// ── Site settings: public read (used by privacy policy page) ───────────────
+// ── Site settings: public read (used by privacy policy page + cookie banner) ─
 router.get('/site-settings', async (req, res) => {
   const s = await SiteSettings.get();
   res.json({
     operatorName: s.operatorName,
     operatorAddress: s.operatorAddress,
     operatorEmail: s.operatorEmail,
+    cloudflareAnalytics: s.cloudflareAnalytics,
   });
 });
 
@@ -288,20 +289,23 @@ router.get('/admin/site-settings', requireAdmin, async (req, res) => {
     operatorName: s.operatorName,
     operatorAddress: s.operatorAddress,
     operatorEmail: s.operatorEmail,
+    cloudflareAnalytics: s.cloudflareAnalytics,
   });
 });
 
 router.patch('/admin/site-settings', requireAdmin, async (req, res) => {
-  const { operatorName, operatorAddress, operatorEmail } = req.body;
+  const { operatorName, operatorAddress, operatorEmail, cloudflareAnalytics } = req.body;
   const s = await SiteSettings.get();
   if (typeof operatorName === 'string') s.operatorName = operatorName.trim();
   if (typeof operatorAddress === 'string') s.operatorAddress = operatorAddress.trim();
   if (typeof operatorEmail === 'string') s.operatorEmail = operatorEmail.trim();
+  if (typeof cloudflareAnalytics === 'boolean') s.cloudflareAnalytics = cloudflareAnalytics;
   await s.save();
   res.json({
     operatorName: s.operatorName,
     operatorAddress: s.operatorAddress,
     operatorEmail: s.operatorEmail,
+    cloudflareAnalytics: s.cloudflareAnalytics,
   });
 });
 


### PR DESCRIPTION
Adds a configurable cookie/analytics notice banner:

- SiteSettings model: new cloudflareAnalytics (Boolean, default false)
- GET /api/site-settings: exposes cloudflareAnalytics to the frontend
- GET+PATCH /api/admin/site-settings: operator can toggle it on/off
- Admin → Site Settings: new "Analytics" card with checkbox
- CookieBanner component: fixed bottom bar shown sitewide when cloudflareAnalytics is true and the user has not yet acknowledged it. Dismissal stored in localStorage (cookie-consent-cf). Links to the privacy policy for full details.
- App.jsx: CookieBanner rendered globally (outside Layout)
- i18n EN + DE: keys for banner text and admin toggle

Note: Cloudflare Web Analytics is cookie-free; the banner is an informational notice fulfilling GDPR Art. 13 transparency obligations.

https://claude.ai/code/session_01Bjsau8D79UU3PQzDn3AQww