### PR TITLE
test(e2e): add missing E2E tests for tags, bulk-tag, and admin users

### DIFF
--- a/e2e/admin.spec.js
+++ b/e2e/admin.spec.js
@@ -1,0 +1,29 @@
+const { test, expect } = require('@playwright/test');
+
+// storageState (admin session) applied globally via playwright.config.js
+
+test.describe('Admin – User Management', () => {
+  test('create-user form inputs and button are the same height', async ({ page }) => {
+    await page.goto('/admin/users');
+
+    // Username input, Password input, Role select trigger, Create button all use h-10
+    const usernameInput = page.locator('form input').nth(0);
+    const passwordInput = page.locator('form input[type="password"]').first();
+    const roleSelect = page.locator('form [role="combobox"]').first();
+    const createBtn = page.getByRole('button', { name: /^create$/i });
+
+    await expect(createBtn).toBeVisible({ timeout: 10_000 });
+
+    const boxes = await Promise.all([
+      usernameInput.boundingBox(),
+      passwordInput.boundingBox(),
+      roleSelect.boundingBox(),
+      createBtn.boundingBox(),
+    ]);
+
+    const [uBox, pBox, rBox, bBox] = boxes;
+    expect(Math.abs(uBox.height - pBox.height)).toBeLessThanOrEqual(2);
+    expect(Math.abs(uBox.height - rBox.height)).toBeLessThanOrEqual(2);
+    expect(Math.abs(uBox.height - bBox.height)).toBeLessThanOrEqual(2);
+  });
+});

--- a/e2e/gallery.spec.js
+++ b/e2e/gallery.spec.js
@@ -51,6 +51,57 @@ test.describe('Gallery – UI & Bulk Actions', () => {
     await expect(page.locator('text=/\\d+ selected/')).toBeVisible();
   });
 
+  test('bulk toolbar shows disabled Tag button when no predefined tags', async ({ page }) => {
+    // Ensure no predefined tags exist
+    await page.request.patch('/api/user/predefined-tags', { data: { tags: [] } });
+
+    // Upload a file to ensure the gallery isn't empty
+    await page.goto('/upload');
+    await page.locator('input[type="file"]').first().setInputFiles({
+      name: 'bulk-notag.txt', mimeType: 'text/plain', buffer: Buffer.from('no tag test'),
+    });
+    await page.getByRole('button', { name: /upload \d/i }).click();
+    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 10_000 });
+
+    await page.goto('/gallery');
+    await page.getByRole('button', { name: /^select$/i }).click();
+
+    // Without predefined tags the toolbar renders a plain disabled "Tag" button
+    const tagBtn = page.getByRole('button', { name: /^tag$/i });
+    await expect(tagBtn).toBeVisible({ timeout: 5_000 });
+    await expect(tagBtn).toBeDisabled();
+  });
+
+  test('bulk tag applies a predefined tag to selected files', async ({ page }) => {
+    // Set up predefined tags
+    await page.request.patch('/api/user/predefined-tags', { data: { tags: ['BulkLabel'] } });
+
+    // Upload a file
+    await page.goto('/upload');
+    await page.locator('input[type="file"]').first().setInputFiles({
+      name: 'bulk-tag-test.txt', mimeType: 'text/plain', buffer: Buffer.from('bulk tag test'),
+    });
+    await page.getByRole('button', { name: /upload \d/i }).click();
+    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 10_000 });
+
+    await page.goto('/gallery');
+    await page.getByRole('button', { name: /^select$/i }).click();
+
+    // Select the first file
+    await page.locator('[role="checkbox"]').first().click();
+    await expect(page.locator('text=/1 selected/')).toBeVisible();
+
+    // Open the tag dropdown in the bulk toolbar and pick "BulkLabel"
+    // The bulk toolbar tag trigger is a combobox (SelectTrigger) — last one on the page
+    const tagSelects = page.locator('[role="combobox"]');
+    const count = await tagSelects.count();
+    await tagSelects.nth(count - 1).click();
+    await page.getByRole('option', { name: 'BulkLabel' }).click();
+
+    // Toast: "Tags added"
+    await expect(page.getByText(/tags added/i)).toBeVisible({ timeout: 5_000 });
+  });
+
   test('bulk delete removes selected files', async ({ page }) => {
     // Upload a dedicated file for deletion
     await page.goto('/upload');

--- a/e2e/tags.spec.js
+++ b/e2e/tags.spec.js
@@ -66,4 +66,48 @@ test.describe('Predefined Tag Management', () => {
     await page.getByRole('option', { name: 'Design' }).click();
     await expect(page.locator('text=Design').first()).toBeVisible();
   });
+
+  test('selecting a tag in FileView saves it and shows the badge', async ({ page }) => {
+    await page.request.patch('/api/user/predefined-tags', {
+      data: { tags: ['Frontend', 'Backend'] },
+    });
+
+    // Upload a file
+    await page.goto('/upload');
+    await page.locator('input[type="file"]').first().setInputFiles({
+      name: 'fileview-tag-save.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('fileview tag save test'),
+    });
+    await page.getByRole('button', { name: /upload \d/i }).click();
+    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 10_000 });
+
+    // Navigate to the file
+    await page.goto('/gallery');
+    await page.locator('a[href^="/f/"]').first().click();
+    await page.waitForURL(/\/f\//);
+
+    // Pick "Frontend" from the tag dropdown
+    const tagSelect = page.locator('[role="combobox"]');
+    await expect(tagSelect.first()).toBeVisible({ timeout: 10_000 });
+    await tagSelect.first().click();
+    await page.getByRole('option', { name: 'Frontend' }).click();
+
+    // Toast: "Tags saved"
+    await expect(page.getByText(/tags saved/i)).toBeVisible({ timeout: 5_000 });
+
+    // Tag badge should be visible in the tags card
+    await expect(page.getByText('Frontend').first()).toBeVisible();
+  });
+
+  test('Settings Preferences shows no-tags hint when list is empty', async ({ page }) => {
+    // Clear all predefined tags
+    await page.request.patch('/api/user/predefined-tags', { data: { tags: [] } });
+
+    await page.goto('/settings');
+    await page.getByRole('tab', { name: /preferences/i }).click();
+
+    // "No tags defined yet" hint should be visible
+    await expect(page.getByText(/no tags defined yet/i)).toBeVisible({ timeout: 5_000 });
+  });
 });


### PR DESCRIPTION
- tags.spec.js: add test for FileView tag-save (toast + badge), and Settings no-tags hint text when predefined list is empty
- gallery.spec.js: add test for disabled Tag button in bulk toolbar when no predefined tags exist, and bulk-tag flow (select file → pick tag → toast)
- admin.spec.js: new spec — create-user form height alignment (Username input, Password input, Role select, Create button all h-10)

https://claude.ai/code/session_01STUqMEJrbV2KyffHbv9g1X