### PR TITLE
fix: X button in DateTimePicker not clickable due to [&_svg]:pointer-…

### DIFF
--- a/client/src/components/ui/date-time-picker.jsx
+++ b/client/src/components/ui/date-time-picker.jsx
@@ -89,7 +89,9 @@ export function DateTimePicker({ onChange, className }) {
             <FontAwesomeIcon icon={faCalendar} className="mr-2 h-3.5 w-3.5 shrink-0" />
             <span className="truncate">{dateLabel ?? t('dateTimePicker.pickDate')}</span>
             {date && (
-              <FontAwesomeIcon icon={faXmark} className="ml-auto h-3.5 w-3.5 shrink-0 opacity-50 hover:opacity-100" onClick={handleClear} />
+              <span onClick={handleClear} className="ml-auto flex items-center opacity-50 hover:opacity-100">
+                <FontAwesomeIcon icon={faXmark} className="h-3.5 w-3.5" />
+              </span>
             )}
           </Button>
         </PopoverTrigger>


### PR DESCRIPTION
…events-none

The Button base class disables pointer events on all child SVGs. Wrapped the clear icon in a <span> so the onClick fires correctly.

https://claude.ai/code/session_01STUqMEJrbV2KyffHbv9g1X