### PR TITLE
fix: drop legacy apiKey_1 unique index before migration

### DIFF
--- a/src/migrations/migrateApiKeyHashes.js
+++ b/src/migrations/migrateApiKeyHashes.js
@@ -1,7 +1,22 @@
 const crypto = require('crypto');
+const mongoose = require('mongoose');
 const User = require('../models/User');
 
 module.exports = async function migrateApiKeyHashes() {
+  const collection = mongoose.connection.collection('users');
+
+  // The old schema had a unique index on apiKey. Setting apiKey=null for
+  // multiple users violates it. Drop the index first before touching any doc.
+  try {
+    await collection.dropIndex('apiKey_1');
+    console.log('[migration] Dropped legacy apiKey_1 unique index');
+  } catch (err) {
+    // code 27 / IndexNotFound means it was already gone — that's fine
+    if (err.code !== 27 && err.codeName !== 'IndexNotFound') {
+      console.warn('[migration] Could not drop apiKey_1 index:', err.message);
+    }
+  }
+
   const users = await User.find({
     apiKey: { $exists: true, $ne: '' },
     apiKeyHash: { $exists: false },
@@ -14,10 +29,18 @@ module.exports = async function migrateApiKeyHashes() {
 
   for (const user of users) {
     try {
-      user.apiKeyHash = crypto.createHash('sha256').update(user.apiKey).digest('hex');
-      user.apiKeyPrefix = user.apiKey.slice(0, 8);
-      user.apiKey = undefined;
-      await user.save();
+      const hash = crypto.createHash('sha256').update(user.apiKey).digest('hex');
+      const prefix = user.apiKey.slice(0, 8);
+
+      // Use raw updateOne to bypass Mongoose's save() path entirely –
+      // that path still triggers the (now-dropped) index on older builds.
+      await collection.updateOne(
+        { _id: user._id },
+        {
+          $set: { apiKeyHash: hash, apiKeyPrefix: prefix },
+          $unset: { apiKey: '' },
+        },
+      );
       migrated++;
     } catch (err) {
       console.error(`[migration] Failed to hash API key for ${user.username}:`, err.message);

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -78,10 +78,18 @@ userSchema.methods.comparePassword = function (candidate) {
 // Regenerates the API key. Returns the plaintext key exactly once.
 userSchema.methods.regenerateApiKey = async function () {
   const plaintext = crypto.randomBytes(24).toString('hex');
-  this.apiKeyHash = hashApiKey(plaintext);
-  this.apiKeyPrefix = plaintext.slice(0, 8);
-  this.apiKey = undefined;
-  await this.save();
+  const hash = hashApiKey(plaintext);
+  const prefix = plaintext.slice(0, 8);
+  // Use raw updateOne to avoid Mongoose triggering the legacy apiKey_1 index
+  await this.constructor.collection.updateOne(
+    { _id: this._id },
+    {
+      $set: { apiKeyHash: hash, apiKeyPrefix: prefix },
+      $unset: { apiKey: '' },
+    },
+  );
+  this.apiKeyHash = hash;
+  this.apiKeyPrefix = prefix;
   return plaintext;
 };
 


### PR DESCRIPTION
The old schema had apiKey as a unique field. Setting it to null for multiple users during migration violates that index (E11000). Fix:

1. Migration now drops the apiKey_1 index first via dropIndex(), then uses raw collection.updateOne() to set/unset fields — bypassing Mongoose's save() path which still enforced the index.

2. regenerateApiKey() also switches to raw updateOne() so it never triggers the legacy index even if the migration runs concurrently or the index drop is delayed.

This is a hotfix for existing deployments that crash on startup due to the E11000 duplicate key error on apiKey: null.

https://claude.ai/code/session_01Bjsau8D79UU3PQzDn3AQww