### PR TITLE
Add avatar URLs to file uploader data across API endpoints

### DIFF
--- a/client/src/pages/FileView.jsx
+++ b/client/src/pages/FileView.jsx
@@ -220,7 +220,7 @@ function FileViewInner() {
                 <Badge variant="secondary">{file.displayType}</Badge>
                 <span>{fmtSize(file.size)}</span>
                 <span className="flex items-center gap-1"><FontAwesomeIcon icon={faEye} className="h-3.5 w-3.5" />{file.views}</span>
-                {file.uploader && <span className="flex items-center gap-1"><UserAvatar userId={file.uploader._id} size="xs" />{file.uploader.username}</span>}
+                {file.uploader && <span className="flex items-center gap-1"><UserAvatar avatarUrl={file.uploader.avatarUrl} size="xs" />{file.uploader.username}</span>}
                 <span className="flex items-center gap-1"><FontAwesomeIcon icon={faCalendar} className="h-3.5 w-3.5" />{fmtDate(file.createdAt)}</span>
               </div>
             </div>

--- a/client/src/pages/Gallery.jsx
+++ b/client/src/pages/Gallery.jsx
@@ -164,7 +164,7 @@ function FileCard({ file, user, onDelete }) {
               </div>
               {file.uploader && (
                 <div className="flex items-center gap-1.5 mt-0.5">
-                  <UserAvatar userId={file.uploader._id} size="xs" />
+                  <UserAvatar avatarUrl={file.uploader.avatarUrl} size="xs" />
                   <p className="text-xs text-muted-foreground truncate">{file.uploader.username}</p>
                 </div>
               )}

--- a/client/src/pages/admin/Users.jsx
+++ b/client/src/pages/admin/Users.jsx
@@ -237,7 +237,7 @@ export default function AdminUsers() {
                 <TableRow key={u._id} className={!u.isActive ? 'opacity-50' : ''}>
                   <TableCell className="font-medium">
                     <div className="flex items-center gap-2">
-                      <UserAvatar userId={u._id} size="sm" />
+                      <UserAvatar avatarUrl={u.avatarUrl} size="sm" />
                       {u.username}
                     </div>
                   </TableCell>

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -170,13 +170,15 @@ router.delete('/file/:shortId', requireLogin, async (req, res) => {
 
 // ── File metadata ───────────────────────────────────────────────────────────
 router.get('/file/:shortId', async (req, res) => {
-  const file = await File.findOne({ shortId: req.params.shortId }).populate('uploader', 'username');
+  const file = await File.findOne({ shortId: req.params.shortId }).populate('uploader', 'username avatarExt');
   if (!file) return res.status(404).json({ error: 'File not found' });
 
   file.views += 1;
   await file.save();
 
-  res.json({ file: file.toObject() });
+  const obj = file.toObject();
+  if (obj.uploader?.avatarExt) obj.uploader.avatarUrl = `/api/user/avatar/${obj.uploader._id}`;
+  res.json({ file: obj });
 });
 
 // ── Gallery ─────────────────────────────────────────────────────────────────
@@ -219,7 +221,7 @@ router.get('/gallery', requireLogin, async (req, res) => {
   const total = await File.countDocuments(filter);
   const pages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const files = await File.find(filter)
-    .populate('uploader', 'username')
+    .populate('uploader', 'username avatarExt')
     .sort({ createdAt: -1 })
     .skip((page - 1) * PAGE_SIZE)
     .limit(PAGE_SIZE);
@@ -228,6 +230,7 @@ router.get('/gallery', requireLogin, async (req, res) => {
     files: files.map((f) => {
       const obj = f.toObject();
       obj.hasThumbnail = fs.existsSync(thumbPath(f.shortId));
+      if (obj.uploader?.avatarExt) obj.uploader.avatarUrl = `/api/user/avatar/${obj.uploader._id}`;
       return obj;
     }),
     total,
@@ -352,9 +355,16 @@ router.get('/admin/stats', requireAdmin, async (req, res) => {
   const recentFiles = await File.find()
     .sort({ createdAt: -1 })
     .limit(10)
-    .populate('uploader', 'username');
+    .populate('uploader', 'username avatarExt');
 
-  res.json({ userCount, fileCount, totalSize, recentFiles: recentFiles.map((f) => f.toObject()) });
+  res.json({
+    userCount, fileCount, totalSize,
+    recentFiles: recentFiles.map((f) => {
+      const obj = f.toObject();
+      if (obj.uploader?.avatarExt) obj.uploader.avatarUrl = `/api/user/avatar/${obj.uploader._id}`;
+      return obj;
+    }),
+  });
 });
 
 // ── Admin: users ────────────────────────────────────────────────────────────
@@ -371,6 +381,7 @@ router.get('/admin/users', requireAdmin, async (req, res) => {
     password: undefined,
     apiKey: undefined,
     apiKeyHash: undefined,
+    avatarUrl: u.avatarExt ? `/api/user/avatar/${u._id}` : undefined,
     fileCount: statsMap[u._id.toString()]?.count || 0,
     storageUsed: statsMap[u._id.toString()]?.size || 0,
   }));
@@ -924,7 +935,7 @@ router.get('/admin/files', requireAdmin, async (req, res) => {
   const total = await File.countDocuments(filter);
   const pages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const files = await File.find(filter)
-    .populate('uploader', 'username')
+    .populate('uploader', 'username avatarExt')
     .sort({ createdAt: -1 })
     .skip((page - 1) * PAGE_SIZE)
     .limit(PAGE_SIZE);
@@ -933,6 +944,7 @@ router.get('/admin/files', requireAdmin, async (req, res) => {
     files: files.map((f) => {
       const obj = f.toObject();
       obj.hasThumbnail = fs.existsSync(thumbPath(f.shortId));
+      if (obj.uploader?.avatarExt) obj.uploader.avatarUrl = `/api/user/avatar/${obj.uploader._id}`;
       return obj;
     }),
     total,


### PR DESCRIPTION
## Summary
This PR enhances the file uploader information returned by API endpoints to include avatar URLs, eliminating the need for frontend components to fetch avatar data separately. The changes ensure consistent avatar display across the application by populating the `avatarExt` field and constructing avatar URLs server-side.

## Key Changes
- **API Endpoints**: Updated file metadata, gallery, admin stats, admin users, and admin files endpoints to:
  - Include `avatarExt` in the `uploader` population query
  - Construct `avatarUrl` from the uploader's ID when `avatarExt` exists
  
- **Frontend Components**: Modified `UserAvatar` component usage to accept `avatarUrl` prop instead of `userId`:
  - `FileView.jsx`: Updated uploader avatar display
  - `Gallery.jsx`: Updated file card uploader avatar display
  - `admin/Users.jsx`: Updated admin users table avatar display

## Implementation Details
- Avatar URLs are constructed server-side using the pattern `/api/user/avatar/{userId}`
- The `avatarUrl` is only added when `avatarExt` exists, preventing unnecessary URL generation for users without avatars
- Changes maintain backward compatibility by using optional chaining (`obj.uploader?.avatarExt`)
- Consistent implementation across all affected endpoints ensures uniform behavior

https://claude.ai/code/session_01199a4VA9rQDG1tCF5TEZ3T