### PR TITLE
fix: replace datetime-local with DateTimePicker to fix RangeError crash

### DIFF
--- a/client/src/components/ShareLinkDialog.jsx
+++ b/client/src/components/ShareLinkDialog.jsx
@@ -16,13 +16,14 @@ import {
   faDownload, faCircleCheck, faCircleXmark,
 } from '@fortawesome/free-solid-svg-icons';
 import { fmtDate } from '@/lib/utils';
+import { DateTimePicker } from '@/components/ui/date-time-picker';
 
 function CreateLinkForm({ shortId, onCreated }) {
   const { t } = useTranslation();
   const { toast } = useToast();
   const [label, setLabel] = useState('');
   const [password, setPassword] = useState('');
-  const [expiresAt, setExpiresAt] = useState('');
+  const [expiresAt, setExpiresAt] = useState(null);
   const [downloadLimit, setDownloadLimit] = useState('');
   const [saving, setSaving] = useState(false);
 
@@ -32,7 +33,7 @@ function CreateLinkForm({ shortId, onCreated }) {
     try {
       const body = { label };
       if (password) body.password = password;
-      if (expiresAt) body.expiresAt = new Date(expiresAt).toISOString();
+      if (expiresAt) body.expiresAt = expiresAt;
       if (downloadLimit) body.downloadLimit = parseInt(downloadLimit, 10);
 
       const r = await fetch(`/api/file/${shortId}/share-links`, {
@@ -55,9 +56,6 @@ function CreateLinkForm({ shortId, onCreated }) {
       setSaving(false);
     }
   }
-
-  // Minimum datetime for the expiry input (now + 1 min)
-  const minDateTime = new Date(Date.now() + 60_000).toISOString().slice(0, 16);
 
   return (
     <form onSubmit={handleSubmit} className="space-y-3 pt-1">
@@ -86,11 +84,11 @@ function CreateLinkForm({ shortId, onCreated }) {
       </div>
 
       <div className="space-y-1">
-        <Label htmlFor="sl-exp">
+        <Label>
           <FontAwesomeIcon icon={faHourglass} className="h-3 w-3 mr-1" />
           {t('shareLink.expiresAt')} <span className="text-muted-foreground">({t('shareLink.optional')})</span>
         </Label>
-        <Input id="sl-exp" type="datetime-local" min={minDateTime} value={expiresAt} onChange={(e) => setExpiresAt(e.target.value)} />
+        <DateTimePicker onChange={setExpiresAt} />
       </div>
 
       <Button type="submit" size="sm" disabled={saving} className="w-full gap-1.5">

--- a/client/src/components/ui/date-time-picker.jsx
+++ b/client/src/components/ui/date-time-picker.jsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+/**
+ * Two-input date+time picker that returns a UTC ISO string via onChange(isoString | null).
+ * Splitting avoids the browser inconsistencies of datetime-local.
+ */
+export function DateTimePicker({ value, onChange, className }) {
+  const today = new Date().toISOString().slice(0, 10);
+
+  const [date, setDate] = useState('');
+  const [time, setTime] = useState('');
+
+  // Sync outward when either input changes
+  useEffect(() => {
+    if (!date || !time) {
+      onChange(null);
+      return;
+    }
+    const d = new Date(`${date}T${time}`);
+    if (isNaN(d.getTime())) {
+      onChange(null);
+      return;
+    }
+    onChange(d.toISOString());
+  }, [date, time]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className={cn('flex gap-2', className)}>
+      <Input
+        type="date"
+        min={today}
+        value={date}
+        onChange={(e) => setDate(e.target.value)}
+        className="flex-1"
+      />
+      <Input
+        type="time"
+        value={time}
+        onChange={(e) => setTime(e.target.value)}
+        className="w-32"
+        disabled={!date}
+      />
+    </div>
+  );
+}

--- a/client/src/pages/Collections.jsx
+++ b/client/src/pages/Collections.jsx
@@ -22,6 +22,7 @@ import {
   faArrowUpRightFromSquare,
 } from '@fortawesome/free-solid-svg-icons';
 import { fmtDate } from '@/lib/utils';
+import { DateTimePicker } from '@/components/ui/date-time-picker';
 
 function CreateCollectionDialog({ onCreated }) {
   const { t } = useTranslation();
@@ -30,7 +31,7 @@ function CreateCollectionDialog({ onCreated }) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [password, setPassword] = useState('');
-  const [expiresAt, setExpiresAt] = useState('');
+  const [expiresAt, setExpiresAt] = useState(null);
   const [saving, setSaving] = useState(false);
 
   async function handleSubmit(e) {
@@ -40,7 +41,7 @@ function CreateCollectionDialog({ onCreated }) {
     try {
       const body = { name: name.trim(), description: description.trim() };
       if (password) body.password = password;
-      if (expiresAt) body.expiresAt = new Date(expiresAt).toISOString();
+      if (expiresAt) body.expiresAt = expiresAt;
 
       const r = await fetch('/api/collections', {
         method: 'POST',
@@ -63,8 +64,6 @@ function CreateCollectionDialog({ onCreated }) {
       setSaving(false);
     }
   }
-
-  const minDateTime = new Date(Date.now() + 60_000).toISOString().slice(0, 16);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -95,11 +94,11 @@ function CreateCollectionDialog({ onCreated }) {
             <Input id="coll-pw" type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder={t('shareLink.noPassword')} />
           </div>
           <div className="space-y-1">
-            <Label htmlFor="coll-exp">
+            <Label>
               <FontAwesomeIcon icon={faHourglass} className="h-3 w-3 mr-1" />
               {t('shareLink.expiresAt')} <span className="text-muted-foreground">({t('shareLink.optional')})</span>
             </Label>
-            <Input id="coll-exp" type="datetime-local" min={minDateTime} value={expiresAt} onChange={(e) => setExpiresAt(e.target.value)} />
+            <DateTimePicker onChange={setExpiresAt} />
           </div>
           <Button type="submit" className="w-full" disabled={saving || !name.trim()}>
             {saving ? t('collections.creating') : t('collections.createBtn')}


### PR DESCRIPTION
- New DateTimePicker component uses separate date+time inputs, avoids browser inconsistencies of datetime-local and the Invalid Date crash
- UTC conversion now happens inside DateTimePicker, not at submit time
- Removed minDateTime calculation that was unused after the refactor

https://claude.ai/code/session_01STUqMEJrbV2KyffHbv9g1X