### PR TITLE
fix: remove 'Template/Vorlage' from privacy footer; update README wit…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A self-hosted file sharing platform with a clean web interface, ShareX integrati
 - **XBackBone migration** — Import your existing XBackBone installation including files and metadata
 - **Short links** — Every file gets an 8-character short ID (e.g. `/f/a1b2c3d4`)
 - **Docker-ready** — Single `docker compose up` gets you running
+- **GDPR-ready** — Privacy policy page, data export (Art. 20), account deletion (Art. 17), audit log, configurable file retention, and API key hashing out of the box
 
 ### Screenshots
 
@@ -220,6 +221,24 @@ sharely/
 | File uploads | Multer |
 | Auth | express-session, bcrypt |
 | Container | Docker, Docker Compose |
+
+## GDPR / Privacy
+
+Sharely is designed with privacy in mind. The following features support GDPR compliance for operators in the EU:
+
+| Feature | GDPR Article |
+|---|---|
+| Privacy Policy page (configurable via Admin Panel) | Art. 13/14 – Transparency |
+| Data export (JSON download of account + file metadata) | Art. 20 – Portability |
+| Account self-deletion (removes all files and data) | Art. 17 – Right to erasure |
+| Audit log (all access and admin actions, 90-day auto-expiry) | Art. 5(2) – Accountability |
+| Configurable file retention (auto-delete after N days) | Art. 5(1)(e) – Storage limitation |
+| API keys stored as SHA-256 hashes, never in plaintext | Art. 32 – Security |
+| Passwords stored as bcrypt hashes (12 rounds) | Art. 32 – Security |
+| Encryption-at-rest documentation (operator self-declaration) | Art. 32 – Security |
+| Cookie consent notice for Cloudflare Analytics (optional) | Art. 13 – Transparency |
+
+> **Note for operators:** GDPR compliance is ultimately the operator's responsibility. Before going live, fill in your operator details under **Admin → Site Settings** (name, address, contact email). Consider whether you need a Data Processing Agreement (DPA) with your hosting provider.
 
 ## License
 

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -404,7 +404,7 @@
     "s6NoEncryption": "Hochgeladene Dateien werden auf App-Ebene nicht verschlüsselt. Die Verschlüsselung ruhender Daten ist abhängig von der Server- und Speicherkonfiguration des Betreibers.",
     "s7Title": "7. Änderungen dieser Erklärung",
     "s7Body": "Der Betreiber kann diese Erklärung jederzeit aktualisieren. Das Datum der letzten Überarbeitung wird oben vermerkt. Die weitere Nutzung des Dienstes nach Änderungen gilt als Zustimmung zur aktualisierten Erklärung.",
-    "version": "Sharely – Open-Source-Dateifreigabe · Vorlage Datenschutzerklärung"
+    "version": "Sharely – Open-Source-Dateifreigabe · Datenschutzerklärung"
   },
   "cookieBanner": {
     "text": "Diese Website verwendet Cloudflare Web Analytics (ohne Cookies) zur Analyse des Datenverkehrs.",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -404,7 +404,7 @@
     "s6NoEncryption": "Uploaded files are not encrypted at the application level. Encryption at rest depends on the operator's server and storage configuration.",
     "s7Title": "7. Changes to this Policy",
     "s7Body": "The operator may update this policy at any time. The date of the latest revision will be noted above. Continued use of the service after changes constitutes acceptance of the updated policy.",
-    "version": "Sharely – open-source file sharing · Template privacy policy"
+    "version": "Sharely – open-source file sharing · Privacy Policy"
   },
   "cookieBanner": {
     "text": "This site uses Cloudflare Web Analytics (cookie-free) to understand traffic.",


### PR DESCRIPTION
…h GDPR section

- privacy.version key no longer says 'Template privacy policy' / 'Vorlage Datenschutzerklärung'
- README: added GDPR-ready to feature list and a GDPR compliance table

https://claude.ai/code/session_01Bjsau8D79UU3PQzDn3AQww