### PR TITLE
Add retry logic for shortId collisions via File.createUnique()

### DIFF
--- a/src/models/File.js
+++ b/src/models/File.js
@@ -84,4 +84,18 @@ fileSchema.virtual('displayType').get(function () {
 fileSchema.set('toJSON', { virtuals: true });
 fileSchema.set('toObject', { virtuals: true });
 
+fileSchema.statics.createUnique = async function (data, maxAttempts = 5) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await this.create(data);
+    } catch (err) {
+      if (err.code === 11000 && err.keyPattern?.shortId && attempt < maxAttempts - 1) {
+        data.shortId = generateShortId();
+        continue;
+      }
+      throw err;
+    }
+  }
+};
+
 module.exports = mongoose.model('File', fileSchema);

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -93,7 +93,7 @@ router.post('/upload', uploadLimiter, requireApiKey, upload.single('file'), asyn
   // storedName is relative to UPLOAD_DIR (e.g. "username/a1b2c3d4.jpg")
   const storedName = path.relative(UPLOAD_DIR, req.file.path);
 
-  const file = await File.create({
+  const file = await File.createUnique({
     originalName: sanitizeFilename(req.file.originalname),
     storedName,
     mimeType: req.file.mimetype,
@@ -125,7 +125,7 @@ router.post('/web-upload', uploadLimiter, requireLogin, upload.array('files', 50
   for (const f of req.files) {
     // storedName is relative to UPLOAD_DIR (e.g. "username/a1b2c3d4.jpg")
     const storedName = path.relative(UPLOAD_DIR, f.path);
-    const doc = await File.create({
+    const doc = await File.createUnique({
       originalName: sanitizeFilename(f.originalname),
       storedName,
       mimeType: f.mimetype,
@@ -800,7 +800,7 @@ router.post('/chunk/:uploadId/complete', requireLogin, async (req, res) => {
   try { fs.rmSync(sessionDir, { recursive: true, force: true }); } catch { /* ignore */ }
 
   const storedName = path.relative(UPLOAD_DIR, finalPath);
-  const doc = await File.create({
+  const doc = await File.createUnique({
     originalName: sanitizeFilename(meta.filename),
     storedName,
     mimeType: meta.mimeType,


### PR DESCRIPTION
Adds a static createUnique() method to the File model that catches MongoDB E11000 duplicate key errors on shortId and retries up to 5 times with a freshly generated ID. Replaces File.create() in all three upload handlers (ShareX, web, chunked). The MongoDB unique index remains the authoritative guarantee; the retry ensures users never see a 500 from a collision.

https://claude.ai/code/session_01RsPeHkW7Yad3VvdFFA5481