### PR TITLE
Add chunked uploads, WebSocket API, email, i18n, and GDPR features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,26 @@ A self-hosted file sharing platform with a clean web interface, ShareX integrati
 
 ## Features
 
-- **Web UI** — Drag-and-drop uploads, searchable gallery with type filters (images, video, audio, PDF, code)
+- **Web UI** — Drag-and-drop uploads, searchable gallery with type filters (images, video, audio, PDF, code), fully mobile-responsive
+- **Chunked uploads** — Files up to 2 GB supported via parallel multi-part chunked upload (automatic, no client config needed)
 - **ShareX integration** — One-click `.sxcu` config download for automatic screenshot uploads from Windows
 - **API uploads** — Bearer token authentication, compatible with curl, wget, and any HTTP client
-- **File viewing** — Images zoom inline, videos/audio stream, PDFs render in-browser, code files syntax-highlighted
+- **File viewing** — Images zoom inline, videos/audio stream with seek support (HTTP Range), PDFs render in-browser, code files syntax-highlighted
+- **File download** — Force-download endpoint (`/f/<id>/download`) separate from the inline viewer
+- **Embed modes** — Per-user toggle between *embed* (rich HTML page with Open Graph / Twitter Card metadata) and *raw* (direct file redirect for native social embeds); social media bots (Discord, Telegram, Twitter, etc.) are detected automatically
 - **Thumbnails** — Video and PDF files get auto-generated JPEG thumbnails (requires ffmpeg / ghostscript, bundled in the Docker image)
-- **User management** — Role-based access control (admin/user), account activation, custom folder names
-- **Admin dashboard** — Stats overview, manage all users and files
+- **Avatars** — Users can upload a profile avatar (JPEG, PNG, GIF, WebP, max 2 MB)
+- **Internationalization** — UI and email templates available in 8 languages: English, Deutsch, Français, Español, Italiano, Português, 日本語, 中文
+- **Email verification & password reset** — Requires SMTP configuration; tokens expire after 24 h (verification) / 1 h (reset)
+- **User management** — Role-based access control (admin/user), account activation/deactivation, custom folder names
+- **Admin dashboard** — Stats overview, manage all users and files, audit log with CSV export
+- **Real-time UI** — WebSocket-powered live updates: file view counters, gallery refresh on upload/delete, admin stats and audit log stream in real time
 - **XBackBone migration** — Import your existing XBackBone installation including files and metadata
 - **Short links** — Every file gets an 8-character short ID (e.g. `/f/a1b2c3d4`)
+- **Delete tokens** — Each file carries a unique deletion token so ShareX (or any client) can delete files without a session
+- **Security** — Dangerous file types (`.exe`, `.bat`, `.sh`, `.php`, `.ps1`, …) are blocked on upload; rate limiting on uploads and authentication endpoints
 - **Docker-ready** — Single `docker compose up` gets you running
-- **GDPR-ready** — Privacy policy page, data export (Art. 20), account deletion (Art. 17), audit log, configurable file retention, and API key hashing out of the box
+- **GDPR-ready** — Privacy policy & Terms of Service pages (configurable), data export (Art. 20), account deletion (Art. 17), audit log with 90-day auto-expiry, configurable file retention, API key hashing, and optional Cloudflare Analytics cookie consent out of the box
 
 ### Screenshots
 
@@ -78,17 +87,36 @@ Copy `.env.example` to `.env` and adjust the values:
 | `MONGO_ROOT_PASSWORD` | — | MongoDB root password (required) |
 | `MONGO_APP_USER` | `appuser` | MongoDB application user |
 | `MONGO_APP_PASSWORD` | — | MongoDB application user password (required) |
+| `MONGO_DB_NAME` | `sharely` | MongoDB database name |
 | `SESSION_SECRET` | — | Secret for session encryption — use a long random string (required) |
 | `BASE_URL` | `http://localhost:3000` | Public base URL for generated share links, no trailing slash |
 | `SITE_NAME` | `sharely` | Site name shown in Open Graph embeds |
-| `MAX_FILE_SIZE_MB` | `100` | Maximum upload file size in MB |
+| `MAX_FILE_SIZE_MB` | `100` | Maximum upload file size in MB (chunked uploads can go up to 2 GB regardless) |
 | `ALLOW_REGISTRATION` | `true` | Set to `false` to disable public sign-up (admin-only user creation) |
+| `SMTP_HOST` | — | SMTP server hostname; leave blank to disable email features |
+| `SMTP_PORT` | `587` | SMTP port |
+| `SMTP_SECURE` | `false` | `true` for implicit TLS (port 465), `false` for STARTTLS (port 587) |
+| `SMTP_USER` | — | SMTP authentication username |
+| `SMTP_PASS` | — | SMTP authentication password |
+| `SMTP_FROM` | _(SMTP_USER)_ | From address shown in outgoing emails |
 
 Generate a secure session secret:
 
 ```bash
 openssl rand -hex 32
 ```
+
+### SMTP / Email
+
+When `SMTP_HOST` is set, sharely enables:
+
+- **Email verification** — new accounts must verify their address before logging in; tokens expire after 24 hours
+- **Email change confirmation** — a verification link is sent to the new address
+- **Password reset** — "Forgot password" flow with a 1-hour reset token (rate-limited to 5 requests per hour)
+
+Email subjects and body copy are translated into all 8 supported languages and sent in the user's chosen language.
+
+If `SMTP_HOST` is left blank, all email-dependent features are hidden from the UI and registration proceeds without verification.
 
 ## API Usage
 
@@ -102,7 +130,7 @@ curl -X POST https://your-domain.com/api/upload \
   -F "sharex=@/path/to/file.png"
 ```
 
-The response contains the URL to the uploaded file.
+The response contains the URL to the uploaded file and a `deletionUrl` that can be used to delete the file without a session (used automatically by ShareX).
 
 **Delete a file:**
 
@@ -111,6 +139,17 @@ curl -X DELETE https://your-domain.com/api/delete/SHORT_ID \
   -H "Authorization: Bearer YOUR_API_KEY"
 ```
 
+**List your files:**
+
+```bash
+curl https://your-domain.com/api/gallery \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+### Chunked Uploads
+
+For large files the web UI automatically switches to chunked upload mode (files above ~250 MB). Chunks of 10–20 MB are uploaded in parallel (3–5 concurrent chunks). The API also exposes the chunked upload endpoints for programmatic use — see `/api/upload/chunk/init`, `/api/upload/chunk/:sessionId`, and `/api/upload/chunk/:sessionId/finalize`.
+
 ## ShareX Setup
 
 1. Log in and go to **Upload**
@@ -118,14 +157,84 @@ curl -X DELETE https://your-domain.com/api/delete/SHORT_ID \
 3. Open the downloaded `.sxcu` file — ShareX will import it automatically
 4. Screenshots and uploads are now sent directly to your instance
 
+ShareX receives a `deletionUrl` in the upload response and can delete files without re-authenticating.
+
+## WebSocket API
+
+The app maintains a persistent WebSocket connection (`/ws`) for all authenticated clients. The protocol uses a request/response pattern plus server-initiated broadcasts.
+
+**Request format** (client → server):
+```json
+{ "id": "unique-request-id", "action": "action:name", "payload": {} }
+```
+
+**Response format** (server → client):
+```json
+{ "id": "unique-request-id", "data": {}, "error": null }
+```
+
+**Broadcast format** (server → relevant clients):
+```json
+{ "event": "event:name", "data": {} }
+```
+
+### Available Actions
+
+| Action | Auth | Description |
+|---|---|---|
+| `site-settings:get` | — | Public site settings |
+| `auth:me` | User | Current session user |
+| `file:get` | User | File details (increments view count) |
+| `file:list` | User | Own files (admins see all) |
+| `file:delete` | User | Delete a file |
+| `user:get-key` | User | API key prefix |
+| `user:regen-key` | User | Regenerate API key |
+| `user:change-password` | User | Change password |
+| `user:change-username` | User | Change username |
+| `user:change-email` | User | Change email (sends verification) |
+| `user:change-language` | User | Set UI language |
+| `user:change-embed-mode` | User | Toggle embed / raw mode |
+| `user:resend-verification` | User | Re-send verification email |
+| `user:export` | User | Export account data as JSON |
+| `user:delete-account` | User | Delete account and all files |
+| `admin:stats` | Admin | Dashboard statistics |
+| `admin:settings:get` | Admin | Read site settings |
+| `admin:settings:update` | Admin | Update site settings |
+| `admin:users:list` | Admin | List all users |
+| `admin:users:create` | Admin | Create user |
+| `admin:users:toggle` | Admin | Activate / deactivate user |
+| `admin:users:role` | Admin | Change user role |
+| `admin:users:delete` | Admin | Delete user |
+| `admin:users:regen-key` | Admin | Regenerate a user's API key |
+| `admin:users:password` | Admin | Set a user's password |
+| `admin:users:folder` | Admin | Change a user's folder name |
+| `admin:files:list` | Admin | List all files |
+| `admin:audit-log:list` | Admin | Paginated audit log |
+
+### Broadcast Events
+
+| Event | Recipients | Payload |
+|---|---|---|
+| `file:uploaded` | Uploader only | `{ shortId, uploaderId }` |
+| `file:deleted` | Owner only | `{ shortId, uploaderId }` |
+| `file:view` | All clients | `{ shortId, views }` |
+| `user:created` | Admins | `{ id, username, role }` |
+| `user:deleted` | Admins | `{ id }` |
+| `user:updated` | Admins | `{ id, …changed fields }` |
+| `audit:log` | Admins | Full AuditLog object |
+| `settings:updated` | Admins | Updated SiteSettings object |
+| `stats:invalidate` | Admins | `{}` (trigger a stats re-fetch) |
+
 ## Reverse Proxy (Nginx example)
+
+WebSocket support requires the `Upgrade` and `Connection` headers to be forwarded:
 
 ```nginx
 server {
     listen 443 ssl;
     server_name files.example.com;
 
-    client_max_body_size 200M;
+    client_max_body_size 2100M;
 
     location / {
         proxy_pass http://localhost:3000;
@@ -133,11 +242,18 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket support
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
     }
 }
 ```
 
 Make sure `BASE_URL` in `.env` matches your public domain.
+
+> **Note on `client_max_body_size`:** Set this at least as large as your largest expected chunked segment plus some headroom. For 2 GB file support, `2100M` is a safe value.
 
 ## Thumbnails
 
@@ -182,7 +298,7 @@ If you're migrating from [XBackBone](https://github.com/SergiX44/XBackBone):
 3. Provide the path to your XBackBone `storage/` directory
 4. Run a preview first, then confirm the import
 
-Users are matched by username. Files without a matching user are assigned to a fallback user you specify. The import is idempotent — re-running it skips already-imported files.
+Users are matched by username. Files without a matching user are assigned to a fallback user you specify. The import handles multiple XBackBone schema versions and searches storage subdirectories automatically. It is idempotent — re-running it skips already-imported files.
 
 ## Project Structure
 
@@ -191,19 +307,26 @@ sharely/
 ├── app.js                  # Express entry point
 ├── src/
 │   ├── config/db.js        # MongoDB connection
-│   ├── models/             # Mongoose schemas (User, File)
-│   ├── middleware/         # Auth, upload handling
+│   ├── models/             # Mongoose schemas (User, File, AuditLog, SiteSettings)
+│   ├── middleware/         # Auth, upload handling, file block list
+│   ├── jobs/
+│   │   └── retentionCleanup.js   # Scheduled file & audit log cleanup
 │   ├── utils/
-│   │   └── generateThumbnail.js  # ffmpeg/ghostscript thumbnail generation
-│   └── routes/             # API routes (auth, files, admin, import)
+│   │   ├── generateThumbnail.js  # ffmpeg/ghostscript thumbnail generation
+│   │   └── mailer.js             # Nodemailer wrapper with i18n templates
+│   ├── ws.js               # WebSocket server (all WS actions & broadcasts)
+│   └── routes/             # REST routes (auth, api, files, import)
 ├── client/                 # React frontend (Vite + Tailwind)
 │   └── src/
-│       ├── pages/          # Upload, Gallery, FileView, Admin pages
+│       ├── i18n/           # i18next config + 8 locale JSON files
+│       ├── hooks/
+│       │   └── useWebSocket.js   # React hook for WS connection & events
+│       ├── pages/          # Upload, Gallery, FileView, Settings, Admin pages
 │       └── components/     # UI components
 ├── scripts/
 │   ├── setup-db.js
 │   ├── migrate-uploads-to-user-folders.js
-│   └── generate-missing-thumbnails.js   # backfill thumbnails for old uploads
+│   └── generate-missing-thumbnails.js
 ├── uploads/
 │   └── .thumbnails/        # auto-generated JPEG thumbnails
 ├── docker-compose.yml
@@ -216,10 +339,13 @@ sharely/
 |---|---|
 | Backend | Node.js, Express |
 | Database | MongoDB (Mongoose) |
+| Real-time | WebSocket (`ws`) |
+| Email | Nodemailer |
 | Frontend | React 18, React Router, Vite |
 | Styling | Tailwind CSS, Radix UI |
-| File uploads | Multer |
-| Auth | express-session, bcrypt |
+| i18n | i18next |
+| File uploads | Multer (standard) + chunked upload (custom) |
+| Auth | express-session, bcryptjs |
 | Container | Docker, Docker Compose |
 
 ## GDPR / Privacy
@@ -229,9 +355,11 @@ Sharely is designed with privacy in mind. The following features support GDPR co
 | Feature | GDPR Article |
 |---|---|
 | Privacy Policy page (configurable via Admin Panel) | Art. 13/14 – Transparency |
-| Data export (JSON download of account + file metadata) | Art. 20 – Portability |
+| Terms of Service page (configurable via Admin Panel) | Art. 13/14 – Transparency |
+| Data export (JSON download of account + file metadata with full URLs) | Art. 20 – Portability |
 | Account self-deletion (removes all files and data) | Art. 17 – Right to erasure |
-| Audit log (all access and admin actions, 90-day auto-expiry) | Art. 5(2) – Accountability |
+| Audit log (all access and admin actions, 90-day auto-expiry via MongoDB TTL) | Art. 5(2) – Accountability |
+| Audit log CSV export for regulators | Art. 5(2) – Accountability |
 | Configurable file retention (auto-delete after N days) | Art. 5(1)(e) – Storage limitation |
 | API keys stored as SHA-256 hashes, never in plaintext | Art. 32 – Security |
 | Passwords stored as bcrypt hashes (12 rounds) | Art. 32 – Security |


### PR DESCRIPTION
## Summary

This is a comprehensive feature release that adds enterprise-grade capabilities to sharely: chunked file uploads (up to 2 GB), real-time WebSocket API, email verification/password reset, internationalization (8 languages), user avatars, audit logging, and enhanced GDPR compliance.

## Key Changes

### Core Features
- **Chunked uploads** — Files up to 2 GB via parallel multi-part upload with automatic client-side switching for large files (>250 MB)
- **WebSocket API** — Real-time bidirectional communication with request/response and broadcast patterns; replaces some REST endpoints for live updates (file views, gallery refresh, admin stats/audit log streaming)
- **Email system** — SMTP integration with Nodemailer; email verification on signup, password reset flow (1h tokens), email change confirmation; all templates translated to 8 languages
- **Internationalization (i18n)** — UI and email templates in English, Deutsch, Français, Español, Italiano, Português, 日本語, 中文; user language preference stored and applied

### User Features
- **User avatars** — Profile picture upload (JPEG, PNG, GIF, WebP, max 2 MB)
- **Embed vs. raw mode toggle** — Per-user setting for social media embeds (rich HTML with Open Graph/Twitter Card metadata vs. direct file redirect); automatic bot detection
- **Delete tokens** — Each file carries a unique deletion token for stateless deletion (used by ShareX without session)
- **File download endpoint** — Separate `/f/<id>/download` for force-download, distinct from inline viewer
- **HTTP Range support** — Video/audio streaming with seek capability

### Admin & Security
- **Audit log** — Comprehensive logging of all access and admin actions with 90-day auto-expiry (MongoDB TTL); CSV export for regulators
- **File blocklist** — Dangerous file types (`.exe`, `.bat`, `.sh`, `.php`, `.ps1`, etc.) blocked on upload
- **Rate limiting** — Applied to upload and authentication endpoints
- **Real-time admin dashboard** — WebSocket-powered live stats and audit log stream

### GDPR Compliance
- **Privacy Policy & Terms of Service pages** — Configurable via admin panel
- **Data export** — JSON download of account + file metadata with full URLs (Art. 20)
- **Account deletion** — Self-service account + all files removal (Art. 17)
- **Audit log with auto-expiry** — 90-day retention via MongoDB TTL (Art. 5(2))
- **Audit log CSV export** — For regulatory requests
- **API key hashing** — SHA-256 hashing, never plaintext storage
- **Password hashing** — bcryptjs with 12 rounds

## Implementation Details

- **Backend structure**: Added `src/ws.js` for WebSocket server with action/broadcast handlers; `src/jobs/retentionCleanup.js` for scheduled cleanup; `src/utils/mailer.js` for email templating
- **Frontend**: New `i18n/` directory with i18next config and 8 locale JSON files; `hooks/useWebSocket.js` React hook for WS connection management; expanded pages (Settings, Admin) and components
- **Database**: New Mongoose schemas for `AuditLog` and `SiteSettings`; added `MONGO_DB_NAME` env var
- **Configuration**: New SMTP env vars (`SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`)
- **Reverse proxy**: Updated Nginx example with WebSocket headers (`Upgrade`, `Connection`) and increased `client_max_body_size` to 2100M
- **API**: New endpoints for chunked upload (`/api/upload/chunk/*`), gallery listing (`/api/gallery`); responses now include `deletionUrl`

## Migration Notes

- XBackBone import now handles multiple schema versions and searches storage subdirectories automatically
- Existing installations can enable email features by setting `SMTP_HOST`; all email-dependent UI is hidden if SMTP is unconfigured
- Chunked

https://claude.ai/code/session_019PeKiQPyheQHYuoadLynUT