### PR TITLE
fix: live-update admin user table on user creation

### DIFF
--- a/client/src/pages/admin/Users.jsx
+++ b/client/src/pages/admin/Users.jsx
@@ -49,7 +49,25 @@ export default function AdminUsers() {
   useEffect(() => { load(); }, []);
 
   useWebSocket((event, data) => {
-    if (event === 'user:created') load();
+    if (event === 'user:created') {
+      setUsers((prev) => {
+        if (prev.some((u) => u._id === data.id)) return prev;
+        return [...prev, {
+          _id: data.id,
+          username: data.username,
+          role: data.role,
+          folderName: data.folderName ?? null,
+          isActive: data.isActive ?? true,
+          createdAt: data.createdAt ?? new Date().toISOString(),
+          apiKeyPrefix: data.apiKeyPrefix ?? '',
+          fileCount: 0,
+          storageUsed: 0,
+          email: null,
+          emailVerified: false,
+          avatarUrl: null,
+        }];
+      });
+    }
     if (event === 'user:deleted') setUsers((prev) => prev.filter((u) => u._id !== data.id));
     if (event === 'user:updated') {
       setUsers((prev) => prev.map((u) => u._id === data.id ? { ...u, ...data } : u));

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -423,7 +423,7 @@ router.post('/admin/users', requireAdmin, async (req, res) => {
   if (exists) return res.status(409).json({ error: 'Username already taken' });
   const user = await User.create({ username, password, role: role === 'admin' ? 'admin' : 'user' });
   await logAudit(req, 'admin_create_user', { targetUsername: username, role: user.role });
-  broadcast('user:created', { id: user._id.toString(), username: user.username, role: user.role }, (c) => c.isAdmin);
+  broadcast('user:created', { id: user._id.toString(), username: user.username, role: user.role, folderName: user.folderName, isActive: user.isActive, createdAt: user.createdAt, apiKeyPrefix: user.apiKeyPrefix }, (c) => c.isAdmin);
   broadcast('stats:invalidate', {}, (c) => c.isAdmin);
   res.status(201).json({ user: { id: user._id, username: user.username, role: user.role } });
 });

--- a/src/ws.js
+++ b/src/ws.js
@@ -505,7 +505,7 @@ async function handleAction(client, { id, action, payload = {} }) {
       if (exists) return err('Username already taken', 409);
       const user = await User.create({ username, password, role: role === 'admin' ? 'admin' : 'user' });
       await wsAudit(client, 'admin_create_user', { targetUsername: username, role: user.role });
-      broadcast('user:created', { id: user._id.toString(), username: user.username, role: user.role }, (c) => c.isAdmin);
+      broadcast('user:created', { id: user._id.toString(), username: user.username, role: user.role, folderName: user.folderName, isActive: user.isActive, createdAt: user.createdAt, apiKeyPrefix: user.apiKeyPrefix }, (c) => c.isAdmin);
       broadcast('stats:invalidate', {}, (c) => c.isAdmin);
       return ok({ user: { id: user._id, username: user.username, role: user.role } });
     }


### PR DESCRIPTION
user:created WS handler was calling load() (async re-fetch) instead of directly updating state like user:deleted and user:updated do. This caused a noticeable delay before the new user appeared.

Now the handler inserts the new row immediately (duplicate-safe), using the new fields added to the broadcast payload (folderName, isActive, createdAt, apiKeyPrefix). The creating admin's existing load() in createUser() still runs in the background to sync full data (fileCount, storageUsed, avatarUrl).

https://claude.ai/code/session_019PeKiQPyheQHYuoadLynUT