### PR TITLE
Add privacy and age confirmation checkboxes to registration

### DIFF
--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -38,7 +38,10 @@
     "hasAccount": "Bereits ein Konto?",
     "login": "Anmelden",
     "privacyNotice": "Mit der Registrierung akzeptierst du unsere",
-    "privacyLink": "Datenschutzerklärung"
+    "privacyLink": "Datenschutzerklärung",
+    "acceptPrivacy": "Ich habe die",
+    "acceptPrivacySuffix": "gelesen und stimme der Verarbeitung meiner personenbezogenen Daten zu.",
+    "ageConfirm": "Ich bestätige, dass ich mindestens 16 Jahre alt bin."
   },
   "gallery": {
     "title": "Galerie",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -38,7 +38,10 @@
     "hasAccount": "Already have an account?",
     "login": "Login",
     "privacyNotice": "By registering you accept our",
-    "privacyLink": "Privacy Policy"
+    "privacyLink": "Privacy Policy",
+    "acceptPrivacy": "I have read and accept the",
+    "acceptPrivacySuffix": "and agree to the processing of my personal data.",
+    "ageConfirm": "I confirm that I am at least 16 years old."
   },
   "gallery": {
     "title": "Gallery",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -38,7 +38,10 @@
     "hasAccount": "¿Ya tienes cuenta?",
     "login": "Iniciar sesión",
     "privacyNotice": "Al registrarte aceptas nuestra",
-    "privacyLink": "Política de privacidad"
+    "privacyLink": "Política de privacidad",
+    "acceptPrivacy": "He leído y acepto la",
+    "acceptPrivacySuffix": "y acepto el tratamiento de mis datos personales.",
+    "ageConfirm": "Confirmo que tengo al menos 16 años."
   },
   "gallery": {
     "title": "Galería",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -38,7 +38,10 @@
     "hasAccount": "Vous avez déjà un compte ?",
     "login": "Connexion",
     "privacyNotice": "En vous inscrivant, vous acceptez notre",
-    "privacyLink": "Politique de confidentialité"
+    "privacyLink": "Politique de confidentialité",
+    "acceptPrivacy": "J'ai lu et j'accepte la",
+    "acceptPrivacySuffix": "et j'accepte le traitement de mes données personnelles.",
+    "ageConfirm": "Je confirme avoir au moins 16 ans."
   },
   "gallery": {
     "title": "Galerie",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -38,7 +38,10 @@
     "hasAccount": "Hai già un account?",
     "login": "Accedi",
     "privacyNotice": "Registrandoti accetti la nostra",
-    "privacyLink": "Informativa sulla privacy"
+    "privacyLink": "Informativa sulla privacy",
+    "acceptPrivacy": "Ho letto e accetto la",
+    "acceptPrivacySuffix": "e acconsento al trattamento dei miei dati personali.",
+    "ageConfirm": "Confermo di avere almeno 16 anni."
   },
   "gallery": {
     "title": "Galleria",

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -38,7 +38,10 @@
     "hasAccount": "すでにアカウントをお持ちですか？",
     "login": "ログイン",
     "privacyNotice": "登録することで、当社の",
-    "privacyLink": "プライバシーポリシー"
+    "privacyLink": "プライバシーポリシー",
+    "acceptPrivacy": "私は",
+    "acceptPrivacySuffix": "を読み、個人データの処理に同意します。",
+    "ageConfirm": "私は16歳以上であることを確認します。"
   },
   "gallery": {
     "title": "ギャラリー",

--- a/client/src/i18n/locales/pt.json
+++ b/client/src/i18n/locales/pt.json
@@ -38,7 +38,10 @@
     "hasAccount": "Já tem uma conta?",
     "login": "Entrar",
     "privacyNotice": "Ao registar-se, aceita a nossa",
-    "privacyLink": "Política de privacidade"
+    "privacyLink": "Política de privacidade",
+    "acceptPrivacy": "Li e aceito a",
+    "acceptPrivacySuffix": "e concordo com o processamento dos meus dados pessoais.",
+    "ageConfirm": "Confirmo que tenho pelo menos 16 anos."
   },
   "gallery": {
     "title": "Galeria",

--- a/client/src/i18n/locales/zh.json
+++ b/client/src/i18n/locales/zh.json
@@ -38,7 +38,10 @@
     "hasAccount": "已有账户？",
     "login": "登录",
     "privacyNotice": "注册即表示您接受我们的",
-    "privacyLink": "隐私政策"
+    "privacyLink": "隐私政策",
+    "acceptPrivacy": "我已阅读并接受",
+    "acceptPrivacySuffix": "，并同意处理我的个人数据。",
+    "ageConfirm": "我确认我已年满16岁。"
   },
   "gallery": {
     "title": "图库",

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -15,6 +15,8 @@ function SignupForm({ className, ...props }) {
   const { t } = useTranslation();
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [privacyAccepted, setPrivacyAccepted] = useState(false);
+  const [ageConfirmed, setAgeConfirmed] = useState(false);
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -89,7 +91,37 @@ function SignupForm({ className, ...props }) {
                 {t('register.confirmPasswordHint')}
               </p>
             </div>
-            <Button type="submit" className="w-full" disabled={loading}>
+            <div className="flex items-start gap-2.5">
+              <input
+                id="acceptPrivacy"
+                type="checkbox"
+                checked={privacyAccepted}
+                onChange={(e) => setPrivacyAccepted(e.target.checked)}
+                required
+                className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-primary"
+              />
+              <label htmlFor="acceptPrivacy" className="text-sm leading-snug cursor-pointer select-none">
+                {t('register.acceptPrivacy')}{' '}
+                <Link to="/privacy" target="_blank" className="underline underline-offset-2 hover:text-foreground">
+                  {t('register.privacyLink')}
+                </Link>
+                {' '}{t('register.acceptPrivacySuffix')}
+              </label>
+            </div>
+            <div className="flex items-start gap-2.5">
+              <input
+                id="ageConfirm"
+                type="checkbox"
+                checked={ageConfirmed}
+                onChange={(e) => setAgeConfirmed(e.target.checked)}
+                required
+                className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-primary"
+              />
+              <label htmlFor="ageConfirm" className="text-sm leading-snug cursor-pointer select-none">
+                {t('register.ageConfirm')}
+              </label>
+            </div>
+            <Button type="submit" className="w-full" disabled={loading || !privacyAccepted || !ageConfirmed}>
               {loading ? t('register.submitting') : t('register.submit')}
             </Button>
           </div>
@@ -99,12 +131,6 @@ function SignupForm({ className, ...props }) {
               {t('register.login')}
             </Link>
           </div>
-          <p className="mt-3 text-center text-xs text-muted-foreground">
-            {t('register.privacyNotice')}{' '}
-            <Link to="/privacy" className="underline underline-offset-4 hover:text-foreground">
-              {t('register.privacyLink')}
-            </Link>.
-          </p>
         </form>
       </CardContent>
     </Card>

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,9 +1,18 @@
 const express = require('express');
 const router = express.Router();
+const { rateLimit } = require('express-rate-limit');
 const User = require('../models/User');
 const { logAudit } = require('../utils/audit');
 
 const allowRegistration = () => process.env.ALLOW_REGISTRATION !== 'false';
+
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many attempts, please try again later.' },
+});
 
 // GET /api/auth/me
 router.get('/me', async (req, res) => {
@@ -22,7 +31,7 @@ router.get('/me', async (req, res) => {
 });
 
 // POST /api/auth/login
-router.post('/login', async (req, res) => {
+router.post('/login', authLimiter, async (req, res) => {
   const { username, password } = req.body;
   if (!username || !password) {
     return res.status(400).json({ error: 'Username and password required' });
@@ -48,7 +57,7 @@ router.post('/login', async (req, res) => {
 });
 
 // POST /api/auth/register
-router.post('/register', async (req, res) => {
+router.post('/register', authLimiter, async (req, res) => {
   if (!allowRegistration()) {
     return res.status(403).json({ error: 'Registration is disabled' });
   }


### PR DESCRIPTION
## Summary
Enhanced the registration form with explicit user consent mechanisms by adding mandatory checkboxes for privacy policy acceptance and age confirmation (16+). Also implemented rate limiting on authentication endpoints to improve security.

## Key Changes

### Frontend (Registration Form)
- Added two new state variables to track privacy acceptance and age confirmation
- Implemented two checkbox inputs with proper accessibility (labels, IDs, required attributes)
- Updated submit button to be disabled until both checkboxes are checked
- Replaced the passive privacy notice footer with active consent checkboxes integrated into the form flow
- Added internationalization strings for all new UI text across 8 languages (English, German, Spanish, French, Italian, Japanese, Portuguese, Chinese)

### Backend (Authentication)
- Implemented rate limiting on `/api/auth/login` and `/api/auth/register` endpoints
- Configured rate limiter to allow maximum 10 requests per 15-minute window per IP
- Added appropriate error messaging for rate limit violations

## Implementation Details
- The privacy checkbox includes an inline link to the privacy policy page (opens in new tab)
- Both checkboxes use consistent styling with the primary accent color
- Rate limiting uses the `express-rate-limit` middleware with standard HTTP headers
- All translation keys follow the existing naming convention (`register.*`)
- Form validation now requires explicit user consent before submission is possible

https://claude.ai/code/session_01Y46UTnGJF1LnE7VNLYwgBy