### PR TITLE
security: hash API keys at rest with SHA-256

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ const { requireApiKey } = require('./src/middleware/auth');
 const File = require('./src/models/File');
 
 const migrateUserFolders = require('./src/migrations/migrateUserFolders');
+const migrateApiKeyHashes = require('./src/migrations/migrateApiKeyHashes');
 const sanitizeFilename = require('./src/utils/sanitizeFilename');
 
 if (!process.env.SESSION_SECRET) {
@@ -138,6 +139,7 @@ const PORT = process.env.PORT || 3000;
 (async () => {
   await connectDB();
   await migrateUserFolders();
+  await migrateApiKeyHashes();
   app.listen(PORT, () => {
     console.log(`sharely running on http://localhost:${PORT}`);
   });

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -72,6 +72,8 @@
     "sharex": "ShareX-Integration",
     "sharexDescription": "Lade die .sxcu-Konfiguration herunter und importiere sie in ShareX",
     "downloadSxcu": ".sxcu herunterladen",
+    "sharexKeyNote": "Der Download generiert einen neuen API-Key – zuvor konfigurierte Tools benötigen den neuen Key.",
+    "keyShownOnce": "Kopiere diesen Key jetzt – er wird nicht erneut angezeigt.",
     "apiUpload": "API-Upload",
     "apiDescription": "Mit curl oder einem beliebigen HTTP-Client verwenden",
     "regenKey": "Schlüssel neu generieren",
@@ -237,6 +239,9 @@
     "changePwTitle": "Passwort ändern für \"{{username}}\"",
     "newPassword": "Neues Passwort",
     "pwChanged": "Passwort für \"{{username}}\" geändert",
+    "newKeyTitle": "Neuer API-Key für \"{{username}}\"",
+    "newKeyDesc": "Kopiere diesen Key jetzt – er wird nicht erneut angezeigt.",
+    "newKeyClose": "Fertig",
     "saving": "Speichern…",
     "save": "Speichern"
   },

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -72,6 +72,8 @@
     "sharex": "ShareX Integration",
     "sharexDescription": "Download the .sxcu config and import it into ShareX",
     "downloadSxcu": "Download .sxcu",
+    "sharexKeyNote": "Downloading generates a new API key — any previously configured tools will need the new key.",
+    "keyShownOnce": "Copy this key now — it will not be shown again.",
     "apiUpload": "API Upload",
     "apiDescription": "Use curl or any HTTP client",
     "regenKey": "Regenerate key",
@@ -237,6 +239,9 @@
     "changePwTitle": "Change password for \"{{username}}\"",
     "newPassword": "New password",
     "pwChanged": "Password changed for \"{{username}}\"",
+    "newKeyTitle": "New API key for \"{{username}}\"",
+    "newKeyDesc": "Copy this key now — it will not be shown again.",
+    "newKeyClose": "Done",
     "saving": "Saving…",
     "save": "Save"
   },

--- a/client/src/pages/Upload.jsx
+++ b/client/src/pages/Upload.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -154,7 +154,8 @@ export default function Upload() {
   const [files, setFiles] = useState([]);
   const [uploading, setUploading] = useState(false);
   const [dragging, setDragging] = useState(false);
-  const [apiKey, setApiKey] = useState('');
+  const [apiKey, setApiKey] = useState('');      // plaintext, shown once after regen
+  const [apiKeyPrefix, setApiKeyPrefix] = useState('');
   const [keyCopied, setKeyCopied] = useState(false);
   const [progress, setProgress] = useState({}); // key: name+size → 0-100
   const fileInputRef = useRef(null);
@@ -263,11 +264,34 @@ export default function Upload() {
     }
   }
 
+  useEffect(() => {
+    fetch('/api/my-key')
+      .then((r) => r.ok ? r.json() : {})
+      .then((d) => { if (d.prefix) setApiKeyPrefix(d.prefix); })
+      .catch(() => {});
+  }, []);
+
   async function regenKey() {
     const r = await fetch('/api/regen-key', { method: 'POST' });
     const data = await r.json();
     setApiKey(data.apiKey);
+    setApiKeyPrefix(data.prefix);
     toast({ title: t('common.apiKeyRegenerated') });
+  }
+
+  async function downloadSxcu() {
+    const r = await fetch('/api/sharex-config');
+    if (!r.ok) return;
+    const prefix = r.headers.get('X-Sharely-Api-Prefix');
+    if (prefix) setApiKeyPrefix(prefix);
+    setApiKey(''); // plaintext is embedded in the file, not shown in UI
+    const blob = await r.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'sharely.sxcu';
+    a.click();
+    URL.revokeObjectURL(url);
   }
 
   function copyToClipboard(text) {
@@ -368,10 +392,12 @@ export default function Upload() {
           </CardTitle>
           <CardDescription>{t('upload.sharexDescription')}</CardDescription>
         </CardHeader>
-        <CardContent className="flex gap-2 flex-wrap">
-          <Button variant="outline" asChild>
-            <a href="/api/sharex-config" download>{t('upload.downloadSxcu')}</a>
+        <CardContent className="space-y-2">
+          <Button variant="outline" className="gap-2" onClick={downloadSxcu}>
+            <FontAwesomeIcon icon={faDownload} className="h-3.5 w-3.5" />
+            {t('upload.downloadSxcu')}
           </Button>
+          <p className="text-xs text-muted-foreground">{t('upload.sharexKeyNote')}</p>
         </CardContent>
       </Card>
 
@@ -389,24 +415,34 @@ export default function Upload() {
   /api/upload`}
           </pre>
 
-          <div className="flex items-center gap-2">
-            <Button variant="outline" size="sm" onClick={regenKey} className="gap-2 shrink-0">
-              <FontAwesomeIcon icon={faRotate} className="h-3.5 w-3.5" />{t('upload.regenKey')}
-            </Button>
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" onClick={regenKey} className="gap-2 shrink-0">
+                <FontAwesomeIcon icon={faRotate} className="h-3.5 w-3.5" />{t('upload.regenKey')}
+              </Button>
+              {apiKeyPrefix && !apiKey && (
+                <code className="text-xs bg-muted px-2 py-1 rounded text-muted-foreground">
+                  {apiKeyPrefix}…
+                </code>
+              )}
+            </div>
             {apiKey && (
-              <Tooltip open={keyCopied || undefined}>
-                <TooltipTrigger asChild>
-                  <code
-                    className="text-xs bg-muted px-2 py-1 rounded truncate flex-1 cursor-pointer hover:bg-muted/70 transition-colors"
-                    onClick={() => copyToClipboard(apiKey)}
-                  >
-                    {apiKey}
-                  </code>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {keyCopied ? t('common.copiedToClipboard') : t('common.copyToClipboard')}
-                </TooltipContent>
-              </Tooltip>
+              <div className="space-y-1">
+                <p className="text-xs text-amber-600 dark:text-amber-400">{t('upload.keyShownOnce')}</p>
+                <Tooltip open={keyCopied || undefined}>
+                  <TooltipTrigger asChild>
+                    <code
+                      className="text-xs bg-muted px-2 py-1 rounded block truncate cursor-pointer hover:bg-muted/70 transition-colors"
+                      onClick={() => copyToClipboard(apiKey)}
+                    >
+                      {apiKey}
+                    </code>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {keyCopied ? t('common.copiedToClipboard') : t('common.copyToClipboard')}
+                  </TooltipContent>
+                </Tooltip>
+              </div>
             )}
           </div>
         </CardContent>

--- a/client/src/pages/admin/Users.jsx
+++ b/client/src/pages/admin/Users.jsx
@@ -35,6 +35,7 @@ export default function AdminUsers() {
   const [pwDialog, setPwDialog] = useState(null); // { id, username }
   const [newPw, setNewPw] = useState('');
   const [savingPw, setSavingPw] = useState(false);
+  const [newKeyDialog, setNewKeyDialog] = useState(null); // { username, apiKey }
 
   async function load() {
     const r = await fetch('/api/admin/users');
@@ -88,7 +89,8 @@ export default function AdminUsers() {
   async function regenKey(id, username) {
     const r = await fetch(`/api/admin/users/${id}/regen-key`, { method: 'POST' });
     if (r.ok) {
-      toast({ title: t('adminUsers.keyRegenerated', { username }) });
+      const data = await r.json();
+      setNewKeyDialog({ username, apiKey: data.apiKey });
       load();
     }
   }
@@ -313,17 +315,9 @@ export default function AdminUsers() {
                   </TableCell>
                   <TableCell className="text-muted-foreground">{fmtDate(u.createdAt)}</TableCell>
                   <TableCell>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <code
-                          className="text-xs bg-muted px-1.5 py-0.5 rounded cursor-pointer hover:bg-muted/70 transition-colors"
-                          onClick={() => { navigator.clipboard.writeText(u.apiKey); toast({ title: t('common.copiedToClipboard') }); }}
-                        >
-                          {u.apiKey?.slice(0, 8)}…
-                        </code>
-                      </TooltipTrigger>
-                      <TooltipContent>{u.apiKey}</TooltipContent>
-                    </Tooltip>
+                    <code className="text-xs bg-muted px-1.5 py-0.5 rounded text-muted-foreground">
+                      {u.apiKeyPrefix || '—'}…
+                    </code>
                   </TableCell>
                   <TableCell>
                     {u._id !== me?.id && (
@@ -380,6 +374,25 @@ export default function AdminUsers() {
           </Table>
         </CardContent>
       </Card>
+      {/* New API key dialog */}
+      <Dialog open={!!newKeyDialog} onOpenChange={(open) => { if (!open) setNewKeyDialog(null); }}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>{t('adminUsers.newKeyTitle', { username: newKeyDialog?.username })}</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">{t('adminUsers.newKeyDesc')}</p>
+          <code
+            className="text-xs bg-muted px-3 py-2 rounded block break-all cursor-pointer hover:bg-muted/70 transition-colors"
+            onClick={() => { navigator.clipboard.writeText(newKeyDialog?.apiKey || ''); toast({ title: t('common.copiedToClipboard') }); }}
+          >
+            {newKeyDialog?.apiKey}
+          </code>
+          <DialogFooter>
+            <Button onClick={() => setNewKeyDialog(null)}>{t('adminUsers.newKeyClose')}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       {/* Change password dialog */}
       <Dialog open={!!pwDialog} onOpenChange={(open) => { if (!open) setPwDialog(null); }}>
         <DialogContent className="sm:max-w-sm">

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,6 +1,5 @@
 const User = require('../models/User');
 
-// Require session-based login
 function requireLogin(req, res, next) {
   if (!req.session.user) {
     return res.status(401).json({ error: 'Authentication required' });
@@ -8,7 +7,6 @@ function requireLogin(req, res, next) {
   next();
 }
 
-// Require admin role
 function requireAdmin(req, res, next) {
   if (!req.session.user) {
     return res.status(401).json({ error: 'Authentication required' });
@@ -19,7 +17,6 @@ function requireAdmin(req, res, next) {
   next();
 }
 
-// Require API key (Authorization: Bearer <key>, ?api_key=<key>, x-api-key header, or body token field)
 async function requireApiKey(req, res, next) {
   let key = null;
 
@@ -38,7 +35,7 @@ async function requireApiKey(req, res, next) {
     return res.status(401).json({ error: 'API key required' });
   }
 
-  const user = await User.findOne({ apiKey: key, isActive: true });
+  const user = await User.findByApiKey(key);
   if (!user) {
     return res.status(401).json({ error: 'Invalid or inactive API key' });
   }

--- a/src/migrations/migrateApiKeyHashes.js
+++ b/src/migrations/migrateApiKeyHashes.js
@@ -1,0 +1,28 @@
+const crypto = require('crypto');
+const User = require('../models/User');
+
+module.exports = async function migrateApiKeyHashes() {
+  const users = await User.find({
+    apiKey: { $exists: true, $ne: '' },
+    apiKeyHash: { $exists: false },
+  });
+
+  if (users.length === 0) return;
+
+  console.log(`[migration] Hashing plaintext API keys for ${users.length} user(s)…`);
+  let migrated = 0;
+
+  for (const user of users) {
+    try {
+      user.apiKeyHash = crypto.createHash('sha256').update(user.apiKey).digest('hex');
+      user.apiKeyPrefix = user.apiKey.slice(0, 8);
+      user.apiKey = undefined;
+      await user.save();
+      migrated++;
+    } catch (err) {
+      console.error(`[migration] Failed to hash API key for ${user.username}:`, err.message);
+    }
+  }
+
+  console.log(`[migration] done — hashed: ${migrated}, errors: ${users.length - migrated}`);
+};

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -2,6 +2,10 @@ const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
 const crypto = require('crypto');
 
+function hashApiKey(plaintext) {
+  return crypto.createHash('sha256').update(plaintext).digest('hex');
+}
+
 const userSchema = new mongoose.Schema({
   username: {
     type: String,
@@ -20,11 +24,11 @@ const userSchema = new mongoose.Schema({
     enum: ['admin', 'user'],
     default: 'user',
   },
-  apiKey: {
-    type: String,
-    unique: true,
-    default: () => crypto.randomBytes(24).toString('hex'),
-  },
+  // Legacy plaintext field – kept only so the startup migration can read and
+  // hash it. Cleared immediately after migration; never written again.
+  apiKey: { type: String },
+  apiKeyHash: { type: String, unique: true, sparse: true },
+  apiKeyPrefix: { type: String, default: '' },
   folderName: {
     type: String,
     unique: true,
@@ -51,10 +55,16 @@ const userSchema = new mongoose.Schema({
   },
 });
 
-// Hash password before saving; auto-assign folderName on new users
 userSchema.pre('save', async function (next) {
-  if (this.isNew && !this.folderName) {
-    this.folderName = crypto.randomBytes(8).toString('hex');
+  if (this.isNew) {
+    if (!this.folderName) {
+      this.folderName = crypto.randomBytes(8).toString('hex');
+    }
+    if (!this.apiKeyHash) {
+      const plaintext = crypto.randomBytes(24).toString('hex');
+      this.apiKeyHash = hashApiKey(plaintext);
+      this.apiKeyPrefix = plaintext.slice(0, 8);
+    }
   }
   if (!this.isModified('password')) return next();
   this.password = await bcrypt.hash(this.password, 12);
@@ -65,9 +75,18 @@ userSchema.methods.comparePassword = function (candidate) {
   return bcrypt.compare(candidate, this.password);
 };
 
-userSchema.methods.regenerateApiKey = function () {
-  this.apiKey = crypto.randomBytes(24).toString('hex');
-  return this.save();
+// Regenerates the API key. Returns the plaintext key exactly once.
+userSchema.methods.regenerateApiKey = async function () {
+  const plaintext = crypto.randomBytes(24).toString('hex');
+  this.apiKeyHash = hashApiKey(plaintext);
+  this.apiKeyPrefix = plaintext.slice(0, 8);
+  this.apiKey = undefined;
+  await this.save();
+  return plaintext;
+};
+
+userSchema.statics.findByApiKey = function (plaintext) {
+  return this.findOne({ apiKeyHash: hashApiKey(plaintext), isActive: true });
 };
 
 module.exports = mongoose.model('User', userSchema);

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -230,9 +230,13 @@ router.get('/gallery', requireLogin, async (req, res) => {
 });
 
 // ── ShareX config ───────────────────────────────────────────────────────────
+// Regenerates the API key and embeds the new plaintext into the .sxcu file.
+// The plaintext is never persisted — this is the only moment it is visible.
 router.get('/sharex-config', requireLogin, async (req, res) => {
   const user = await User.findById(req.session.user.id);
   if (!user) return res.status(404).json({ error: 'User not found' });
+
+  const plaintext = await user.regenerateApiKey();
 
   const config = {
     Version: '16.1.0',
@@ -244,7 +248,7 @@ router.get('/sharex-config', requireLogin, async (req, res) => {
     Arguments: {
       file: '{filename}',
       text: '{input}',
-      token: user.apiKey,
+      token: plaintext,
     },
     FileFormName: 'upload',
     URL: '{json:url}',
@@ -254,21 +258,22 @@ router.get('/sharex-config', requireLogin, async (req, res) => {
 
   res.setHeader('Content-Type', 'application/json');
   res.setHeader('Content-Disposition', 'attachment; filename="sharely.sxcu"');
+  res.setHeader('X-Sharely-Api-Prefix', user.apiKeyPrefix);
   res.send(JSON.stringify(config, null, 2));
 });
 
 // ── API key management ──────────────────────────────────────────────────────
 router.get('/my-key', requireLogin, async (req, res) => {
-  const user = await User.findById(req.session.user.id);
+  const user = await User.findById(req.session.user.id).select('apiKeyPrefix');
   if (!user) return res.status(404).json({ error: 'Not found' });
-  res.json({ apiKey: user.apiKey });
+  res.json({ prefix: user.apiKeyPrefix });
 });
 
 router.post('/regen-key', requireLogin, async (req, res) => {
   const user = await User.findById(req.session.user.id);
   if (!user) return res.status(404).json({ error: 'Not found' });
-  await user.regenerateApiKey();
-  res.json({ apiKey: user.apiKey });
+  const plaintext = await user.regenerateApiKey();
+  res.json({ apiKey: plaintext, prefix: user.apiKeyPrefix });
 });
 
 // ── Site settings: public read (used by privacy policy page + cookie banner) ─
@@ -337,7 +342,8 @@ router.get('/admin/users', requireAdmin, async (req, res) => {
   const result = users.map((u) => ({
     ...u.toObject(),
     password: undefined,
-    apiKey: u.apiKey,
+    apiKey: undefined,
+    apiKeyHash: undefined,
     fileCount: statsMap[u._id.toString()]?.count || 0,
     storageUsed: statsMap[u._id.toString()]?.size || 0,
   }));
@@ -405,8 +411,8 @@ router.delete('/admin/users/:id', requireAdmin, async (req, res) => {
 router.post('/admin/users/:id/regen-key', requireAdmin, async (req, res) => {
   const user = await User.findById(req.params.id);
   if (!user) return res.status(404).json({ error: 'Not found' });
-  await user.regenerateApiKey();
-  res.json({ apiKey: user.apiKey });
+  const plaintext = await user.regenerateApiKey();
+  res.json({ apiKey: plaintext, prefix: user.apiKeyPrefix });
 });
 
 router.patch('/admin/users/:id/password', requireAdmin, async (req, res) => {


### PR DESCRIPTION
API keys were previously stored as plaintext in MongoDB. A database leak would have exposed all keys immediately. This commit replaces plaintext storage with SHA-256 hashes (192-bit key entropy makes this secure without bcrypt's cost).

Backend:
- User model: adds apiKeyHash (SHA-256, unique) + apiKeyPrefix (8 chars for display). Legacy apiKey field kept only for the startup migration. regenerateApiKey() now returns the plaintext once and never stores it. findByApiKey() hashes the incoming value before lookup.
- migrateApiKeyHashes.js: on startup, hashes any remaining plaintext apiKey values, stores hash+prefix, and clears the plaintext field.
- auth.js: requireApiKey hashes the incoming key and looks up apiKeyHash.
- api.js:
  - GET  /api/my-key       → returns { prefix } only
  - POST /api/regen-key    → returns plaintext once, never again
  - GET  /api/sharex-config → regenerates key, embeds plaintext in the
    .sxcu download (only moment it is visible), sets X-Sharely-Api-Prefix
  - Admin regen-key         → returns plaintext for admin to relay

Frontend:
- Upload.jsx: shows current prefix (ab12cd34…) on load; after regen shows full key with amber "shown once" warning; .sxcu download uses fetch() to capture the updated prefix from the response header.
- admin/Users.jsx: table shows apiKeyPrefix only; regen opens a dialog showing the new plaintext so the admin can pass it to the user.

https://claude.ai/code/session_01Bjsau8D79UU3PQzDn3AQww