### PR TITLE
test: add Playwright E2E tests + GitHub Actions CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,62 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      mongo:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --eval 'db.adminCommand(\"ping\")'"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      MONGODB_URI: mongodb://localhost:27017/sharely_e2e
+      SESSION_SECRET: ci-test-secret-that-is-long-enough-for-ci
+      PORT: 3099
+      E2E_PORT: 3099
+      BASE_URL: http://localhost:3099
+      UPLOAD_DIR: /tmp/sharely-e2e-uploads
+      NODE_ENV: test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install backend dependencies
+        run: npm ci
+
+      - name: Install frontend dependencies & build
+        run: |
+          cd client
+          npm ci
+          npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/e2e/gallery.spec.js
+++ b/e2e/gallery.spec.js
@@ -1,0 +1,80 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsAdmin } = require('./helpers');
+
+test.describe('Gallery – UI & Bulk Actions', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test('Upload and Select buttons are the same height', async ({ page }) => {
+    await page.goto('/gallery');
+    const uploadBtn = page.getByRole('link', { name: /upload/i });
+    const selectBtn = page.getByRole('button', { name: /^select$/i });
+
+    await expect(uploadBtn).toBeVisible();
+    await expect(selectBtn).toBeVisible();
+
+    const uploadBox = await uploadBtn.boundingBox();
+    const selectBox = await selectBtn.boundingBox();
+    expect(Math.abs(uploadBox.height - selectBox.height)).toBeLessThanOrEqual(2);
+  });
+
+  test('Search input, All Types select and Search button are the same height', async ({ page }) => {
+    await page.goto('/gallery');
+    const searchInput = page.locator('input[placeholder*="Search"]').first();
+    const typeSelect = page.locator('[data-radix-select-trigger]').first();
+    const searchBtn = page.getByRole('button', { name: /^search$/i });
+
+    const inputBox = await searchInput.boundingBox();
+    const selectBox = await typeSelect.boundingBox();
+    const btnBox = await searchBtn.boundingBox();
+
+    expect(Math.abs(inputBox.height - selectBox.height)).toBeLessThanOrEqual(2);
+    expect(Math.abs(inputBox.height - btnBox.height)).toBeLessThanOrEqual(2);
+  });
+
+  test('select mode shows checkboxes and toolbar', async ({ page }) => {
+    await page.goto('/gallery');
+    // Upload a file first to have something to select
+    await page.goto('/upload');
+    const fileInput = page.locator('input[type="file"]').first();
+    await fileInput.setInputFiles({ name: 'bulk-test.txt', mimeType: 'text/plain', buffer: Buffer.from('bulk') });
+    await page.getByRole('button', { name: /upload/i }).first().click();
+    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 10_000 });
+
+    await page.goto('/gallery');
+    await page.getByRole('button', { name: /^select$/i }).click();
+
+    // Toolbar should appear
+    await expect(page.getByText(/select all/i)).toBeVisible();
+    await expect(page.getByText(/deselect all/i)).toBeVisible();
+
+    // Select all
+    await page.getByRole('button', { name: /select all/i }).click();
+    const selectedText = page.locator('text=/\\d+ selected/');
+    await expect(selectedText).toBeVisible();
+  });
+
+  test('bulk delete removes selected files', async ({ page }) => {
+    // Upload a file specifically for deletion
+    await page.goto('/upload');
+    const fileInput = page.locator('input[type="file"]').first();
+    await fileInput.setInputFiles({ name: 'delete-me.txt', mimeType: 'text/plain', buffer: Buffer.from('to delete') });
+    await page.getByRole('button', { name: /upload/i }).first().click();
+    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 10_000 });
+
+    await page.goto('/gallery');
+    await page.getByRole('button', { name: /^select$/i }).click();
+
+    // Select the first file
+    await page.locator('[data-radix-checkbox-root]').first().click();
+
+    // Click delete
+    await page.getByRole('button', { name: /^delete$/i }).click();
+
+    // Confirm in AlertDialog
+    await page.getByRole('button', { name: /delete/i }).last().click();
+
+    await expect(page.getByText(/files deleted/i)).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/e2e/global-setup.js
+++ b/e2e/global-setup.js
@@ -1,0 +1,48 @@
+const { request } = require('@playwright/test');
+
+const PORT = process.env.E2E_PORT || '3099';
+const BASE = `http://localhost:${PORT}`;
+
+// Credentials reused across all spec files via process.env
+process.env.E2E_ADMIN_USER = 'e2eadmin';
+process.env.E2E_ADMIN_PASS = 'E2eAdminPass123!';
+process.env.E2E_USER = 'e2euser';
+process.env.E2E_PASS = 'E2eUserPass123!';
+
+module.exports = async function globalSetup() {
+  const api = await request.newContext({ baseURL: BASE });
+
+  // Complete first-run wizard (no-op if already done)
+  const status = await api.get('/api/install/status');
+  const { installed } = await status.json();
+
+  if (!installed) {
+    const r = await api.post('/api/install/setup', {
+      data: {
+        username: process.env.E2E_ADMIN_USER,
+        password: process.env.E2E_ADMIN_PASS,
+        confirmPassword: process.env.E2E_ADMIN_PASS,
+        operatorName: 'E2E Test',
+        operatorAddress: 'Test Street 1',
+        operatorEmail: 'e2e@test.local',
+        allowRegistration: true,
+      },
+    });
+    if (!r.ok()) throw new Error(`Install failed: ${await r.text()}`);
+    console.log('✅ App installed (admin created)');
+  }
+
+  // Ensure regular test user exists (register if not)
+  const loginR = await api.post('/api/auth/login', {
+    data: { username: process.env.E2E_USER, password: process.env.E2E_PASS },
+  });
+  if (loginR.status() === 401) {
+    const regR = await api.post('/api/auth/register', {
+      data: { username: process.env.E2E_USER, password: process.env.E2E_PASS },
+    });
+    if (!regR.ok()) throw new Error(`Register test user failed: ${await regR.text()}`);
+    console.log('✅ Test user created');
+  }
+
+  await api.dispose();
+};

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -1,0 +1,35 @@
+const path = require('path');
+const fs = require('fs');
+
+async function login(page, username, password) {
+  await page.goto('/auth/login');
+  await page.getByLabel(/username/i).fill(username);
+  await page.getByLabel(/password/i).fill(password);
+  await page.getByRole('button', { name: /^login$/i }).click();
+  await page.waitForURL(/\/gallery/);
+}
+
+async function loginAsAdmin(page) {
+  await login(page, process.env.E2E_ADMIN_USER, process.env.E2E_ADMIN_PASS);
+}
+
+async function loginAsUser(page) {
+  await login(page, process.env.E2E_USER, process.env.E2E_PASS);
+}
+
+// Upload a small text file via the API and return its shortId
+async function uploadFileViaApi(request, baseURL, cookie) {
+  const content = `E2E test file ${Date.now()}`;
+  const blob = Buffer.from(content);
+  const form = new FormData();
+  form.append('files', new Blob([blob], { type: 'text/plain' }), 'e2e-test.txt');
+
+  const r = await request.post('/api/web-upload', {
+    multipart: { files: { name: 'e2e-test.txt', mimeType: 'text/plain', buffer: Buffer.from(content) } },
+  });
+  if (!r.ok()) throw new Error(`Upload failed: ${await r.text()}`);
+  const data = await r.json();
+  return data.files[0].shortId;
+}
+
+module.exports = { login, loginAsAdmin, loginAsUser, uploadFileViaApi };

--- a/e2e/sharelink.spec.js
+++ b/e2e/sharelink.spec.js
@@ -1,0 +1,40 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsAdmin } = require('./helpers');
+
+test.describe('Share Links', () => {
+  let fileShortId;
+
+  test.beforeEach(async ({ page, request }) => {
+    await loginAsAdmin(page);
+
+    // Upload a file via API to use for share link tests
+    const r = await request.post('/api/web-upload', {
+      multipart: {
+        files: { name: 'share-test.txt', mimeType: 'text/plain', buffer: Buffer.from('share link test') },
+      },
+    });
+    const data = await r.json();
+    fileShortId = data.files?.[0]?.shortId;
+  });
+
+  test('download limit=1: second browser visit redirects to share page', async ({ page, request }) => {
+    if (!fileShortId) test.skip();
+
+    // Create share link with limit=1 via API
+    const linkR = await request.post('/api/share', {
+      data: { fileShortId, downloadLimit: 1 },
+    });
+    const { link } = await linkR.json();
+    const token = link.token;
+
+    // First download (use fetch to not navigate away)
+    const dl1 = await request.get(`/s/${token}/download`);
+    expect(dl1.ok()).toBeTruthy();
+
+    // Second visit in browser — should redirect to share view, not show raw JSON
+    const response = await page.goto(`/s/${token}/download`);
+    // Should end up at the share view page, not a JSON error
+    await expect(page).toHaveURL(new RegExp(`/s/${token}$`));
+    await expect(page.getByText(/limit reached|download limit/i)).toBeVisible();
+  });
+});

--- a/e2e/tags.spec.js
+++ b/e2e/tags.spec.js
@@ -1,0 +1,75 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsAdmin } = require('./helpers');
+
+test.describe('Predefined Tag Management', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test('add predefined tags in Settings', async ({ page }) => {
+    await page.goto('/settings');
+    await page.getByRole('tab', { name: /preferences/i }).click();
+
+    // Tag Management card should be visible
+    await expect(page.getByText(/tag management/i)).toBeVisible();
+
+    // Add tag "Design"
+    await page.getByPlaceholder(/new tag/i).fill('Design');
+    await page.getByRole('button', { name: /^add$/i }).click();
+    await expect(page.getByText('Design')).toBeVisible();
+
+    // Add tag "Code"
+    await page.getByPlaceholder(/new tag/i).fill('Code');
+    await page.getByRole('button', { name: /^add$/i }).click();
+    await expect(page.getByText('Code')).toBeVisible();
+  });
+
+  test('remove predefined tag', async ({ page }) => {
+    // First add a tag to remove
+    await page.goto('/settings');
+    await page.getByRole('tab', { name: /preferences/i }).click();
+    await page.getByPlaceholder(/new tag/i).fill('ToRemove');
+    await page.getByRole('button', { name: /^add$/i }).click();
+    await expect(page.getByText('ToRemove')).toBeVisible();
+
+    // Remove it
+    const badge = page.locator('text=ToRemove').locator('..');
+    await badge.getByRole('button').click();
+    await expect(page.getByText('ToRemove')).not.toBeVisible();
+  });
+
+  test('tag dropdown appears in FileView after defining tags', async ({ page, request }) => {
+    // Ensure tags exist (add via API)
+    await request.patch('/api/user/predefined-tags', {
+      data: { tags: ['Design', 'Code'] },
+    });
+
+    // Upload a file via UI
+    await page.goto('/upload');
+    const fileInput = page.locator('input[type="file"]').first();
+    await fileInput.setInputFiles({
+      name: 'e2e-tag-test.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('tag test content'),
+    });
+    await page.getByRole('button', { name: /upload/i }).first().click();
+    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 10_000 });
+
+    // Navigate to the file
+    await page.goto('/gallery');
+    await page.locator('a[href^="/f/"]').first().click();
+    await page.waitForURL(/\/f\//);
+
+    // Tag section should have a dropdown (Select trigger)
+    const tagSelect = page.locator('[data-radix-select-trigger]').first();
+    if (await tagSelect.isVisible()) {
+      await tagSelect.click();
+      await expect(page.getByRole('option', { name: 'Design' })).toBeVisible();
+      await expect(page.getByRole('option', { name: 'Code' })).toBeVisible();
+
+      // Select a tag
+      await page.getByRole('option', { name: 'Design' }).click();
+      await expect(page.getByText('Design')).toBeVisible();
+    }
+  });
+});

--- a/e2e/upload.spec.js
+++ b/e2e/upload.spec.js
@@ -1,0 +1,31 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsAdmin } = require('./helpers');
+
+test.describe('Upload Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test('shows clipboard paste hint', async ({ page }) => {
+    await page.goto('/upload');
+    await expect(page.getByText(/ctrl\+v|clipboard/i)).toBeVisible();
+  });
+
+  test('shows folder drop hint', async ({ page }) => {
+    await page.goto('/upload');
+    await expect(page.getByText(/drag.*drop|drop.*folder/i)).toBeVisible();
+  });
+
+  test('file upload flow completes', async ({ page }) => {
+    await page.goto('/upload');
+    const fileInput = page.locator('input[type="file"]').first();
+    await fileInput.setInputFiles({
+      name: 'e2e-upload.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('E2E upload test'),
+    });
+    await expect(page.getByText(/1 file selected/i)).toBeVisible();
+    await page.getByRole('button', { name: /upload/i }).first().click();
+    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "ws": "^8.21.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "nodemon": "^3.1.3"
       },
       "engines": {
@@ -47,6 +48,22 @@
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@types/webidl-conversions": {
@@ -1339,6 +1356,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "dev": "nodemon app.js",
     "build": "cd client && npm install && npm run build",
     "migrate:user-folders": "node scripts/migrate-uploads-to-user-folders.js",
-    "migrate:thumbnails": "node scripts/generate-missing-thumbnails.js"
+    "migrate:thumbnails": "node scripts/generate-missing-thumbnails.js",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
@@ -25,6 +27,7 @@
     "ws": "^8.21.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "nodemon": "^3.1.3"
   },
   "engines": {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,36 @@
+const { defineConfig } = require('@playwright/test');
+
+const PORT = process.env.E2E_PORT || '3099';
+const MONGO = process.env.MONGODB_URI || `mongodb://localhost:27017/sharely_e2e_${Date.now()}`;
+
+module.exports = defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    headless: true,
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+
+  webServer: {
+    command: `node app.js`,
+    url: `http://localhost:${PORT}/api/install/status`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 20_000,
+    env: {
+      MONGODB_URI: MONGO,
+      SESSION_SECRET: 'e2e-test-secret-that-is-long-enough-12345',
+      PORT,
+      BASE_URL: `http://localhost:${PORT}`,
+      UPLOAD_DIR: '/tmp/sharely-e2e-uploads',
+      NODE_ENV: 'test',
+    },
+  },
+
+  globalSetup: './e2e/global-setup.js',
+});


### PR DESCRIPTION
Sets up end-to-end testing so Claude can verify features autonomously:

- playwright.config.js: starts backend with in-memory-friendly config
- e2e/global-setup.js: runs install wizard + creates test user via API
- e2e/tags.spec.js: predefined tag settings + FileView dropdown
- e2e/gallery.spec.js: button height alignment, select mode, bulk delete
- e2e/upload.spec.js: clipboard hint text, file upload flow
- e2e/sharelink.spec.js: download limit=1 redirects to share page
- .github/workflows/e2e.yml: CI with MongoDB 7 service, Playwright report artifact

Run locally: npm run test:e2e (requires MONGODB_URI)

https://claude.ai/code/session_01STUqMEJrbV2KyffHbv9g1X