### PR TITLE
Add bulk tag removal and collection move operations

### DIFF
--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -107,6 +107,10 @@
     "bulkDeleted": "{{count}} Dateien gelöscht",
     "bulkTagged": "Tags hinzugefügt",
     "bulkAddedToCollection": "Zur Sammlung hinzugefügt",
+    "bulkRemoveTag": "Tag entfernen",
+    "bulkMoveToCollection": "In Sammlung verschieben",
+    "bulkTagRemoved": "Tags entfernt",
+    "bulkMoved": "In Sammlung verschoben",
     "filterByTag": "Nach Tag filtern",
     "allTags": "Alle Tags",
     "noTags": "Keine Tags"

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -107,6 +107,10 @@
     "bulkDeleted": "{{count}} files deleted",
     "bulkTagged": "Tags added",
     "bulkAddedToCollection": "Added to collection",
+    "bulkRemoveTag": "Remove tag",
+    "bulkMoveToCollection": "Move to collection",
+    "bulkTagRemoved": "Tags removed",
+    "bulkMoved": "Moved to collection",
     "filterByTag": "Filter by tag",
     "allTags": "All tags",
     "noTags": "No tags"

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -81,6 +81,10 @@
     "bulkDeleted": "{{count}} archivos eliminados",
     "bulkTagged": "Etiquetas añadidas",
     "bulkAddedToCollection": "Añadido a la colección",
+    "bulkRemoveTag": "Eliminar etiqueta",
+    "bulkMoveToCollection": "Mover a colección",
+    "bulkTagRemoved": "Etiquetas eliminadas",
+    "bulkMoved": "Movido a la colección",
     "filterByTag": "Filtrar por etiqueta",
     "allTags": "Todas las etiquetas",
     "noTags": "Sin etiquetas"

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -81,6 +81,10 @@
     "bulkDeleted": "{{count}} fichiers supprimés",
     "bulkTagged": "Tags ajoutés",
     "bulkAddedToCollection": "Ajouté à la collection",
+    "bulkRemoveTag": "Supprimer le tag",
+    "bulkMoveToCollection": "Déplacer vers la collection",
+    "bulkTagRemoved": "Tags supprimés",
+    "bulkMoved": "Déplacé vers la collection",
     "filterByTag": "Filtrer par tag",
     "allTags": "Tous les tags",
     "noTags": "Aucun tag"

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -81,6 +81,10 @@
     "bulkDeleted": "{{count}} file eliminati",
     "bulkTagged": "Tag aggiunti",
     "bulkAddedToCollection": "Aggiunto alla raccolta",
+    "bulkRemoveTag": "Rimuovi tag",
+    "bulkMoveToCollection": "Sposta nella raccolta",
+    "bulkTagRemoved": "Tag rimossi",
+    "bulkMoved": "Spostato nella raccolta",
     "filterByTag": "Filtra per tag",
     "allTags": "Tutti i tag",
     "noTags": "Nessun tag"

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -81,6 +81,10 @@
     "bulkDeleted": "{{count}}件のファイルを削除しました",
     "bulkTagged": "タグを追加しました",
     "bulkAddedToCollection": "コレクションに追加しました",
+    "bulkRemoveTag": "タグを削除",
+    "bulkMoveToCollection": "コレクションに移動",
+    "bulkTagRemoved": "タグを削除しました",
+    "bulkMoved": "コレクションに移動しました",
     "filterByTag": "タグで絞り込む",
     "allTags": "すべてのタグ",
     "noTags": "タグなし"

--- a/client/src/i18n/locales/pt.json
+++ b/client/src/i18n/locales/pt.json
@@ -81,6 +81,10 @@
     "bulkDeleted": "{{count}} arquivos excluídos",
     "bulkTagged": "Tags adicionadas",
     "bulkAddedToCollection": "Adicionado à coleção",
+    "bulkRemoveTag": "Remover tag",
+    "bulkMoveToCollection": "Mover para coleção",
+    "bulkTagRemoved": "Tags removidas",
+    "bulkMoved": "Movido para a coleção",
     "filterByTag": "Filtrar por tag",
     "allTags": "Todas as tags",
     "noTags": "Sem tags"

--- a/client/src/i18n/locales/zh.json
+++ b/client/src/i18n/locales/zh.json
@@ -81,6 +81,10 @@
     "bulkDeleted": "已删除 {{count}} 个文件",
     "bulkTagged": "已添加标签",
     "bulkAddedToCollection": "已添加到合集",
+    "bulkRemoveTag": "移除标签",
+    "bulkMoveToCollection": "移动到合集",
+    "bulkTagRemoved": "标签已移除",
+    "bulkMoved": "已移动到合集",
     "filterByTag": "按标签筛选",
     "allTags": "所有标签",
     "noTags": "无标签"

--- a/client/src/pages/Gallery.jsx
+++ b/client/src/pages/Gallery.jsx
@@ -35,7 +35,7 @@ import {
 import { useToast } from '@/hooks/use-toast';
 import { fmtSize } from '@/lib/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUpload, faMagnifyingGlass, faXmark, faImage, faVideo, faMusic, faFileLines, faCode, faFile, faLink, faDownload, faArrowUpRightFromSquare, faTrash, faEllipsisVertical, faCheckSquare, faTag, faFolderPlus } from '@fortawesome/free-solid-svg-icons';
+import { faUpload, faMagnifyingGlass, faXmark, faImage, faVideo, faMusic, faFileLines, faCode, faFile, faLink, faDownload, faArrowUpRightFromSquare, faTrash, faEllipsisVertical, faCheckSquare, faTag, faFolderPlus, faMinus, faArrowRight } from '@fortawesome/free-solid-svg-icons';
 import { Checkbox } from '@/components/ui/checkbox';
 import { useTranslation } from 'react-i18next';
 import { UserAvatar } from '@/components/UserAvatar';
@@ -338,6 +338,7 @@ export default function Gallery() {
   const [selected, setSelected] = useState(new Set());
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [bulkCollOpen, setBulkCollOpen] = useState(false);
+  const [bulkMoveCollOpen, setBulkMoveCollOpen] = useState(false);
   const [myCollections, setMyCollections] = useState([]);
   const [allTags, setAllTags] = useState([]);
   const [predefinedTags, setPredefinedTags] = useState([]);
@@ -385,12 +386,19 @@ export default function Gallery() {
     } else if (action === 'tag') {
       toast({ title: t('gallery.bulkTagged') });
       fetchFiles();
+    } else if (action === 'removeTag') {
+      toast({ title: t('gallery.bulkTagRemoved') });
+      fetchFiles();
     } else if (action === 'addToCollection') {
       toast({ title: t('gallery.bulkAddedToCollection') });
+    } else if (action === 'moveToCollection') {
+      toast({ title: t('gallery.bulkMoved') });
+      fetchFiles();
     }
     setSelected(new Set());
     setBulkDeleteOpen(false);
     setBulkCollOpen(false);
+    setBulkMoveCollOpen(false);
   }
 
   const fetchFiles = useCallback(async () => {
@@ -525,7 +533,7 @@ export default function Gallery() {
           <Button variant="ghost" size="sm" onClick={selectAll} className="text-xs">{t('common.selectAll') || 'Select all'}</Button>
           <Button variant="ghost" size="sm" onClick={() => setSelected(new Set())} disabled={selected.size === 0} className="text-xs">{t('common.deselectAll') || 'Deselect all'}</Button>
 
-          {/* Tag */}
+          {/* Tag hinzufügen */}
           {predefinedTags.length > 0 ? (
             <Select onValueChange={(tag) => bulkAction('tag', { tags: [tag] })} disabled={selected.size === 0} value="">
               <SelectTrigger className="h-8 w-44 text-xs" disabled={selected.size === 0}>
@@ -542,7 +550,28 @@ export default function Gallery() {
             </Button>
           )}
 
-          {/* Add to collection */}
+          {/* Tag entfernen */}
+          {allTags.length > 0 ? (
+            <Select onValueChange={(tag) => bulkAction('removeTag', { tags: [tag] })} disabled={selected.size === 0} value="">
+              <SelectTrigger className="h-8 w-44 text-xs" disabled={selected.size === 0}>
+                <span className="flex items-center gap-1 shrink-0">
+                  <FontAwesomeIcon icon={faMinus} className="h-2.5 w-2.5" />
+                  <FontAwesomeIcon icon={faTag} className="h-3.5 w-3.5 mr-1" />
+                </span>
+                <SelectValue placeholder={t('gallery.bulkRemoveTag')} />
+              </SelectTrigger>
+              <SelectContent>
+                {allTags.map((tag) => <SelectItem key={tag} value={tag}>{tag}</SelectItem>)}
+              </SelectContent>
+            </Select>
+          ) : (
+            <Button size="sm" variant="outline" disabled className="gap-1.5">
+              <FontAwesomeIcon icon={faMinus} className="h-2.5 w-2.5" />
+              <FontAwesomeIcon icon={faTag} className="h-3.5 w-3.5" />{t('gallery.bulkRemoveTag')}
+            </Button>
+          )}
+
+          {/* Zur Sammlung hinzufügen */}
           {bulkCollOpen ? (
             <div className="flex gap-1 items-center">
               <Select onValueChange={(collId) => { bulkAction('addToCollection', { collectionId: collId }); setBulkCollOpen(false); }}>
@@ -556,6 +585,23 @@ export default function Gallery() {
           ) : (
             <Button size="sm" variant="outline" disabled={selected.size === 0} onClick={() => setBulkCollOpen(true)} className="gap-1.5">
               <FontAwesomeIcon icon={faFolderPlus} className="h-3.5 w-3.5" />{t('gallery.bulkAddToCollection')}
+            </Button>
+          )}
+
+          {/* In Sammlung verschieben */}
+          {bulkMoveCollOpen ? (
+            <div className="flex gap-1 items-center">
+              <Select onValueChange={(collId) => { bulkAction('moveToCollection', { collectionId: collId }); setBulkMoveCollOpen(false); }}>
+                <SelectTrigger className="h-8 w-44 text-xs"><SelectValue placeholder={t('gallery.bulkMoveToCollection')} /></SelectTrigger>
+                <SelectContent>
+                  {myCollections.map((c) => <SelectItem key={c.shortId} value={c.shortId}>{c.name}</SelectItem>)}
+                </SelectContent>
+              </Select>
+              <Button size="sm" variant="ghost" onClick={() => setBulkMoveCollOpen(false)}><FontAwesomeIcon icon={faXmark} /></Button>
+            </div>
+          ) : (
+            <Button size="sm" variant="outline" disabled={selected.size === 0 || myCollections.length === 0} onClick={() => setBulkMoveCollOpen(true)} className="gap-1.5">
+              <FontAwesomeIcon icon={faArrowRight} className="h-3.5 w-3.5" />{t('gallery.bulkMoveToCollection')}
             </Button>
           )}
 

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -238,6 +238,13 @@ router.post('/files/bulk', requireLogin, async (req, res) => {
     return res.json({ success: true });
   }
 
+  if (action === 'removeTag') {
+    const tagsToRemove = (tags || []).map((t) => t.trim()).filter(Boolean);
+    if (tagsToRemove.length === 0) return res.status(400).json({ error: 'No tags specified' });
+    await File.updateMany(filter, { $pull: { tags: { $in: tagsToRemove } } });
+    return res.json({ success: true });
+  }
+
   if (action === 'addToCollection') {
     if (!collectionId) return res.status(400).json({ error: 'Collection ID required' });
     const collection = await Collection.findOne({ shortId: collectionId });
@@ -248,6 +255,24 @@ router.post('/files/bulk', requireLogin, async (req, res) => {
     for (const file of files) {
       if (!collection.files.some((f) => f.toString() === file._id.toString())) {
         collection.files.push(file._id);
+      }
+    }
+    await collection.save();
+    return res.json({ success: true });
+  }
+
+  if (action === 'moveToCollection') {
+    if (!collectionId) return res.status(400).json({ error: 'Collection ID required' });
+    const collection = await Collection.findOne({ shortId: collectionId });
+    if (!collection) return res.status(404).json({ error: 'Collection not found' });
+    const isCollOwner = collection.owner.toString() === req.session.user.id.toString();
+    if (!isCollOwner && !isAdmin) return res.status(403).json({ error: 'Forbidden' });
+    const files = await File.find(filter);
+    const fileIds = files.map((f) => f._id);
+    await Collection.updateMany({}, { $pull: { files: { $in: fileIds } } });
+    for (const fileId of fileIds) {
+      if (!collection.files.some((f) => f.toString() === fileId.toString())) {
+        collection.files.push(fileId);
       }
     }
     await collection.save();


### PR DESCRIPTION
## Summary
This PR adds two new bulk operations to the Gallery: the ability to remove tags from multiple files at once and to move files between collections (in addition to the existing "add to collection" feature).

## Key Changes
- **Bulk tag removal**: Added `removeTag` action that allows users to select multiple files and remove a specific tag from all of them at once
- **Bulk move to collection**: Added `moveToCollection` action that moves selected files from their current collections to a target collection (removes them from all other collections first)
- **UI enhancements**: 
  - Added new "Remove tag" dropdown selector in the bulk actions toolbar with minus icon
  - Added new "Move to collection" button in the bulk actions toolbar with arrow icon
  - Both new actions include proper state management and user feedback via toast notifications
- **Backend API**: Implemented both new actions in the `/files/bulk` endpoint with proper validation and authorization checks
- **Internationalization**: Added translation strings for all 8 supported languages (English, German, Spanish, French, Italian, Japanese, Portuguese, Chinese)

## Implementation Details
- The `moveToCollection` action removes selected files from all collections before adding them to the target collection, ensuring files exist in only one collection
- Both new actions properly handle the `selected` state cleanup and trigger a `fetchFiles()` refresh to update the UI
- New Font Awesome icons imported: `faMinus` and `faArrowRight` for visual consistency
- All bulk operations follow the existing pattern with proper error handling and permission checks

https://claude.ai/code/session_01YVHiAVvksXu4RSjrF1YTC2