### PR TITLE
fix: restore copyUrl and handleDelete lost during hooks refactoring

### DIFF
--- a/client/src/pages/FileView.jsx
+++ b/client/src/pages/FileView.jsx
@@ -196,6 +196,22 @@ function FileViewInner() {
     fetch('/api/tags').then((r) => r.ok ? r.json() : { tags: [] }).then((d) => setTagSuggestions(d.tags));
   }, [canEdit]);
 
+  async function handleDelete() {
+    const r = await fetch(`/api/file/${shortId}`, { method: 'DELETE' });
+    if (r.ok) {
+      toast({ title: t('fileView.fileDeleted') });
+      navigate('/gallery');
+    } else {
+      toast({ title: t('fileView.deleteFailed'), variant: 'destructive' });
+    }
+  }
+
+  function copyUrl() {
+    const url = `${window.location.origin}/f/${shortId}`;
+    navigator.clipboard.writeText(url);
+    toast({ title: t('fileView.urlCopied') });
+  }
+
   if (error) {
     return (
       <div className="flex flex-col items-center justify-center py-24 gap-4">


### PR DESCRIPTION
Both functions were accidentally dropped when all hooks were moved to the top of FileViewInner to satisfy Rules of Hooks. Re-added them before the early returns so they are in scope for the render section.

https://claude.ai/code/session_01STUqMEJrbV2KyffHbv9g1X