### PR TITLE
fix: show existing expiry date in EditCollectionDialog; remove clearE…

### DIFF
--- a/client/src/components/ui/date-time-picker.jsx
+++ b/client/src/components/ui/date-time-picker.jsx
@@ -47,11 +47,13 @@ function Spinner({ value, max, onChange }) {
   );
 }
 
-export function DateTimePicker({ onChange, className }) {
+export function DateTimePicker({ defaultValue, onChange, className }) {
   const { t, i18n } = useTranslation();
-  const [date, setDate] = useState(null);
-  const [hours, setHours] = useState(0);
-  const [minutes, setMinutes] = useState(0);
+
+  const initDate = defaultValue ? new Date(defaultValue) : null;
+  const [date, setDate] = useState(initDate);
+  const [hours, setHours] = useState(initDate ? initDate.getHours() : 0);
+  const [minutes, setMinutes] = useState(initDate ? initDate.getMinutes() : 0);
   const [calOpen, setCalOpen] = useState(false);
   const [timeOpen, setTimeOpen] = useState(false);
 

--- a/client/src/pages/Collections.jsx
+++ b/client/src/pages/Collections.jsx
@@ -119,7 +119,7 @@ function EditCollectionDialog({ coll, onUpdated }) {
   const [password, setPassword] = useState('');
   const [clearPassword, setClearPassword] = useState(false);
   const [expiresAt, setExpiresAt] = useState(null);
-  const [clearExpiry, setClearExpiry] = useState(false);
+  const [dialogKey, setDialogKey] = useState(0);
   const [saving, setSaving] = useState(false);
 
   function handleOpen(val) {
@@ -128,8 +128,8 @@ function EditCollectionDialog({ coll, onUpdated }) {
       setDescription(coll.description || '');
       setPassword('');
       setClearPassword(false);
-      setExpiresAt(null);
-      setClearExpiry(false);
+      setExpiresAt(coll.expiresAt ?? null);
+      setDialogKey((k) => k + 1);
     }
     setOpen(val);
   }
@@ -139,9 +139,10 @@ function EditCollectionDialog({ coll, onUpdated }) {
     if (!name.trim()) return;
     setSaving(true);
     try {
-      const body = { name: name.trim(), description: description.trim(), clearPassword, clearExpiry };
+      const body = { name: name.trim(), description: description.trim(), clearPassword };
       if (password) body.password = password;
-      if (expiresAt) body.expiresAt = expiresAt;
+      if (coll.expiresAt && !expiresAt) body.clearExpiry = true;
+      else if (expiresAt) body.expiresAt = expiresAt;
 
       const r = await fetch(`/api/collections/${coll.shortId}`, {
         method: 'PATCH',
@@ -203,13 +204,7 @@ function EditCollectionDialog({ coll, onUpdated }) {
               <FontAwesomeIcon icon={faHourglass} className="h-3 w-3 mr-1" />
               {t('shareLink.expiresAt')} <span className="text-muted-foreground">({t('shareLink.optional')})</span>
             </Label>
-            <DateTimePicker onChange={setExpiresAt} />
-            {coll.expiresAt && (
-              <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
-                <Checkbox checked={clearExpiry} onCheckedChange={(v) => setClearExpiry(!!v)} />
-                {t('collections.clearExpiry')}
-              </label>
-            )}
+            <DateTimePicker key={dialogKey} defaultValue={coll.expiresAt} onChange={setExpiresAt} />
           </div>
           <Button type="submit" className="w-full" disabled={saving || !name.trim()}>
             {saving ? t('collections.saving') : t('collections.saveBtn')}


### PR DESCRIPTION
…xpiry checkbox

- DateTimePicker accepts defaultValue prop to initialize with existing date
- EditCollectionDialog passes coll.expiresAt as defaultValue; uses key prop to remount picker fresh each time the dialog opens
- clearExpiry is now derived from state: sent when collection had an expiry and user cleared it via the X button in the picker
- Removed redundant clearExpiry checkbox

https://claude.ai/code/session_01STUqMEJrbV2KyffHbv9g1X