### PR TITLE
fix: Import page code block scrolls horizontally on mobile

### DIFF
--- a/client/src/pages/admin/Import.jsx
+++ b/client/src/pages/admin/Import.jsx
@@ -148,7 +148,7 @@ export default function AdminImport() {
             <CardTitle className="text-base">{t('adminImport.pathsTitle')}</CardTitle>
             <CardDescription>
               {t('adminImport.pathsDesc')}
-              <code className="block font-mono text-xs bg-muted px-2 py-1 rounded mt-1 whitespace-pre">
+              <code className="block font-mono text-xs bg-muted px-2 py-1 rounded mt-1 whitespace-pre overflow-x-auto">
                 volumes:{'\n'}
                 {'  '}- /path/to/xbackbone/database.db:/xbackbone/database.db:ro{'\n'}
                 {'  '}- /path/to/xbackbone/storage:/xbackbone/storage:ro


### PR DESCRIPTION
Added overflow-x-auto to the volumes example code block so long paths don't overflow the card on small screens.

https://claude.ai/code/session_01QprqE3hExHk8jEwBJqmTgR