### PR TITLE
fix: replace native time input with custom HH:MM spinner in DateTimeP…

### DIFF
--- a/client/src/components/ui/date-time-picker.jsx
+++ b/client/src/components/ui/date-time-picker.jsx
@@ -1,11 +1,10 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { format, isValid } from 'date-fns';
 import { de, fr, es, it, pt, ja, zhCN, enUS } from 'date-fns/locale';
 import { useTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCalendar, faClock, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { faCalendar, faClock, faXmark, faChevronUp, faChevronDown } from '@fortawesome/free-solid-svg-icons';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Calendar } from '@/components/ui/calendar';
 import { cn } from '@/lib/utils';
@@ -13,26 +12,82 @@ import { cn } from '@/lib/utils';
 const LOCALE_MAP = { de, fr, es, it, pt, ja, zh: zhCN };
 
 function getDateFnsLocale(lang) {
-  const base = lang?.split('-')[0];
-  return LOCALE_MAP[base] ?? enUS;
+  return LOCALE_MAP[lang?.split('-')[0]] ?? enUS;
+}
+
+function TimeSpinner({ value, max, onChange }) {
+  const inputRef = useRef(null);
+
+  function clamp(v) {
+    if (v < 0) return max;
+    if (v > max) return 0;
+    return v;
+  }
+
+  function handleKey(e) {
+    if (e.key === 'ArrowUp') { e.preventDefault(); onChange(clamp(value + 1)); }
+    if (e.key === 'ArrowDown') { e.preventDefault(); onChange(clamp(value - 1)); }
+  }
+
+  function handleChange(e) {
+    const n = parseInt(e.target.value, 10);
+    if (!isNaN(n)) onChange(clamp(n));
+  }
+
+  function handleBlur(e) {
+    const n = parseInt(e.target.value, 10);
+    onChange(isNaN(n) ? 0 : clamp(n));
+  }
+
+  return (
+    <div className="flex flex-col items-center">
+      <button
+        type="button"
+        tabIndex={-1}
+        className="p-0.5 text-muted-foreground hover:text-foreground"
+        onClick={() => onChange(clamp(value + 1))}
+      >
+        <FontAwesomeIcon icon={faChevronUp} className="h-3 w-3" />
+      </button>
+      <input
+        ref={inputRef}
+        type="text"
+        inputMode="numeric"
+        className="w-8 text-center text-sm font-mono bg-transparent focus:outline-none focus:ring-1 focus:ring-ring rounded"
+        value={String(value).padStart(2, '0')}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onKeyDown={handleKey}
+        maxLength={2}
+      />
+      <button
+        type="button"
+        tabIndex={-1}
+        className="p-0.5 text-muted-foreground hover:text-foreground"
+        onClick={() => onChange(clamp(value - 1))}
+      >
+        <FontAwesomeIcon icon={faChevronDown} className="h-3 w-3" />
+      </button>
+    </div>
+  );
 }
 
 export function DateTimePicker({ onChange, className }) {
   const { t, i18n } = useTranslation();
   const [date, setDate] = useState(null);
-  const [time, setTime] = useState('00:00');
+  const [hours, setHours] = useState(0);
+  const [minutes, setMinutes] = useState(0);
   const [open, setOpen] = useState(false);
 
   const locale = useMemo(() => getDateFnsLocale(i18n.language), [i18n.language]);
 
   useEffect(() => {
     if (!date) { onChange(null); return; }
-    const [h, m] = time.split(':').map(Number);
     const d = new Date(date);
-    d.setHours(h, m, 0, 0);
+    d.setHours(hours, minutes, 0, 0);
     if (!isValid(d)) { onChange(null); return; }
     onChange(d.toISOString());
-  }, [date, time]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [date, hours, minutes]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleDaySelect(day) {
     setDate(day ?? null);
@@ -42,10 +97,12 @@ export function DateTimePicker({ onChange, className }) {
   function handleClear(e) {
     e.stopPropagation();
     setDate(null);
-    setTime('00:00');
+    setHours(0);
+    setMinutes(0);
   }
 
-  const label = date ? `${format(date, 'PP', { locale })} ${time}` : null;
+  const timeStr = `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+  const label = date ? `${format(date, 'PP', { locale })} ${timeStr}` : null;
 
   return (
     <div className={cn('flex gap-2', className)}>
@@ -78,15 +135,14 @@ export function DateTimePicker({ onChange, className }) {
         </PopoverContent>
       </Popover>
 
-      <div className="relative w-32">
-        <FontAwesomeIcon icon={faClock} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-        <Input
-          type="time"
-          value={time}
-          onChange={(e) => setTime(e.target.value)}
-          disabled={!date}
-          className="pl-8"
-        />
+      <div className={cn(
+        'flex items-center gap-1 rounded-md border px-2 w-28',
+        !date && 'opacity-50 pointer-events-none',
+      )}>
+        <FontAwesomeIcon icon={faClock} className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        <TimeSpinner value={hours} max={23} onChange={setHours} />
+        <span className="text-sm font-mono text-muted-foreground select-none">:</span>
+        <TimeSpinner value={minutes} max={59} onChange={setMinutes} />
       </div>
     </div>
   );


### PR DESCRIPTION
…icker

The native <input type="time"> rendered as a scroll-dropdown on some platforms. Replaced with a custom TimeSpinner using two text inputs (hours/minutes) and up/down chevron buttons, styled consistently with shadcn design.

https://claude.ai/code/session_01STUqMEJrbV2KyffHbv9g1X