### PR TITLE
Fix missing WebSocket broadcast on ShareX uploads

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ const SiteSettings = require('./src/models/SiteSettings');
 const uploadMiddleware = require('./src/middleware/upload');
 const { requireApiKey } = require('./src/middleware/auth');
 const File = require('./src/models/File');
-const { initWS } = require('./src/ws');
+const { initWS, broadcast } = require('./src/ws');
 
 const migrateUserFolders = require('./src/migrations/migrateUserFolders');
 const migrateApiKeyHashes = require('./src/migrations/migrateApiKeyHashes');
@@ -119,6 +119,9 @@ app.post('/upload', uploadLimiter, uploadMiddleware.single('upload'), requireApi
     uploader: user._id,
   });
   await logAudit(req, 'upload', { fileName: file.originalName, fileSize: file.size, shortId: file.shortId });
+  const uploaderId = String(user._id);
+  broadcast('file:uploaded', { shortId: file.shortId, uploaderId }, (c) => c.userId === uploaderId);
+  broadcast('stats:invalidate', {}, (c) => c.isAdmin);
   const base = process.env.BASE_URL || 'http://localhost:3000';
   res.json({
     url: `${base}/f/${file.shortId}`,

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -106,6 +106,9 @@ router.post('/upload', uploadLimiter, requireApiKey, upload.single('file'), asyn
   generateThumbnail(req.file.path, req.file.mimetype, file.shortId).catch(() => {});
 
   await logAudit(req, 'upload', { fileName: file.originalName, fileSize: file.size, shortId: file.shortId });
+  const apiUploaderId = String(req.apiUser._id);
+  broadcast('file:uploaded', { shortId: file.shortId, uploaderId: apiUploaderId }, (c) => c.userId === apiUploaderId);
+  broadcast('stats:invalidate', {}, (c) => c.isAdmin);
   const base = BASE_URL();
   res.json({
     url: `${base}/f/${file.shortId}`,


### PR DESCRIPTION
The ShareX .sxcu config points to /upload (app.js), not /api/upload. Both API-key upload routes were missing broadcast calls — added file:uploaded and stats:invalidate broadcasts to app.js /upload and api.js /api/upload.

https://claude.ai/code/session_015STanDbdxh3gC4rPoXTMsN