### PR TITLE
Restyle tabs to underline indicator matching dark theme

### DIFF
--- a/client/src/components/ui/tabs.jsx
+++ b/client/src/components/ui/tabs.jsx
@@ -7,7 +7,7 @@ function TabsList({ className, ...props }) {
   return (
     <TabsPrimitive.List
       className={cn(
-        'inline-flex items-center justify-start rounded-lg bg-muted p-1 text-muted-foreground gap-1',
+        'flex items-center gap-1 border-b border-border',
         className,
       )}
       {...props}
@@ -19,7 +19,13 @@ function TabsTrigger({ className, ...props }) {
   return (
     <TabsPrimitive.Trigger
       className={cn(
-        'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+        'relative flex items-center gap-2 px-3 py-2.5 text-sm font-medium text-muted-foreground transition-colors',
+        'hover:text-foreground',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        'disabled:pointer-events-none disabled:opacity-50',
+        'data-[state=active]:text-foreground',
+        'after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:rounded-full',
+        'after:bg-transparent data-[state=active]:after:bg-primary',
         className,
       )}
       {...props}
@@ -31,7 +37,7 @@ function TabsContent({ className, ...props }) {
   return (
     <TabsPrimitive.Content
       className={cn(
-        'mt-4 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        'mt-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
         className,
       )}
       {...props}


### PR DESCRIPTION
Replaces the muted-background segmented-control style with a clean bottom-border underline that uses the primary blue (--primary) for the active tab — consistent with the app's dark colour palette.

https://claude.ai/code/session_01QuYxSMLofzub4D5MF4yDQ2