### PR TITLE
fix: i18n support and date-fns locale in DateTimePicker

### DIFF
--- a/client/src/components/ui/date-time-picker.jsx
+++ b/client/src/components/ui/date-time-picker.jsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { format, isValid } from 'date-fns';
+import { de, fr, es, it, pt, ja, zhCN, enUS } from 'date-fns/locale';
 import { useTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCalendar, faClock, faXmark } from '@fortawesome/free-solid-svg-icons';
@@ -9,11 +10,20 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { Calendar } from '@/components/ui/calendar';
 import { cn } from '@/lib/utils';
 
+const LOCALE_MAP = { de, fr, es, it, pt, ja, zh: zhCN };
+
+function getDateFnsLocale(lang) {
+  const base = lang?.split('-')[0];
+  return LOCALE_MAP[base] ?? enUS;
+}
+
 export function DateTimePicker({ onChange, className }) {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [date, setDate] = useState(null);
   const [time, setTime] = useState('00:00');
   const [open, setOpen] = useState(false);
+
+  const locale = useMemo(() => getDateFnsLocale(i18n.language), [i18n.language]);
 
   useEffect(() => {
     if (!date) { onChange(null); return; }
@@ -35,10 +45,7 @@ export function DateTimePicker({ onChange, className }) {
     setTime('00:00');
   }
 
-  const locale = i18n.language?.startsWith('de') ? undefined : undefined;
-  const label = date
-    ? `${format(date, 'PP', { locale })} ${time}`
-    : null;
+  const label = date ? `${format(date, 'PP', { locale })} ${time}` : null;
 
   return (
     <div className={cn('flex gap-2', className)}>
@@ -49,7 +56,7 @@ export function DateTimePicker({ onChange, className }) {
             className={cn('flex-1 justify-start text-left font-normal', !date && 'text-muted-foreground')}
           >
             <FontAwesomeIcon icon={faCalendar} className="mr-2 h-3.5 w-3.5 shrink-0" />
-            <span className="truncate">{label ?? 'Pick a date…'}</span>
+            <span className="truncate">{label ?? t('dateTimePicker.pickDate')}</span>
             {date && (
               <FontAwesomeIcon
                 icon={faXmark}
@@ -65,6 +72,7 @@ export function DateTimePicker({ onChange, className }) {
             selected={date}
             onSelect={handleDaySelect}
             disabled={{ before: new Date() }}
+            locale={locale}
             initialFocus
           />
         </PopoverContent>

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -722,5 +722,8 @@
     "s8Body": "Diese Nutzungsbedingungen unterliegen dem Recht des Landes, in dem der Betreiber seinen Sitz hat. Bei Fragen wende dich bitte an:",
     "s8Contact": "Kontakt:",
     "version": "Sharely - Open-Source-Dateifreigabe - Nutzungsbedingungen"
+  },
+  "dateTimePicker": {
+    "pickDate": "Datum auswählen…"
   }
 }

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -722,5 +722,8 @@
     "s8Body": "These terms are governed by the laws of the jurisdiction where the operator is located. For questions about these terms, please contact:",
     "s8Contact": "Contact:",
     "version": "Sharely - Open-Source File Sharing - Terms of Service"
+  },
+  "dateTimePicker": {
+    "pickDate": "Pick a date…"
   }
 }

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -722,5 +722,8 @@
     "added": "File added to collection",
     "done": "Added",
     "failed": "Failed to add file"
+  },
+  "dateTimePicker": {
+    "pickDate": "Seleccionar fecha…"
   }
 }

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -722,5 +722,8 @@
     "added": "File added to collection",
     "done": "Added",
     "failed": "Failed to add file"
+  },
+  "dateTimePicker": {
+    "pickDate": "Choisir une date…"
   }
 }

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -722,5 +722,8 @@
     "added": "File added to collection",
     "done": "Added",
     "failed": "Failed to add file"
+  },
+  "dateTimePicker": {
+    "pickDate": "Seleziona data…"
   }
 }

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -722,5 +722,8 @@
     "added": "File added to collection",
     "done": "Added",
     "failed": "Failed to add file"
+  },
+  "dateTimePicker": {
+    "pickDate": "日付を選択…"
   }
 }

--- a/client/src/i18n/locales/pt.json
+++ b/client/src/i18n/locales/pt.json
@@ -722,5 +722,8 @@
     "added": "File added to collection",
     "done": "Added",
     "failed": "Failed to add file"
+  },
+  "dateTimePicker": {
+    "pickDate": "Escolher data…"
   }
 }

--- a/client/src/i18n/locales/zh.json
+++ b/client/src/i18n/locales/zh.json
@@ -722,5 +722,8 @@
     "added": "File added to collection",
     "done": "Added",
     "failed": "Failed to add file"
+  },
+  "dateTimePicker": {
+    "pickDate": "选择日期…"
   }
 }


### PR DESCRIPTION
- Replace hardcoded 'Pick a date…' with t('dateTimePicker.pickDate')
- Add dateTimePicker translations to all 8 locale files (de/en/fr/es/it/pt/ja/zh)
- Pass date-fns locale to Calendar and format() so month names, weekday abbreviations, and date formatting match the selected UI language

https://claude.ai/code/session_01STUqMEJrbV2KyffHbv9g1X