### PR TITLE
feat: clipboard upload, tags, and bulk actions

### DIFF
--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -95,7 +95,21 @@
     "contextOpen": "Öffnen",
     "contextCopyLink": "Link kopieren",
     "contextOpenRaw": "Roh öffnen",
-    "contextDownload": "Herunterladen"
+    "contextDownload": "Herunterladen",
+    "selectMode": "Auswählen",
+    "cancelSelect": "Abbrechen",
+    "selectedCount": "{{count}} ausgewählt",
+    "bulkDelete": "Löschen",
+    "bulkAddToCollection": "Zur Sammlung hinzufügen",
+    "bulkTag": "Tags",
+    "bulkDeleteConfirmTitle": "{{count}} Dateien löschen?",
+    "bulkDeleteConfirmDesc": "Diese Aktion kann nicht rückgängig gemacht werden.",
+    "bulkDeleted": "{{count}} Dateien gelöscht",
+    "bulkTagged": "Tags hinzugefügt",
+    "bulkAddedToCollection": "Zur Sammlung hinzugefügt",
+    "filterByTag": "Nach Tag filtern",
+    "allTags": "Alle Tags",
+    "noTags": "Keine Tags"
   },
   "upload": {
     "title": "Hochladen",
@@ -121,7 +135,9 @@
     "uploadFailed": "Hochladen fehlgeschlagen",
     "selectFiles": "Hochladen",
     "openFolder": "Öffnen",
-    "folderDropHint": "Ordner können per Drag & Drop hinzugefügt werden"
+    "folderDropHint": "Ordner können per Drag & Drop hinzugefügt werden",
+    "pasteHint": "Du kannst auch Bilder oder Text aus der Zwischenablage einfügen (Strg+V)",
+    "pastedFiles": "{{count}} Datei(en) aus Zwischenablage hinzugefügt"
   },
   "settings": {
     "title": "Einstellungen",
@@ -231,7 +247,11 @@
     "loadFailed": "Datei konnte nicht geladen werden",
     "backToGallery": "Zurück zur Galerie",
     "shareLink": "Freigabe-Link",
-    "addToCollection": "Zu Sammlung hinzufügen"
+    "addToCollection": "Zu Sammlung hinzufügen",
+    "tags": "Tags",
+    "addTag": "Tag hinzufügen…",
+    "tagSaved": "Tags gespeichert",
+    "tagFailed": "Speichern fehlgeschlagen"
   },
   "shareLink": {
     "title": "Freigabe-Links",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -95,7 +95,21 @@
     "contextOpen": "Open",
     "contextCopyLink": "Copy link",
     "contextOpenRaw": "Open raw",
-    "contextDownload": "Download"
+    "contextDownload": "Download",
+    "selectMode": "Select",
+    "cancelSelect": "Cancel",
+    "selectedCount": "{{count}} selected",
+    "bulkDelete": "Delete",
+    "bulkAddToCollection": "Add to collection",
+    "bulkTag": "Tag",
+    "bulkDeleteConfirmTitle": "Delete {{count}} files?",
+    "bulkDeleteConfirmDesc": "This action cannot be undone.",
+    "bulkDeleted": "{{count}} files deleted",
+    "bulkTagged": "Tags added",
+    "bulkAddedToCollection": "Added to collection",
+    "filterByTag": "Filter by tag",
+    "allTags": "All tags",
+    "noTags": "No tags"
   },
   "upload": {
     "title": "Upload",
@@ -121,7 +135,9 @@
     "uploadFailed": "Upload failed",
     "selectFiles": "Upload",
     "openFolder": "Open folder",
-    "folderDropHint": "Folders can be added via drag & drop"
+    "folderDropHint": "Folders can be added via drag & drop",
+    "pasteHint": "You can also paste images or text from the clipboard (Ctrl+V)",
+    "pastedFiles": "Added {{count}} file(s) from clipboard"
   },
   "settings": {
     "title": "Settings",
@@ -231,7 +247,11 @@
     "loadFailed": "Failed to load file",
     "backToGallery": "Back to gallery",
     "shareLink": "Share Link",
-    "addToCollection": "Add to Collection"
+    "addToCollection": "Add to Collection",
+    "tags": "Tags",
+    "addTag": "Add tag…",
+    "tagSaved": "Tags saved",
+    "tagFailed": "Failed to save tags"
   },
   "shareLink": {
     "title": "Share Links",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -69,7 +69,21 @@
     "contextOpen": "Abrir",
     "contextCopyLink": "Copiar enlace",
     "contextOpenRaw": "Abrir en crudo",
-    "contextDownload": "Descargar"
+    "contextDownload": "Descargar",
+    "selectMode": "Seleccionar",
+    "cancelSelect": "Cancelar",
+    "selectedCount": "{{count}} seleccionado(s)",
+    "bulkDelete": "Eliminar",
+    "bulkAddToCollection": "Añadir a colección",
+    "bulkTag": "Etiquetar",
+    "bulkDeleteConfirmTitle": "¿Eliminar {{count}} archivos?",
+    "bulkDeleteConfirmDesc": "Esta acción no se puede deshacer.",
+    "bulkDeleted": "{{count}} archivos eliminados",
+    "bulkTagged": "Etiquetas añadidas",
+    "bulkAddedToCollection": "Añadido a la colección",
+    "filterByTag": "Filtrar por etiqueta",
+    "allTags": "Todas las etiquetas",
+    "noTags": "Sin etiquetas"
   },
   "upload": {
     "title": "Subir",
@@ -95,7 +109,9 @@
     "uploadFailed": "Error al subir",
     "selectFiles": "Subir",
     "openFolder": "Abrir",
-    "folderDropHint": "Las carpetas se pueden añadir arrastrando y soltando"
+    "folderDropHint": "Las carpetas se pueden añadir arrastrando y soltando",
+    "pasteHint": "También puedes pegar imágenes o texto desde el portapapeles (Ctrl+V)",
+    "pastedFiles": "{{count}} archivo(s) añadido(s) desde el portapapeles"
   },
   "settings": {
     "tabProfile": "Perfil",
@@ -190,7 +206,11 @@
     "loadFailed": "No se pudo cargar el archivo",
     "backToGallery": "Volver a la galería",
     "shareLink": "Enlace de compartir",
-    "addToCollection": "Añadir a colección"
+    "addToCollection": "Añadir a colección",
+    "tags": "Etiquetas",
+    "addTag": "Añadir etiqueta…",
+    "tagSaved": "Etiquetas guardadas",
+    "tagFailed": "Error al guardar las etiquetas"
   },
   "admin": {
     "dashboard": "Panel",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -69,7 +69,21 @@
     "contextOpen": "Ouvrir",
     "contextCopyLink": "Copier le lien",
     "contextOpenRaw": "Ouvrir en brut",
-    "contextDownload": "Télécharger"
+    "contextDownload": "Télécharger",
+    "selectMode": "Sélectionner",
+    "cancelSelect": "Annuler",
+    "selectedCount": "{{count}} sélectionné(s)",
+    "bulkDelete": "Supprimer",
+    "bulkAddToCollection": "Ajouter à la collection",
+    "bulkTag": "Étiquetter",
+    "bulkDeleteConfirmTitle": "Supprimer {{count}} fichiers ?",
+    "bulkDeleteConfirmDesc": "Cette action est irréversible.",
+    "bulkDeleted": "{{count}} fichiers supprimés",
+    "bulkTagged": "Tags ajoutés",
+    "bulkAddedToCollection": "Ajouté à la collection",
+    "filterByTag": "Filtrer par tag",
+    "allTags": "Tous les tags",
+    "noTags": "Aucun tag"
   },
   "upload": {
     "title": "Téléverser",
@@ -95,7 +109,9 @@
     "uploadFailed": "Échec du téléversement",
     "selectFiles": "Télécharger",
     "openFolder": "Ouvrir",
-    "folderDropHint": "Les dossiers peuvent être ajoutés par glisser-déposer"
+    "folderDropHint": "Les dossiers peuvent être ajoutés par glisser-déposer",
+    "pasteHint": "Vous pouvez aussi coller des images ou du texte depuis le presse-papiers (Ctrl+V)",
+    "pastedFiles": "{{count}} fichier(s) ajouté(s) depuis le presse-papiers"
   },
   "settings": {
     "tabProfile": "Profil",
@@ -190,7 +206,11 @@
     "loadFailed": "Impossible de charger le fichier",
     "backToGallery": "Retour à la galerie",
     "shareLink": "Lien de partage",
-    "addToCollection": "Ajouter à la collection"
+    "addToCollection": "Ajouter à la collection",
+    "tags": "Tags",
+    "addTag": "Ajouter un tag…",
+    "tagSaved": "Tags enregistrés",
+    "tagFailed": "Échec de l'enregistrement des tags"
   },
   "admin": {
     "dashboard": "Tableau de bord",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -69,7 +69,21 @@
     "contextOpen": "Apri",
     "contextCopyLink": "Copia link",
     "contextOpenRaw": "Apri raw",
-    "contextDownload": "Scarica"
+    "contextDownload": "Scarica",
+    "selectMode": "Seleziona",
+    "cancelSelect": "Annulla",
+    "selectedCount": "{{count}} selezionato/i",
+    "bulkDelete": "Elimina",
+    "bulkAddToCollection": "Aggiungi alla raccolta",
+    "bulkTag": "Etichetta",
+    "bulkDeleteConfirmTitle": "Eliminare {{count}} file?",
+    "bulkDeleteConfirmDesc": "Questa azione non può essere annullata.",
+    "bulkDeleted": "{{count}} file eliminati",
+    "bulkTagged": "Tag aggiunti",
+    "bulkAddedToCollection": "Aggiunto alla raccolta",
+    "filterByTag": "Filtra per tag",
+    "allTags": "Tutti i tag",
+    "noTags": "Nessun tag"
   },
   "upload": {
     "title": "Carica",
@@ -95,7 +109,9 @@
     "uploadFailed": "Caricamento fallito",
     "selectFiles": "Carica",
     "openFolder": "Apri",
-    "folderDropHint": "Le cartelle possono essere aggiunte tramite trascinamento"
+    "folderDropHint": "Le cartelle possono essere aggiunte tramite trascinamento",
+    "pasteHint": "Puoi anche incollare immagini o testo dagli appunti (Ctrl+V)",
+    "pastedFiles": "{{count}} file aggiunto/i dagli appunti"
   },
   "settings": {
     "tabProfile": "Profilo",
@@ -190,7 +206,11 @@
     "loadFailed": "Impossibile caricare il file",
     "backToGallery": "Torna alla galleria",
     "shareLink": "Link di condivisione",
-    "addToCollection": "Aggiungi alla raccolta"
+    "addToCollection": "Aggiungi alla raccolta",
+    "tags": "Tag",
+    "addTag": "Aggiungi tag…",
+    "tagSaved": "Tag salvati",
+    "tagFailed": "Salvataggio tag fallito"
   },
   "admin": {
     "dashboard": "Dashboard",

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -69,7 +69,21 @@
     "contextOpen": "開く",
     "contextCopyLink": "リンクをコピー",
     "contextOpenRaw": "Rawで開く",
-    "contextDownload": "ダウンロード"
+    "contextDownload": "ダウンロード",
+    "selectMode": "選択",
+    "cancelSelect": "キャンセル",
+    "selectedCount": "{{count}}件選択中",
+    "bulkDelete": "削除",
+    "bulkAddToCollection": "コレクションに追加",
+    "bulkTag": "タグ付け",
+    "bulkDeleteConfirmTitle": "{{count}}件のファイルを削除しますか？",
+    "bulkDeleteConfirmDesc": "この操作は元に戻せません。",
+    "bulkDeleted": "{{count}}件のファイルを削除しました",
+    "bulkTagged": "タグを追加しました",
+    "bulkAddedToCollection": "コレクションに追加しました",
+    "filterByTag": "タグで絞り込む",
+    "allTags": "すべてのタグ",
+    "noTags": "タグなし"
   },
   "upload": {
     "title": "アップロード",
@@ -95,7 +109,9 @@
     "uploadFailed": "アップロードに失敗しました",
     "selectFiles": "アップロード",
     "openFolder": "開く",
-    "folderDropHint": "フォルダはドラッグ＆ドロップで追加できます"
+    "folderDropHint": "フォルダはドラッグ＆ドロップで追加できます",
+    "pasteHint": "クリップボードから画像やテキストを貼り付けることもできます（Ctrl+V）",
+    "pastedFiles": "クリップボードから{{count}}件のファイルを追加しました"
   },
   "settings": {
     "tabProfile": "プロフィール",
@@ -190,7 +206,11 @@
     "loadFailed": "ファイルの読み込みに失敗しました",
     "backToGallery": "ギャラリーに戻る",
     "shareLink": "共有リンク",
-    "addToCollection": "コレクションに追加"
+    "addToCollection": "コレクションに追加",
+    "tags": "タグ",
+    "addTag": "タグを追加…",
+    "tagSaved": "タグを保存しました",
+    "tagFailed": "タグの保存に失敗しました"
   },
   "admin": {
     "dashboard": "ダッシュボード",

--- a/client/src/i18n/locales/pt.json
+++ b/client/src/i18n/locales/pt.json
@@ -69,7 +69,21 @@
     "contextOpen": "Abrir",
     "contextCopyLink": "Copiar link",
     "contextOpenRaw": "Abrir raw",
-    "contextDownload": "Descarregar"
+    "contextDownload": "Descarregar",
+    "selectMode": "Selecionar",
+    "cancelSelect": "Cancelar",
+    "selectedCount": "{{count}} selecionado(s)",
+    "bulkDelete": "Excluir",
+    "bulkAddToCollection": "Adicionar à coleção",
+    "bulkTag": "Etiquetar",
+    "bulkDeleteConfirmTitle": "Excluir {{count}} arquivos?",
+    "bulkDeleteConfirmDesc": "Esta ação não pode ser desfeita.",
+    "bulkDeleted": "{{count}} arquivos excluídos",
+    "bulkTagged": "Tags adicionadas",
+    "bulkAddedToCollection": "Adicionado à coleção",
+    "filterByTag": "Filtrar por tag",
+    "allTags": "Todas as tags",
+    "noTags": "Sem tags"
   },
   "upload": {
     "title": "Enviar",
@@ -95,7 +109,9 @@
     "uploadFailed": "Falha no envio",
     "selectFiles": "Carregar",
     "openFolder": "Abrir",
-    "folderDropHint": "Pastas podem ser adicionadas via arrastar e soltar"
+    "folderDropHint": "Pastas podem ser adicionadas via arrastar e soltar",
+    "pasteHint": "Você também pode colar imagens ou texto da área de transferência (Ctrl+V)",
+    "pastedFiles": "{{count}} arquivo(s) adicionado(s) da área de transferência"
   },
   "settings": {
     "tabProfile": "Perfil",
@@ -190,7 +206,11 @@
     "loadFailed": "Não foi possível carregar o ficheiro",
     "backToGallery": "Voltar à galeria",
     "shareLink": "Link de compartilhamento",
-    "addToCollection": "Adicionar à coleção"
+    "addToCollection": "Adicionar à coleção",
+    "tags": "Tags",
+    "addTag": "Adicionar tag…",
+    "tagSaved": "Tags salvas",
+    "tagFailed": "Falha ao salvar tags"
   },
   "admin": {
     "dashboard": "Painel",

--- a/client/src/i18n/locales/zh.json
+++ b/client/src/i18n/locales/zh.json
@@ -69,7 +69,21 @@
     "contextOpen": "打开",
     "contextCopyLink": "复制链接",
     "contextOpenRaw": "打开原始文件",
-    "contextDownload": "下载"
+    "contextDownload": "下载",
+    "selectMode": "选择",
+    "cancelSelect": "取消",
+    "selectedCount": "已选 {{count}} 个",
+    "bulkDelete": "删除",
+    "bulkAddToCollection": "添加到合集",
+    "bulkTag": "添加标签",
+    "bulkDeleteConfirmTitle": "删除 {{count}} 个文件？",
+    "bulkDeleteConfirmDesc": "此操作无法撤销。",
+    "bulkDeleted": "已删除 {{count}} 个文件",
+    "bulkTagged": "已添加标签",
+    "bulkAddedToCollection": "已添加到合集",
+    "filterByTag": "按标签筛选",
+    "allTags": "所有标签",
+    "noTags": "无标签"
   },
   "upload": {
     "title": "上传",
@@ -95,7 +109,9 @@
     "uploadFailed": "上传失败",
     "selectFiles": "上传",
     "openFolder": "打开",
-    "folderDropHint": "文件夹可以通过拖放添加"
+    "folderDropHint": "文件夹可以通过拖放添加",
+    "pasteHint": "也可以从剪贴板粘贴图片或文本（Ctrl+V）",
+    "pastedFiles": "已从剪贴板添加 {{count}} 个文件"
   },
   "settings": {
     "tabProfile": "个人资料",
@@ -190,7 +206,11 @@
     "loadFailed": "文件加载失败",
     "backToGallery": "返回图库",
     "shareLink": "分享链接",
-    "addToCollection": "添加到集合"
+    "addToCollection": "添加到集合",
+    "tags": "标签",
+    "addTag": "添加标签…",
+    "tagSaved": "标签已保存",
+    "tagFailed": "标签保存失败"
   },
   "admin": {
     "dashboard": "仪表板",

--- a/client/src/pages/FileView.jsx
+++ b/client/src/pages/FileView.jsx
@@ -63,7 +63,8 @@ import {
 import { useToast } from '@/hooks/use-toast';
 import { fmtSize, fmtDate } from '@/lib/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faDownload, faTrash, faCopy, faArrowUpRightFromSquare, faEye, faCalendar, faLink, faFolderPlus } from '@fortawesome/free-solid-svg-icons';
+import { faDownload, faTrash, faCopy, faArrowUpRightFromSquare, faEye, faCalendar, faLink, faFolderPlus, faTag, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { Input } from '@/components/ui/input';
 import { useTranslation } from 'react-i18next';
 import { UserAvatar } from '@/components/UserAvatar';
 import { useWebSocket } from '@/hooks/useWebSocket';
@@ -214,6 +215,44 @@ function FileViewInner() {
   }
 
   const canDelete = user && (user.id === file.uploader?._id || user.role === 'admin');
+  const canEdit = canDelete;
+
+  const [tags, setTags] = useState(file.tags || []);
+  const [tagInput, setTagInput] = useState('');
+  const [tagSuggestions, setTagSuggestions] = useState([]);
+
+  useEffect(() => {
+    if (!canEdit) return;
+    fetch('/api/tags').then((r) => r.ok ? r.json() : { tags: [] }).then((d) => setTagSuggestions(d.tags));
+  }, [canEdit]);
+
+  async function saveTags(newTags) {
+    const r = await fetch(`/api/file/${shortId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tags: newTags }),
+    });
+    if (r.ok) {
+      toast({ title: t('fileView.tagSaved') });
+    } else {
+      toast({ title: t('fileView.tagFailed'), variant: 'destructive' });
+    }
+  }
+
+  function addTag(tag) {
+    const trimmed = tag.trim().slice(0, 50);
+    if (!trimmed || tags.includes(trimmed) || tags.length >= 20) return;
+    const next = [...tags, trimmed];
+    setTags(next);
+    setTagInput('');
+    saveTags(next);
+  }
+
+  function removeTag(tag) {
+    const next = tags.filter((t_) => t_ !== tag);
+    setTags(next);
+    saveTags(next);
+  }
 
   return (
     <div className="max-w-5xl mx-auto space-y-4">
@@ -286,6 +325,41 @@ function FileViewInner() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Tags */}
+      {(canEdit || tags.length > 0) && (
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2 flex-wrap">
+              <FontAwesomeIcon icon={faTag} className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+              {tags.map((tag) => (
+                <Badge key={tag} variant="secondary" className="gap-1 pr-1">
+                  {tag}
+                  {canEdit && (
+                    <button onClick={() => removeTag(tag)} className="ml-0.5 hover:text-destructive">
+                      <FontAwesomeIcon icon={faXmark} className="h-3 w-3" />
+                    </button>
+                  )}
+                </Badge>
+              ))}
+              {canEdit && (
+                <form onSubmit={(e) => { e.preventDefault(); addTag(tagInput); }} className="flex gap-1">
+                  <Input
+                    value={tagInput}
+                    onChange={(e) => setTagInput(e.target.value)}
+                    placeholder={t('fileView.addTag')}
+                    className="h-7 w-32 text-xs"
+                    list="tag-suggestions"
+                  />
+                  <datalist id="tag-suggestions">
+                    {tagSuggestions.filter((s) => !tags.includes(s)).map((s) => <option key={s} value={s} />)}
+                  </datalist>
+                </form>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Viewer */}
       <Card className="overflow-hidden">

--- a/client/src/pages/Gallery.jsx
+++ b/client/src/pages/Gallery.jsx
@@ -35,7 +35,8 @@ import {
 import { useToast } from '@/hooks/use-toast';
 import { fmtSize } from '@/lib/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUpload, faMagnifyingGlass, faXmark, faImage, faVideo, faMusic, faFileLines, faCode, faFile, faLink, faDownload, faArrowUpRightFromSquare, faTrash, faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
+import { faUpload, faMagnifyingGlass, faXmark, faImage, faVideo, faMusic, faFileLines, faCode, faFile, faLink, faDownload, faArrowUpRightFromSquare, faTrash, faEllipsisVertical, faCheckSquare, faTag, faFolderPlus } from '@fortawesome/free-solid-svg-icons';
+import { Checkbox } from '@/components/ui/checkbox';
 import { useTranslation } from 'react-i18next';
 import { UserAvatar } from '@/components/UserAvatar';
 import { useWebSocket } from '@/hooks/useWebSocket';
@@ -126,7 +127,7 @@ function FileThumbnail({ file, icon }) {
   return <FilePlaceholder file={file} icon={icon} />;
 }
 
-function FileCard({ file, user, onDelete }) {
+function FileCard({ file, user, onDelete, selectMode, selected, onToggleSelect }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -147,6 +148,36 @@ function FileCard({ file, user, onDelete }) {
     } else {
       toast({ title: t('fileView.deleteFailed'), variant: 'destructive' });
     }
+  }
+
+  if (selectMode) {
+    return (
+      <div
+        onClick={() => onToggleSelect(file.shortId)}
+        className={`group rounded-lg border bg-card overflow-hidden flex flex-col cursor-pointer transition-colors ${selected ? 'border-primary ring-2 ring-primary/40' : 'hover:border-primary/60'}`}
+      >
+        <div className="aspect-square bg-muted/30 flex items-center justify-center overflow-hidden relative">
+          <FileThumbnail file={file} icon={TYPE_ICONS[file.displayType] || faFile} />
+          <div className="absolute top-2 left-2">
+            <Checkbox checked={selected} onCheckedChange={() => onToggleSelect(file.shortId)} />
+          </div>
+        </div>
+        <div className="p-3 space-y-1">
+          <p className="text-sm font-medium truncate" title={file.originalName}>{file.originalName}</p>
+          <div className="flex items-center justify-between">
+            <Badge variant="secondary" className="text-xs px-1.5 py-0">{file.displayType}</Badge>
+            <span className="text-xs text-muted-foreground">{fmtSize(file.size)}</span>
+          </div>
+          {file.tags?.length > 0 && (
+            <div className="flex flex-wrap gap-1 pt-0.5">
+              {file.tags.slice(0, 3).map((tag) => (
+                <Badge key={tag} variant="outline" className="text-xs px-1 py-0">{tag}</Badge>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -212,6 +243,13 @@ function FileCard({ file, user, onDelete }) {
                   </DropdownMenu>
                 </div>
               </div>
+              {file.tags?.length > 0 && (
+                <div className="flex flex-wrap gap-1 pt-0.5">
+                  {file.tags.slice(0, 3).map((tag) => (
+                    <Badge key={tag} variant="outline" className="text-xs px-1 py-0">{tag}</Badge>
+                  ))}
+                </div>
+              )}
               {file.uploader && (
                 <div className="flex items-center gap-1.5 mt-0.5">
                   <UserAvatar avatarUrl={file.uploader.avatarUrl} size="xs" />
@@ -281,6 +319,7 @@ function FileCard({ file, user, onDelete }) {
 export default function Gallery() {
   const { user } = useAuth();
   const { t } = useTranslation();
+  const { toast } = useToast();
   const [searchParams, setSearchParams] = useSearchParams();
   const [files, setFiles] = useState([]);
   const [total, setTotal] = useState(0);
@@ -289,13 +328,72 @@ export default function Gallery() {
 
   const q = searchParams.get('q') || '';
   const type = searchParams.get('type') || 'all';
+  const tag = searchParams.get('tag') || '';
   const page = parseInt(searchParams.get('page') || '1', 10);
 
   const [searchInput, setSearchInput] = useState(q);
 
+  // Bulk selection
+  const [selectMode, setSelectMode] = useState(false);
+  const [selected, setSelected] = useState(new Set());
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+  const [bulkTagInput, setBulkTagInput] = useState('');
+  const [bulkTagOpen, setBulkTagOpen] = useState(false);
+  const [bulkCollOpen, setBulkCollOpen] = useState(false);
+  const [myCollections, setMyCollections] = useState([]);
+  const [allTags, setAllTags] = useState([]);
+
+  // Tag suggestions & user collections (loaded lazily)
+  useEffect(() => {
+    if (!selectMode) return;
+    fetch('/api/tags').then((r) => r.ok ? r.json() : { tags: [] }).then((d) => setAllTags(d.tags));
+    fetch('/api/collections').then((r) => r.ok ? r.json() : { collections: [] }).then((d) => setMyCollections(d.collections || []));
+  }, [selectMode]);
+
+  function toggleSelectMode() {
+    setSelectMode((v) => !v);
+    setSelected(new Set());
+  }
+
+  function toggleSelect(shortId) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      next.has(shortId) ? next.delete(shortId) : next.add(shortId);
+      return next;
+    });
+  }
+
+  function selectAll() {
+    setSelected(new Set(files.map((f) => f.shortId)));
+  }
+
+  async function bulkAction(action, extra = {}) {
+    const shortIds = Array.from(selected);
+    const r = await fetch('/api/files/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action, shortIds, ...extra }),
+    });
+    if (!r.ok) { toast({ title: 'Failed', variant: 'destructive' }); return; }
+    if (action === 'delete') {
+      toast({ title: t('gallery.bulkDeleted', { count: shortIds.length }) });
+      fetchFiles();
+    } else if (action === 'tag') {
+      toast({ title: t('gallery.bulkTagged') });
+      fetchFiles();
+    } else if (action === 'addToCollection') {
+      toast({ title: t('gallery.bulkAddedToCollection') });
+    }
+    setSelected(new Set());
+    setBulkDeleteOpen(false);
+    setBulkTagOpen(false);
+    setBulkCollOpen(false);
+  }
+
   const fetchFiles = useCallback(async () => {
     setLoading(true);
     const params = new URLSearchParams({ page, q, type });
+    if (tag) params.set('tag', tag);
     try {
       const r = await fetch(`/api/gallery?${params}`);
       if (r.ok) {
@@ -307,7 +405,7 @@ export default function Gallery() {
     } finally {
       setLoading(false);
     }
-  }, [page, q, type]);
+  }, [page, q, type, tag]);
 
   useEffect(() => { fetchFiles(); }, [fetchFiles]);
 
@@ -323,12 +421,12 @@ export default function Gallery() {
 
   function handleSearch(e) {
     e.preventDefault();
-    setSearchParams({ q: searchInput, type, page: 1 });
+    setSearchParams({ q: searchInput, type, ...(tag && { tag }), page: 1 });
   }
 
   function clearSearch() {
     setSearchInput('');
-    setSearchParams({ type, page: 1 });
+    setSearchParams({ type, ...(tag && { tag }), page: 1 });
   }
 
   return (
@@ -342,9 +440,15 @@ export default function Gallery() {
             {user?.role !== 'admin' ? ` ${t('gallery.filesOwned')}` : ''}
           </p>
         </div>
-        <Button asChild>
-          <Link to="/upload"><FontAwesomeIcon icon={faUpload} className="h-4 w-4 mr-2" />{t('gallery.upload')}</Link>
-        </Button>
+        <div className="flex gap-2">
+          <Button variant={selectMode ? 'secondary' : 'outline'} size="sm" onClick={toggleSelectMode} className="gap-1.5">
+            <FontAwesomeIcon icon={faCheckSquare} className="h-3.5 w-3.5" />
+            {selectMode ? t('gallery.cancelSelect') : t('gallery.selectMode')}
+          </Button>
+          <Button asChild>
+            <Link to="/upload"><FontAwesomeIcon icon={faUpload} className="h-4 w-4 mr-2" />{t('gallery.upload')}</Link>
+          </Button>
+        </div>
       </div>
 
       {/* Search & filter */}
@@ -363,7 +467,7 @@ export default function Gallery() {
             </button>
           )}
         </div>
-        <Select value={type} onValueChange={(v) => setSearchParams({ q, type: v, page: 1 })}>
+        <Select value={type} onValueChange={(v) => setSearchParams({ q, type: v, ...(tag && { tag }), page: 1 })}>
           <SelectTrigger className="w-36">
             <SelectValue />
           </SelectTrigger>
@@ -378,6 +482,100 @@ export default function Gallery() {
         </Select>
         <Button type="submit" variant="secondary">{t('gallery.search')}</Button>
       </form>
+
+      {/* Tag filter chips */}
+      {allTags.length === 0 && tag && (
+        <div className="flex items-center gap-2 flex-wrap">
+          <Badge variant="secondary" className="gap-1 cursor-pointer" onClick={() => setSearchParams({ q, type, page: 1 })}>
+            <FontAwesomeIcon icon={faXmark} className="h-2.5 w-2.5" />
+            {tag}
+          </Badge>
+        </div>
+      )}
+      {allTags.length > 0 && (
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-xs text-muted-foreground">{t('gallery.filterByTag')}:</span>
+          {allTags.map((t_) => (
+            <Badge
+              key={t_}
+              variant={tag === t_ ? 'default' : 'outline'}
+              className="cursor-pointer"
+              onClick={() => setSearchParams({ q, type, tag: tag === t_ ? '' : t_, page: 1 })}
+            >
+              {t_}
+            </Badge>
+          ))}
+          {tag && (
+            <button className="text-xs text-muted-foreground hover:text-foreground" onClick={() => setSearchParams({ q, type, page: 1 })}>
+              <FontAwesomeIcon icon={faXmark} className="h-3 w-3 mr-0.5" />{t('gallery.allTags')}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Bulk toolbar */}
+      {selectMode && (
+        <div className="flex items-center gap-2 flex-wrap p-3 rounded-lg border bg-muted/40">
+          <span className="text-sm font-medium mr-auto">
+            {selected.size > 0 ? t('gallery.selectedCount', { count: selected.size }) : t('gallery.selectMode')}
+          </span>
+          <Button variant="ghost" size="sm" onClick={selectAll} className="text-xs">{t('common.selectAll') || 'Select all'}</Button>
+          <Button variant="ghost" size="sm" onClick={() => setSelected(new Set())} disabled={selected.size === 0} className="text-xs">{t('common.deselectAll') || 'Deselect all'}</Button>
+
+          {/* Tag */}
+          {bulkTagOpen ? (
+            <form onSubmit={(e) => { e.preventDefault(); if (bulkTagInput.trim()) bulkAction('tag', { tags: bulkTagInput.split(',').map((s) => s.trim()) }); }}
+              className="flex gap-1">
+              <Input autoFocus value={bulkTagInput} onChange={(e) => setBulkTagInput(e.target.value)} placeholder={t('fileView.addTag')} className="h-8 w-40 text-xs" list="bulk-tag-suggestions" />
+              <datalist id="bulk-tag-suggestions">{allTags.map((t_) => <option key={t_} value={t_} />)}</datalist>
+              <Button size="sm" type="submit" disabled={!bulkTagInput.trim() || selected.size === 0}>{t('gallery.bulkTag')}</Button>
+              <Button size="sm" variant="ghost" type="button" onClick={() => setBulkTagOpen(false)}><FontAwesomeIcon icon={faXmark} /></Button>
+            </form>
+          ) : (
+            <Button size="sm" variant="outline" disabled={selected.size === 0} onClick={() => setBulkTagOpen(true)} className="gap-1.5">
+              <FontAwesomeIcon icon={faTag} className="h-3.5 w-3.5" />{t('gallery.bulkTag')}
+            </Button>
+          )}
+
+          {/* Add to collection */}
+          {bulkCollOpen ? (
+            <div className="flex gap-1 items-center">
+              <Select onValueChange={(collId) => { bulkAction('addToCollection', { collectionId: collId }); setBulkCollOpen(false); }}>
+                <SelectTrigger className="h-8 w-44 text-xs"><SelectValue placeholder={t('addToCollection.title')} /></SelectTrigger>
+                <SelectContent>
+                  {myCollections.map((c) => <SelectItem key={c.shortId} value={c.shortId}>{c.name}</SelectItem>)}
+                </SelectContent>
+              </Select>
+              <Button size="sm" variant="ghost" onClick={() => setBulkCollOpen(false)}><FontAwesomeIcon icon={faXmark} /></Button>
+            </div>
+          ) : (
+            <Button size="sm" variant="outline" disabled={selected.size === 0} onClick={() => setBulkCollOpen(true)} className="gap-1.5">
+              <FontAwesomeIcon icon={faFolderPlus} className="h-3.5 w-3.5" />{t('gallery.bulkAddToCollection')}
+            </Button>
+          )}
+
+          {/* Delete */}
+          <Button size="sm" variant="destructive" disabled={selected.size === 0} onClick={() => setBulkDeleteOpen(true)} className="gap-1.5">
+            <FontAwesomeIcon icon={faTrash} className="h-3.5 w-3.5" />{t('gallery.bulkDelete')}
+          </Button>
+        </div>
+      )}
+
+      {/* Bulk delete confirmation */}
+      <AlertDialog open={bulkDeleteOpen} onOpenChange={setBulkDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('gallery.bulkDeleteConfirmTitle', { count: selected.size })}</AlertDialogTitle>
+            <AlertDialogDescription>{t('gallery.bulkDeleteConfirmDesc')}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('fileView.cancel')}</AlertDialogCancel>
+            <AlertDialogAction onClick={() => bulkAction('delete')} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+              {t('gallery.bulkDelete')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* Grid */}
       {loading ? (
@@ -402,7 +600,17 @@ export default function Gallery() {
         </div>
       ) : (
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
-          {files.map((f) => <FileCard key={f._id} file={f} user={user} onDelete={fetchFiles} />)}
+          {files.map((f) => (
+            <FileCard
+              key={f._id}
+              file={f}
+              user={user}
+              onDelete={fetchFiles}
+              selectMode={selectMode}
+              selected={selected.has(f.shortId)}
+              onToggleSelect={toggleSelect}
+            />
+          ))}
         </div>
       )}
 

--- a/client/src/pages/Upload.jsx
+++ b/client/src/pages/Upload.jsx
@@ -161,13 +161,34 @@ export default function Upload() {
   const fileInputRef = useRef(null);
 
   const addFiles = useCallback((incoming) => {
-    // incoming: { file: File, path: string }[]
     setFiles((prev) => {
       const existing = new Set(prev.map((item) => item.path + item.file.size));
       const news = incoming.filter((item) => !existing.has(item.path + item.file.size));
       return [...prev, ...news];
     });
   }, []);
+
+  useEffect(() => {
+    async function handlePaste(e) {
+      const items = Array.from(e.clipboardData?.items || []);
+      const collected = [];
+      for (const item of items) {
+        if (item.kind !== 'file') continue;
+        const raw = item.getAsFile();
+        if (!raw) continue;
+        const isGenericName = raw.name === 'image.png' || raw.name === 'image.jpeg';
+        const ext = raw.type.split('/')[1] || 'bin';
+        const name = isGenericName ? `clipboard-${Date.now()}.${ext}` : raw.name;
+        collected.push({ file: new File([raw], name, { type: raw.type }), path: name });
+      }
+      if (collected.length > 0) {
+        addFiles(collected);
+        toast({ title: t('upload.pastedFiles', { count: collected.length }) });
+      }
+    }
+    window.addEventListener('paste', handlePaste);
+    return () => window.removeEventListener('paste', handlePaste);
+  }, [addFiles, toast, t]);
 
   function removeFile(idx) {
     setFiles((prev) => prev.filter((_, i) => i !== idx));
@@ -331,6 +352,7 @@ export default function Upload() {
             {t('upload.selectFiles')}
           </Button>
           <p className="text-xs text-muted-foreground mt-3">{t('upload.folderDropHint')}</p>
+        <p className="text-xs text-muted-foreground mt-1">{t('upload.pasteHint')}</p>
         </div>
 
         <input ref={fileInputRef} type="file" multiple hidden onChange={handleFileSelect} />

--- a/src/models/File.js
+++ b/src/models/File.js
@@ -45,6 +45,10 @@ const fileSchema = new mongoose.Schema({
     type: Number,
     default: 0,
   },
+  tags: {
+    type: [{ type: String, trim: true, maxlength: 50 }],
+    default: [],
+  },
   createdAt: {
     type: Date,
     default: Date.now,

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -187,6 +187,83 @@ router.delete('/file/:shortId', requireLogin, async (req, res) => {
   res.json({ success: true });
 });
 
+// ── Update file tags / name ─────────────────────────────────────────────────
+router.patch('/file/:shortId', requireLogin, async (req, res) => {
+  const file = await File.findOne({ shortId: req.params.shortId });
+  if (!file) return res.status(404).json({ error: 'File not found' });
+
+  const isOwner = file.uploader.toString() === req.session.user.id.toString();
+  if (!isOwner && req.session.user.role !== 'admin') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  if (Array.isArray(req.body.tags)) {
+    file.tags = req.body.tags.slice(0, 20).map((t) => t.trim().slice(0, 50)).filter(Boolean);
+  }
+  if (req.body.originalName !== undefined) {
+    const name = sanitizeFilename(req.body.originalName.trim()).slice(0, 255);
+    if (name) file.originalName = name;
+  }
+
+  await file.save();
+  res.json({ tags: file.tags, originalName: file.originalName });
+});
+
+// ── Bulk operations ──────────────────────────────────────────────────────────
+router.post('/files/bulk', requireLogin, async (req, res) => {
+  const { action, shortIds, tags, collectionId } = req.body;
+  if (!Array.isArray(shortIds) || shortIds.length === 0) {
+    return res.status(400).json({ error: 'No files specified' });
+  }
+
+  const isAdmin = req.session.user.role === 'admin';
+  const filter = { shortId: { $in: shortIds } };
+  if (!isAdmin) filter.uploader = req.session.user.id;
+
+  if (action === 'delete') {
+    const files = await File.find(filter);
+    for (const file of files) {
+      const ownerId = file.uploader.toString();
+      const { shortId } = file;
+      await deleteFileRecord(req, file);
+      broadcast('file:deleted', { shortId, uploaderId: ownerId }, (c) => c.userId === ownerId);
+    }
+    broadcast('stats:invalidate', {}, (c) => c.isAdmin);
+    return res.json({ success: true, count: shortIds.length });
+  }
+
+  if (action === 'tag') {
+    const newTags = (tags || []).slice(0, 20).map((t) => t.trim().slice(0, 50)).filter(Boolean);
+    await File.updateMany(filter, { $addToSet: { tags: { $each: newTags } } });
+    return res.json({ success: true });
+  }
+
+  if (action === 'addToCollection') {
+    if (!collectionId) return res.status(400).json({ error: 'Collection ID required' });
+    const collection = await Collection.findOne({ shortId: collectionId });
+    if (!collection) return res.status(404).json({ error: 'Collection not found' });
+    const isCollOwner = collection.owner.toString() === req.session.user.id.toString();
+    if (!isCollOwner && !isAdmin) return res.status(403).json({ error: 'Forbidden' });
+    const files = await File.find(filter);
+    for (const file of files) {
+      if (!collection.files.some((f) => f.toString() === file._id.toString())) {
+        collection.files.push(file._id);
+      }
+    }
+    await collection.save();
+    return res.json({ success: true });
+  }
+
+  res.status(400).json({ error: 'Invalid action' });
+});
+
+// ── Tag suggestions for current user ────────────────────────────────────────
+router.get('/tags', requireLogin, async (req, res) => {
+  const filter = req.session.user.role === 'admin' ? {} : { uploader: req.session.user.id };
+  const tags = await File.distinct('tags', filter);
+  res.json({ tags: tags.filter(Boolean).sort() });
+});
+
 // ── File metadata ───────────────────────────────────────────────────────────
 router.get('/file/:shortId', async (req, res) => {
   const file = await File.findOne({ shortId: req.params.shortId }).populate('uploader', 'username avatarExt');
@@ -203,7 +280,7 @@ router.get('/file/:shortId', async (req, res) => {
 
 // ── Gallery ─────────────────────────────────────────────────────────────────
 router.get('/gallery', requireLogin, async (req, res) => {
-  const { q, type, page: pageStr } = req.query;
+  const { q, type, tag, page: pageStr } = req.query;
   const page = Math.max(1, parseInt(pageStr || '1', 10));
   const PAGE_SIZE = 24;
   const isAdmin = req.session.user.role === 'admin';
@@ -211,6 +288,7 @@ router.get('/gallery', requireLogin, async (req, res) => {
   const filter = {};
   if (!isAdmin) filter.uploader = req.session.user.id;
   if (q) filter.originalName = { $regex: escapeRegex(q), $options: 'i' };
+  if (tag) filter.tags = tag;
 
   if (type && type !== 'all') {
     const typeMap = { image: /^image\//, video: /^video\//, audio: /^audio\//, pdf: /^application\/pdf$/ };
@@ -260,6 +338,7 @@ router.get('/gallery', requireLogin, async (req, res) => {
 });
 
 // ── ShareX config ───────────────────────────────────────────────────────────
+
 // Regenerates the API key and embeds the new plaintext into the .sxcu file.
 // The plaintext is never persisted — this is the only moment it is visible.
 router.get('/sharex-config', requireLogin, async (req, res) => {


### PR DESCRIPTION
Clipboard upload:
- Paste (Ctrl+V) on the upload page captures images/text from clipboard
- Auto-generates filename (clipboard-<timestamp>.png) for generic names
- Hint text shown in the drop zone

Tags:
- tags[] field added to File model
- PATCH /api/file/:shortId — update tags and/or originalName
- GET /api/tags — distinct tag list for the current user (autocomplete)
- Gallery /api/gallery now supports ?tag= filter
- FileView: tag chips with inline add/remove (owner only), autocomplete via datalist
- Gallery FileCard shows up to 3 tag badges

Bulk actions (Gallery):
- "Select" toggle activates checkbox mode on all file cards
- Bulk toolbar: tag (comma-separated, with autocomplete), add to collection, delete
- POST /api/files/bulk — delete / tag / addToCollection
- Tag filter chip strip shown when user has tags

i18n: all 8 languages updated

https://claude.ai/code/session_01STUqMEJrbV2KyffHbv9g1X