### PR TITLE
feat: mobile-friendly responsive improvements across the app

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuSeparator, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faImages, faUpload, faGear, faRightFromBracket, faUser, faTableCellsLarge, faChevronDown, faBoxOpen, faClockRotateLeft } from '@fortawesome/free-solid-svg-icons';
+import { faImages, faUpload, faGear, faRightFromBracket, faUser, faTableCellsLarge, faChevronDown, faBoxOpen, faClockRotateLeft, faBars } from '@fortawesome/free-solid-svg-icons';
 import { cn } from '@/lib/utils';
 import { LanguageSelector } from '@/components/LanguageSelector';
 import { useTranslation } from 'react-i18next';
@@ -54,7 +54,8 @@ export function Layout({ children }) {
           <div className="flex items-center gap-6">
             <Link to="/" className="font-bold text-primary text-sm tracking-widest uppercase">sharely</Link>
             <Separator orientation="vertical" className="h-5" />
-            <nav className="flex items-center gap-1">
+            {/* Desktop nav */}
+            <nav className="hidden sm:flex items-center gap-1">
               <NavLink to="/gallery" icon={faImages}>{t('nav.gallery')}</NavLink>
               <NavLink to="/upload" icon={faUpload}>{t('nav.upload')}</NavLink>
               {user?.role === 'admin' && (
@@ -65,6 +66,34 @@ export function Layout({ children }) {
 
           <div className="flex items-center gap-1">
             <LanguageSelector />
+
+            {/* Mobile hamburger nav */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="flex sm:hidden h-8 w-8">
+                  <FontAwesomeIcon icon={faBars} className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-44">
+                <DropdownMenuItem asChild>
+                  <Link to="/gallery" className="flex items-center gap-2 cursor-pointer">
+                    <FontAwesomeIcon icon={faImages} className="h-4 w-4" />{t('nav.gallery')}
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link to="/upload" className="flex items-center gap-2 cursor-pointer">
+                    <FontAwesomeIcon icon={faUpload} className="h-4 w-4" />{t('nav.upload')}
+                  </Link>
+                </DropdownMenuItem>
+                {user?.role === 'admin' && (
+                  <DropdownMenuItem asChild>
+                    <Link to="/admin" className="flex items-center gap-2 cursor-pointer">
+                      <FontAwesomeIcon icon={faTableCellsLarge} className="h-4 w-4" />{t('nav.admin')}
+                    </Link>
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
 
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/client/src/pages/FileView.jsx
+++ b/client/src/pages/FileView.jsx
@@ -85,7 +85,7 @@ function CodeViewer({ shortId, lang }) {
   }, [code]);
 
   return (
-    <ScrollArea className="h-[70vh] w-full">
+    <ScrollArea className="h-[50vh] sm:h-[70vh] w-full">
       <pre className="p-4 text-sm leading-relaxed">
         <code ref={codeRef} className={`language-${lang || 'plaintext'}`}>{code}</code>
       </pre>

--- a/client/src/pages/Gallery.jsx
+++ b/client/src/pages/Gallery.jsx
@@ -22,13 +22,20 @@ import {
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { useToast } from '@/hooks/use-toast';
 import { fmtSize } from '@/lib/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUpload, faMagnifyingGlass, faXmark, faImage, faVideo, faMusic, faFileLines, faCode, faFile, faLink, faDownload, faArrowUpRightFromSquare, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faUpload, faMagnifyingGlass, faXmark, faImage, faVideo, faMusic, faFileLines, faCode, faFile, faLink, faDownload, faArrowUpRightFromSquare, faTrash, faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { UserAvatar } from '@/components/UserAvatar';
 
@@ -160,7 +167,49 @@ function FileCard({ file, user, onDelete }) {
                 <Badge variant="secondary" className="text-xs px-1.5 py-0">
                   {file.displayType}
                 </Badge>
-                <span className="text-xs text-muted-foreground">{fmtSize(file.size)}</span>
+                <div className="flex items-center gap-1">
+                  <span className="text-xs text-muted-foreground">{fmtSize(file.size)}</span>
+                  {/* Touch-friendly actions menu */}
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild onClick={(e) => e.preventDefault()}>
+                      <button className="sm:opacity-0 sm:group-hover:opacity-100 transition-opacity p-1 rounded text-muted-foreground hover:text-foreground hover:bg-accent">
+                        <FontAwesomeIcon icon={faEllipsisVertical} className="h-3.5 w-3.5" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-44">
+                      <DropdownMenuItem onSelect={() => navigate(`/f/${file.shortId}`)}>
+                        <FontAwesomeIcon icon={faFile} className="h-4 w-4" />
+                        {t('gallery.contextOpen')}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onSelect={copyLink}>
+                        <FontAwesomeIcon icon={faLink} className="h-4 w-4" />
+                        {t('gallery.contextCopyLink')}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onSelect={() => window.open(`/f/${file.shortId}/raw`, '_blank')}>
+                        <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="h-4 w-4" />
+                        {t('gallery.contextOpenRaw')}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem asChild>
+                        <a href={`/f/${file.shortId}/download`} download>
+                          <FontAwesomeIcon icon={faDownload} className="h-4 w-4" />
+                          {t('gallery.contextDownload')}
+                        </a>
+                      </DropdownMenuItem>
+                      {canDelete && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            onSelect={() => setConfirmDelete(true)}
+                            className="text-destructive focus:text-destructive"
+                          >
+                            <FontAwesomeIcon icon={faTrash} className="h-4 w-4" />
+                            {t('fileView.delete')}
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
               </div>
               {file.uploader && (
                 <div className="flex items-center gap-1.5 mt-0.5">

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -265,6 +265,7 @@ export default function Settings() {
       <h1 className="text-2xl font-bold">{t('settings.title')}</h1>
 
       <Tabs defaultValue="profile">
+        <div className="overflow-x-auto pb-1">
         <TabsList>
           <TabsTrigger value="profile">
             <FontAwesomeIcon icon={faUser} className="mr-2 h-3.5 w-3.5" />
@@ -283,6 +284,7 @@ export default function Settings() {
             {t('settings.tabPrivacy')}
           </TabsTrigger>
         </TabsList>
+        </div>
 
         {/* ── Profile ── */}
         <TabsContent value="profile" className="space-y-4">

--- a/client/src/pages/Upload.jsx
+++ b/client/src/pages/Upload.jsx
@@ -313,7 +313,7 @@ export default function Upload() {
         onDragLeave={() => setDragging(false)}
         onDrop={onDrop}
         className={`
-          rounded-lg border-2 border-dashed transition-all p-10 text-center
+          rounded-lg border-2 border-dashed transition-all p-6 sm:p-10 text-center
           ${dragging ? 'border-primary bg-primary/5' : 'border-border'}
         `}
       >

--- a/client/src/pages/admin/AuditLog.jsx
+++ b/client/src/pages/admin/AuditLog.jsx
@@ -181,7 +181,7 @@ export default function AdminAuditLog() {
 
       {/* Table */}
       <Card>
-        <CardContent className="p-0">
+        <CardContent className="p-0 overflow-x-auto">
           <Table>
             <TableHeader>
               <TableRow>

--- a/client/src/pages/admin/Files.jsx
+++ b/client/src/pages/admin/Files.jsx
@@ -107,7 +107,7 @@ export default function AdminFiles() {
       </form>
 
       <Card>
-        <CardContent className="p-0">
+        <CardContent className="p-0 overflow-x-auto">
           <Table>
             <TableHeader>
               <TableRow>

--- a/client/src/pages/admin/Users.jsx
+++ b/client/src/pages/admin/Users.jsx
@@ -217,7 +217,7 @@ export default function AdminUsers() {
 
       {/* Users table */}
       <Card>
-        <CardContent className="p-0">
+        <CardContent className="p-0 overflow-x-auto">
           <Table>
             <TableHeader>
               <TableRow>


### PR DESCRIPTION
- Layout: hide desktop nav on small screens; add hamburger DropdownMenu for mobile navigation
- Gallery: add touch-friendly ⋮ action button per card (copy link, download, delete) since ContextMenu is right-click only on touch devices
- Upload: reduce drop zone padding on mobile (p-6 sm:p-10)
- FileView: lower code viewer height on mobile (h-[50vh] sm:h-[70vh])
- Admin Users/Files/AuditLog: wrap tables in overflow-x-auto so they scroll horizontally on small screens
- Settings: wrap TabsList in overflow-x-auto so 4 tabs don't overflow on narrow screens

https://claude.ai/code/session_01QprqE3hExHk8jEwBJqmTgR