### PR TITLE
Fix bulk tag removal and collection management in Gallery

### DIFF
--- a/client/src/pages/Gallery.jsx
+++ b/client/src/pages/Gallery.jsx
@@ -551,25 +551,30 @@ export default function Gallery() {
           )}
 
           {/* Tag entfernen */}
-          {allTags.length > 0 ? (
-            <Select onValueChange={(tag) => bulkAction('removeTag', { tags: [tag] })} disabled={selected.size === 0} value="">
-              <SelectTrigger className="h-8 w-44 text-xs" disabled={selected.size === 0}>
-                <span className="flex items-center gap-1 shrink-0">
-                  <FontAwesomeIcon icon={faMinus} className="h-2.5 w-2.5" />
-                  <FontAwesomeIcon icon={faTag} className="h-3.5 w-3.5 mr-1" />
-                </span>
-                <SelectValue placeholder={t('gallery.bulkRemoveTag')} />
-              </SelectTrigger>
-              <SelectContent>
-                {allTags.map((tag) => <SelectItem key={tag} value={tag}>{tag}</SelectItem>)}
-              </SelectContent>
-            </Select>
-          ) : (
-            <Button size="sm" variant="outline" disabled className="gap-1.5">
-              <FontAwesomeIcon icon={faMinus} className="h-2.5 w-2.5" />
-              <FontAwesomeIcon icon={faTag} className="h-3.5 w-3.5" />{t('gallery.bulkRemoveTag')}
-            </Button>
-          )}
+          {(() => {
+            const removableTags = [...new Set(
+              files.filter((f) => selected.has(f.shortId)).flatMap((f) => f.tags || []),
+            )].sort();
+            return removableTags.length > 0 ? (
+              <Select onValueChange={(tag) => bulkAction('removeTag', { tags: [tag] })} disabled={selected.size === 0} value="">
+                <SelectTrigger className="h-8 w-44 text-xs" disabled={selected.size === 0}>
+                  <span className="flex items-center gap-1 shrink-0">
+                    <FontAwesomeIcon icon={faMinus} className="h-2.5 w-2.5" />
+                    <FontAwesomeIcon icon={faTag} className="h-3.5 w-3.5 mr-1" />
+                  </span>
+                  <SelectValue placeholder={t('gallery.bulkRemoveTag')} />
+                </SelectTrigger>
+                <SelectContent>
+                  {removableTags.map((tag) => <SelectItem key={tag} value={tag}>{tag}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            ) : (
+              <Button size="sm" variant="outline" disabled className="gap-1.5">
+                <FontAwesomeIcon icon={faMinus} className="h-2.5 w-2.5" />
+                <FontAwesomeIcon icon={faTag} className="h-3.5 w-3.5" />{t('gallery.bulkRemoveTag')}
+              </Button>
+            );
+          })()}
 
           {/* Zur Sammlung hinzufügen */}
           {bulkCollOpen ? (
@@ -583,7 +588,7 @@ export default function Gallery() {
               <Button size="sm" variant="ghost" onClick={() => setBulkCollOpen(false)}><FontAwesomeIcon icon={faXmark} /></Button>
             </div>
           ) : (
-            <Button size="sm" variant="outline" disabled={selected.size === 0} onClick={() => setBulkCollOpen(true)} className="gap-1.5">
+            <Button size="sm" variant="outline" disabled={selected.size === 0 || myCollections.length === 0} onClick={() => setBulkCollOpen(true)} className="gap-1.5">
               <FontAwesomeIcon icon={faFolderPlus} className="h-3.5 w-3.5" />{t('gallery.bulkAddToCollection')}
             </Button>
           )}

--- a/e2e/bulk-actions-fixes.spec.js
+++ b/e2e/bulk-actions-fixes.spec.js
@@ -1,5 +1,5 @@
 const { test, expect } = require('@playwright/test');
-const { uploadFileViaApi, loginAsUser } = require('./helpers');
+const { uploadFileViaApi, loginAsUser, loginAsAdmin } = require('./helpers');
 
 // All tests tagged with the PR that introduced these fixes for easy filtering.
 // Default storageState = admin session (set in playwright.config.js).
@@ -28,62 +28,74 @@ test.describe('Bulk action fixes — PR #143', () => {
   });
 
   // ── Fix 1: moveToCollection owner scoping ─────────────────────────────────
-  test('moveToCollection: does not remove file from another users collection', async ({ browser }) => {
+  test('moveToCollection: does not remove file from another users collection', async ({ playwright }) => {
     const PORT = process.env.E2E_PORT || '3099';
     const baseURL = `http://localhost:${PORT}`;
 
-    // Admin context — restore saved admin session and set baseURL explicitly
-    const adminCtx = await browser.newContext({ baseURL, storageState: 'e2e/.auth/admin.json' });
-    const adminPage = await adminCtx.newPage();
-
-    // Regular user context — fresh browser context with baseURL so loginAsUser can navigate
-    const userCtx = await browser.newContext({ baseURL });
-    const userPage = await userCtx.newPage();
-    await loginAsUser(userPage);
+    // Two completely isolated API contexts — no shared state, no browser required.
+    const adminApi = await playwright.request.newContext({ baseURL });
+    const userApi = await playwright.request.newContext({ baseURL });
 
     try {
-      // Regular user uploads the file; userCtx.request shares the browser session cookie
-      const shortId = await uploadFileViaApi(userCtx.request);
+      // Authenticate both principals explicitly via the API
+      const ar = await adminApi.post('/api/auth/login', {
+        data: { username: process.env.E2E_ADMIN_USER, password: process.env.E2E_ADMIN_PASS },
+      });
+      expect(ar.ok()).toBe(true);
 
-      // Admin creates a collection and adds that file to it
-      const adminCollR = await adminPage.request.post('/api/collections', {
+      const ur = await userApi.post('/api/auth/login', {
+        data: { username: process.env.E2E_USER, password: process.env.E2E_PASS },
+      });
+      expect(ur.ok()).toBe(true);
+
+      // Verify roles to catch any session mix-up early
+      const { user: adminMe } = await (await adminApi.get('/api/auth/me')).json();
+      expect(adminMe.role).toBe('admin');
+
+      const { user: userMe } = await (await userApi.get('/api/auth/me')).json();
+      expect(userMe.role).toBe('user');
+
+      // Regular user uploads the file
+      const shortId = await uploadFileViaApi(userApi);
+
+      // Admin creates a collection and adds the user's file to it
+      const adminCollR = await adminApi.post('/api/collections', {
         data: { name: `admin-coll-${Date.now()}` },
       });
       expect(adminCollR.ok()).toBe(true);
       const { shortId: adminCollId } = await adminCollR.json();
 
-      const addR = await adminPage.request.post(`/api/collections/${adminCollId}/files`, {
+      const addR = await adminApi.post(`/api/collections/${adminCollId}/files`, {
         data: { shortId },
       });
       expect(addR.ok()).toBe(true);
 
-      // Regular user creates a destination collection for the move
-      const targetR = await userCtx.request.post('/api/collections', {
+      // Regular user creates a destination collection and moves the file there
+      const targetR = await userApi.post('/api/collections', {
         data: { name: `user-target-${Date.now()}` },
       });
       expect(targetR.ok()).toBe(true);
       const { shortId: targetCollId } = await targetR.json();
 
-      // Regular user moves the file to their own collection
-      const moveR = await userCtx.request.post('/api/files/bulk', {
+      const moveR = await userApi.post('/api/files/bulk', {
         data: { action: 'moveToCollection', shortIds: [shortId], collectionId: targetCollId },
       });
       expect(moveR.ok()).toBe(true);
 
-      // Admin's collection must still contain the file — the pull was scoped to the user's own
-      const adminColl = await adminPage.request.get(`/api/collections/${adminCollId}`);
+      // Admin's collection must still contain the file — pull was scoped to user's own collections
+      const adminColl = await adminApi.get(`/api/collections/${adminCollId}`);
       expect(adminColl.ok()).toBe(true);
       const { files: adminFiles } = await adminColl.json();
       expect(adminFiles.some((f) => f.shortId === shortId)).toBe(true);
 
       // User's destination collection must now contain the file
-      const targetColl = await userCtx.request.get(`/api/collections/${targetCollId}`);
+      const targetColl = await userApi.get(`/api/collections/${targetCollId}`);
       expect(targetColl.ok()).toBe(true);
       const { files: targetFiles } = await targetColl.json();
       expect(targetFiles.some((f) => f.shortId === shortId)).toBe(true);
     } finally {
-      await adminCtx.close();
-      await userCtx.close();
+      await adminApi.dispose();
+      await userApi.dispose();
     }
   });
 

--- a/e2e/bulk-actions-fixes.spec.js
+++ b/e2e/bulk-actions-fixes.spec.js
@@ -28,35 +28,22 @@ test.describe('Bulk action fixes — PR #143', () => {
   });
 
   // ── Fix 1: moveToCollection owner scoping ─────────────────────────────────
-  test('moveToCollection: does not remove file from another users collection', async ({ playwright }) => {
+  test('moveToCollection: does not remove file from another users collection', async ({ page, browser }) => {
     const PORT = process.env.E2E_PORT || '3099';
     const baseURL = `http://localhost:${PORT}`;
 
-    // Two completely isolated API contexts — no shared state, no browser required.
-    const adminApi = await playwright.request.newContext({ baseURL });
-    const userApi = await playwright.request.newContext({ baseURL });
+    // page.request is pre-authenticated as admin via storageState (playwright.config.js).
+    const adminApi = page.request;
+
+    // Isolated browser context for the regular user — loginAsUser navigates to /auth/login
+    // and logs in; the resulting cookies are shared with userCtx.request.
+    const userCtx = await browser.newContext({ baseURL });
+    const userPage = await userCtx.newPage();
+    await loginAsUser(userPage);
 
     try {
-      // Authenticate both principals explicitly via the API
-      const ar = await adminApi.post('/api/auth/login', {
-        data: { username: process.env.E2E_ADMIN_USER, password: process.env.E2E_ADMIN_PASS },
-      });
-      expect(ar.ok()).toBe(true);
-
-      const ur = await userApi.post('/api/auth/login', {
-        data: { username: process.env.E2E_USER, password: process.env.E2E_PASS },
-      });
-      expect(ur.ok()).toBe(true);
-
-      // Verify roles to catch any session mix-up early
-      const { user: adminMe } = await (await adminApi.get('/api/auth/me')).json();
-      expect(adminMe.role).toBe('admin');
-
-      const { user: userMe } = await (await userApi.get('/api/auth/me')).json();
-      expect(userMe.role).toBe('user');
-
       // Regular user uploads the file
-      const shortId = await uploadFileViaApi(userApi);
+      const shortId = await uploadFileViaApi(userCtx.request);
 
       // Admin creates a collection and adds the user's file to it
       const adminCollR = await adminApi.post('/api/collections', {
@@ -71,13 +58,13 @@ test.describe('Bulk action fixes — PR #143', () => {
       expect(addR.ok()).toBe(true);
 
       // Regular user creates a destination collection and moves the file there
-      const targetR = await userApi.post('/api/collections', {
+      const targetR = await userCtx.request.post('/api/collections', {
         data: { name: `user-target-${Date.now()}` },
       });
       expect(targetR.ok()).toBe(true);
       const { shortId: targetCollId } = await targetR.json();
 
-      const moveR = await userApi.post('/api/files/bulk', {
+      const moveR = await userCtx.request.post('/api/files/bulk', {
         data: { action: 'moveToCollection', shortIds: [shortId], collectionId: targetCollId },
       });
       expect(moveR.ok()).toBe(true);
@@ -89,13 +76,12 @@ test.describe('Bulk action fixes — PR #143', () => {
       expect(adminFiles.some((f) => f.shortId === shortId)).toBe(true);
 
       // User's destination collection must now contain the file
-      const targetColl = await userApi.get(`/api/collections/${targetCollId}`);
+      const targetColl = await userCtx.request.get(`/api/collections/${targetCollId}`);
       expect(targetColl.ok()).toBe(true);
       const { files: targetFiles } = await targetColl.json();
       expect(targetFiles.some((f) => f.shortId === shortId)).toBe(true);
     } finally {
-      await adminApi.dispose();
-      await userApi.dispose();
+      await userCtx.close();
     }
   });
 

--- a/e2e/bulk-actions-fixes.spec.js
+++ b/e2e/bulk-actions-fixes.spec.js
@@ -28,51 +28,57 @@ test.describe('Bulk action fixes — PR #143', () => {
   });
 
   // ── Fix 1: moveToCollection owner scoping ─────────────────────────────────
-  test('moveToCollection: does not remove file from another users collection', async ({ browser }) => {
-    const adminCtx = await browser.newContext({ storageState: 'e2e/.auth/admin.json' });
-    const adminPage = await adminCtx.newPage();
-
-    const userCtx = await browser.newContext();
-    const userPage = await userCtx.newPage();
-    await loginAsUser(userPage);
+  test('moveToCollection: does not remove file from another users collection', async ({ page, playwright }) => {
+    const PORT = process.env.E2E_PORT || '3099';
+    // Create an isolated API context for the regular user (browser.newContext() does not
+    // inherit baseURL from playwright.config.js, but playwright.request.newContext() does
+    // when baseURL is passed explicitly).
+    const userApi = await playwright.request.newContext({
+      baseURL: `http://localhost:${PORT}`,
+    });
 
     try {
-      // Regular user uploads the file that the admin will also curate
-      const shortId = await uploadFileViaApi(userPage.request);
+      // Authenticate as regular user via API
+      const loginR = await userApi.post('/api/auth/login', {
+        data: { username: process.env.E2E_USER, password: process.env.E2E_PASS },
+      });
+      expect(loginR.ok()).toBe(true);
 
-      // Admin creates a collection and adds that file to it
-      const adminCollR = await adminPage.request.post('/api/collections', {
+      // Regular user uploads the file that the admin will also curate
+      const shortId = await uploadFileViaApi(userApi);
+
+      // Admin (page.request) creates a collection and adds that file to it
+      const adminCollR = await page.request.post('/api/collections', {
         data: { name: `admin-coll-${Date.now()}` },
       });
       const { shortId: adminCollId } = await adminCollR.json();
-      await adminPage.request.post(`/api/collections/${adminCollId}/files`, {
+      await page.request.post(`/api/collections/${adminCollId}/files`, {
         data: { shortId },
       });
 
       // Regular user creates a destination collection for the move
-      const targetR = await userPage.request.post('/api/collections', {
+      const targetR = await userApi.post('/api/collections', {
         data: { name: `user-target-${Date.now()}` },
       });
       const { shortId: targetCollId } = await targetR.json();
 
       // Regular user moves the file to their own collection
-      const moveR = await userPage.request.post('/api/files/bulk', {
+      const moveR = await userApi.post('/api/files/bulk', {
         data: { action: 'moveToCollection', shortIds: [shortId], collectionId: targetCollId },
       });
       expect(moveR.ok()).toBe(true);
 
       // Admin's collection must still contain the file — the pull was scoped to the user's own
-      const adminColl = await adminPage.request.get(`/api/collections/${adminCollId}`);
+      const adminColl = await page.request.get(`/api/collections/${adminCollId}`);
       const { files: adminFiles } = await adminColl.json();
       expect(adminFiles.some((f) => f.shortId === shortId)).toBe(true);
 
       // User's destination collection must now contain the file
-      const targetColl = await userPage.request.get(`/api/collections/${targetCollId}`);
+      const targetColl = await userApi.get(`/api/collections/${targetCollId}`);
       const { files: targetFiles } = await targetColl.json();
       expect(targetFiles.some((f) => f.shortId === shortId)).toBe(true);
     } finally {
-      await adminCtx.close();
-      await userCtx.close();
+      await userApi.dispose();
     }
   });
 
@@ -142,21 +148,32 @@ test.describe('Bulk action fixes — PR #143', () => {
   });
 
   // ── Fix 5: add-to-collection disabled when user has no collections ─────────
-  test('add-to-collection and move-to-collection are both disabled with no collections', async ({ browser }) => {
-    const userCtx = await browser.newContext();
+  test('add-to-collection and move-to-collection are both disabled with no collections', async ({ browser, playwright }) => {
+    const PORT = process.env.E2E_PORT || '3099';
+    const baseURL = `http://localhost:${PORT}`;
+
+    // API context for the regular user (inherits cookies across requests)
+    const userApi = await playwright.request.newContext({ baseURL });
+    const loginR = await userApi.post('/api/auth/login', {
+      data: { username: process.env.E2E_USER, password: process.env.E2E_PASS },
+    });
+    expect(loginR.ok()).toBe(true);
+
+    // Browser context with explicit baseURL so page.goto('/gallery') resolves correctly
+    const userCtx = await browser.newContext({ baseURL });
     const userPage = await userCtx.newPage();
     await loginAsUser(userPage);
 
     try {
       // Delete all collections belonging to this user
-      const collsR = await userPage.request.get('/api/collections');
+      const collsR = await userApi.get('/api/collections');
       const { collections } = await collsR.json();
       for (const c of collections) {
-        await userPage.request.delete(`/api/collections/${c.shortId}`);
+        await userApi.delete(`/api/collections/${c.shortId}`);
       }
 
       // Upload a file so the gallery isn't empty and a file can be selected
-      await uploadFileViaApi(userPage.request);
+      await uploadFileViaApi(userApi);
 
       await userPage.goto('/gallery');
       await userPage.getByRole('button', { name: /^select$/i }).click();
@@ -169,6 +186,7 @@ test.describe('Bulk action fixes — PR #143', () => {
       await expect(addBtn).toBeDisabled();
       await expect(moveBtn).toBeDisabled();
     } finally {
+      await userApi.dispose();
       await userCtx.close();
     }
   });

--- a/e2e/bulk-actions-fixes.spec.js
+++ b/e2e/bulk-actions-fixes.spec.js
@@ -1,5 +1,5 @@
 const { test, expect } = require('@playwright/test');
-const { uploadFileViaApi, loginAsUser, loginAsAdmin } = require('./helpers');
+const { uploadFileViaApi, loginAsUser } = require('./helpers');
 
 // All tests tagged with the PR that introduced these fixes for easy filtering.
 // Default storageState = admin session (set in playwright.config.js).
@@ -28,38 +28,46 @@ test.describe('Bulk action fixes — PR #143', () => {
   });
 
   // ── Fix 1: moveToCollection owner scoping ─────────────────────────────────
-  test('moveToCollection: does not remove file from another users collection', async ({ browser }) => {
+  test('moveToCollection: does not remove file from another users collection', async ({ page, browser }) => {
     const PORT = process.env.E2E_PORT || '3099';
     const baseURL = `http://localhost:${PORT}`;
 
-    // Both principals get completely fresh browser contexts with no inherited storageState,
-    // so each login creates an independent session — no session-ID sharing possible.
-    const adminCtx = await browser.newContext({ baseURL });
-    const adminPage = await adminCtx.newPage();
-    await loginAsAdmin(adminPage);
+    // Admin = the default storageState session (proven valid by the other tests).
+    const adminApi = page.request;
 
-    const userCtx = await browser.newContext({ baseURL });
+    // User context with an EXPLICIT empty storageState, so it can never inherit the
+    // admin cookie from playwright.config.js's `use.storageState`. loginAsUser then
+    // establishes a genuine user session in this clean jar.
+    const userCtx = await browser.newContext({ baseURL, storageState: { cookies: [], origins: [] } });
     const userPage = await userCtx.newPage();
     await loginAsUser(userPage);
 
     try {
+      // Assert the two principals really are who we think — a session mix-up would
+      // otherwise surface much later as a confusing "file missing" assertion.
+      const adminMe = await (await adminApi.get('/api/auth/me')).json();
+      expect(adminMe.user.role).toBe('admin');
+      const userMe = await (await userCtx.request.get('/api/auth/me')).json();
+      expect(userMe.user.role).toBe('user');
+      expect(userMe.user.id).not.toBe(adminMe.user.id);
+
       // Regular user uploads the file
       const shortId = await uploadFileViaApi(userCtx.request);
 
       // Admin creates a collection and adds the user's file to it
-      const adminCollR = await adminCtx.request.post('/api/collections', {
+      const adminCollR = await adminApi.post('/api/collections', {
         data: { name: `admin-coll-${Date.now()}` },
       });
       expect(adminCollR.ok()).toBe(true);
       const { shortId: adminCollId } = await adminCollR.json();
 
-      const addR = await adminCtx.request.post(`/api/collections/${adminCollId}/files`, {
+      const addR = await adminApi.post(`/api/collections/${adminCollId}/files`, {
         data: { shortId },
       });
       expect(addR.ok()).toBe(true);
 
       // Sanity-check: file must be in admin's collection before the move
-      const preMove = await adminCtx.request.get(`/api/collections/${adminCollId}`);
+      const preMove = await adminApi.get(`/api/collections/${adminCollId}`);
       const { files: preFiles } = await preMove.json();
       expect(preFiles.some((f) => f.shortId === shortId)).toBe(true);
 
@@ -76,7 +84,7 @@ test.describe('Bulk action fixes — PR #143', () => {
       expect(moveR.ok()).toBe(true);
 
       // Admin's collection must still contain the file — pull was scoped to user's own collections
-      const adminColl = await adminCtx.request.get(`/api/collections/${adminCollId}`);
+      const adminColl = await adminApi.get(`/api/collections/${adminCollId}`);
       expect(adminColl.ok()).toBe(true);
       const { files: adminFiles } = await adminColl.json();
       expect(adminFiles.some((f) => f.shortId === shortId)).toBe(true);
@@ -87,7 +95,6 @@ test.describe('Bulk action fixes — PR #143', () => {
       const { files: targetFiles } = await targetColl.json();
       expect(targetFiles.some((f) => f.shortId === shortId)).toBe(true);
     } finally {
-      await adminCtx.close();
       await userCtx.close();
     }
   });

--- a/e2e/bulk-actions-fixes.spec.js
+++ b/e2e/bulk-actions-fixes.spec.js
@@ -1,0 +1,175 @@
+const { test, expect } = require('@playwright/test');
+const { uploadFileViaApi, loginAsUser } = require('./helpers');
+
+// All tests tagged with the PR that introduced these fixes for easy filtering.
+// Default storageState = admin session (set in playwright.config.js).
+
+test.describe('Bulk action fixes — PR #143', () => {
+  // ── Fix 3: removeTag input bounds ─────────────────────────────────────────
+  test('removeTag: tag at index 20 is not processed (array capped at 20)', async ({ page }) => {
+    const shortId = await uploadFileViaApi(page.request);
+    // Tag the file with 'survives' only
+    await page.request.patch(`/api/file/${shortId}`, { data: { tags: ['survives'] } });
+
+    // Build a 21-tag array where 'survives' sits at index 20 (beyond the .slice(0,20) cap)
+    const twentyOneTags = [
+      ...Array.from({ length: 20 }, (_, i) => `no-op-${i}`),
+      'survives',
+    ];
+    const r = await page.request.post('/api/files/bulk', {
+      data: { action: 'removeTag', shortIds: [shortId], tags: twentyOneTags },
+    });
+    expect(r.status()).toBe(200);
+
+    // 'survives' was at index 20 — it must still be on the file
+    const meta = await page.request.get(`/api/file/${shortId}`);
+    const { file } = await meta.json();
+    expect(file.tags).toContain('survives');
+  });
+
+  // ── Fix 1: moveToCollection owner scoping ─────────────────────────────────
+  test('moveToCollection: does not remove file from another users collection', async ({ browser }) => {
+    const adminCtx = await browser.newContext({ storageState: 'e2e/.auth/admin.json' });
+    const adminPage = await adminCtx.newPage();
+
+    const userCtx = await browser.newContext();
+    const userPage = await userCtx.newPage();
+    await loginAsUser(userPage);
+
+    try {
+      // Regular user uploads the file that the admin will also curate
+      const shortId = await uploadFileViaApi(userPage.request);
+
+      // Admin creates a collection and adds that file to it
+      const adminCollR = await adminPage.request.post('/api/collections', {
+        data: { name: `admin-coll-${Date.now()}` },
+      });
+      const { shortId: adminCollId } = await adminCollR.json();
+      await adminPage.request.post(`/api/collections/${adminCollId}/files`, {
+        data: { shortId },
+      });
+
+      // Regular user creates a destination collection for the move
+      const targetR = await userPage.request.post('/api/collections', {
+        data: { name: `user-target-${Date.now()}` },
+      });
+      const { shortId: targetCollId } = await targetR.json();
+
+      // Regular user moves the file to their own collection
+      const moveR = await userPage.request.post('/api/files/bulk', {
+        data: { action: 'moveToCollection', shortIds: [shortId], collectionId: targetCollId },
+      });
+      expect(moveR.ok()).toBe(true);
+
+      // Admin's collection must still contain the file — the pull was scoped to the user's own
+      const adminColl = await adminPage.request.get(`/api/collections/${adminCollId}`);
+      const { files: adminFiles } = await adminColl.json();
+      expect(adminFiles.some((f) => f.shortId === shortId)).toBe(true);
+
+      // User's destination collection must now contain the file
+      const targetColl = await userPage.request.get(`/api/collections/${targetCollId}`);
+      const { files: targetFiles } = await targetColl.json();
+      expect(targetFiles.some((f) => f.shortId === shortId)).toBe(true);
+    } finally {
+      await adminCtx.close();
+      await userCtx.close();
+    }
+  });
+
+  // ── Fix 4: atomic $addToSet — file already in destination stays there ─────
+  test('moveToCollection: file already in destination collection is not lost', async ({ page }) => {
+    const shortId = await uploadFileViaApi(page.request);
+
+    const collR = await page.request.post('/api/collections', {
+      data: { name: `atomic-test-${Date.now()}` },
+    });
+    const { shortId: collId } = await collR.json();
+
+    // Put the file in the collection first
+    await page.request.post(`/api/collections/${collId}/files`, { data: { shortId } });
+
+    // Move the file to the same collection (the $pull then $addToSet must round-trip cleanly)
+    const moveR = await page.request.post('/api/files/bulk', {
+      data: { action: 'moveToCollection', shortIds: [shortId], collectionId: collId },
+    });
+    expect(moveR.ok()).toBe(true);
+
+    // File must still be present — the old stale-read path would have left it if lucky,
+    // but only the atomic path guarantees it regardless of concurrency.
+    const coll = await page.request.get(`/api/collections/${collId}`);
+    const { files } = await coll.json();
+    expect(files.some((f) => f.shortId === shortId)).toBe(true);
+  });
+
+  // ── Fix 2: remove-tag dropdown uses selected files' tags only ─────────────
+  test('remove-tag dropdown lists only tags present on selected files', async ({ page }) => {
+    const ts = Date.now();
+    const tagA = `sel-${ts}`;   // tag on the selected file
+    const tagB = `nsel-${ts}`;  // tag on a different file (must not appear)
+
+    // Upload file A and tag it
+    const rA = await page.request.post('/api/web-upload', {
+      multipart: { files: { name: 'file-a.txt', mimeType: 'text/plain', buffer: Buffer.from(`A-${ts}`) } },
+    });
+    const [fileA] = (await rA.json()).files;
+    await page.request.patch(`/api/file/${fileA.shortId}`, { data: { tags: [tagA] } });
+
+    // Upload file B and tag it with a different tag
+    const rB = await page.request.post('/api/web-upload', {
+      multipart: { files: { name: 'file-b.txt', mimeType: 'text/plain', buffer: Buffer.from(`B-${ts}`) } },
+    });
+    const [fileB] = (await rB.json()).files;
+    await page.request.patch(`/api/file/${fileB.shortId}`, { data: { tags: [tagB] } });
+
+    // Clear predefined tags so the add-tag section renders a plain button (not a combobox),
+    // leaving the remove-tag combobox as the only select in the bulk toolbar.
+    await page.request.patch('/api/user/predefined-tags', { data: { tags: [] } });
+
+    // Navigate filtered to file A only — Select All will select only this file
+    await page.goto(`/gallery?tag=${tagA}`);
+    await page.getByRole('button', { name: /^select$/i }).click();
+    await page.getByRole('button', { name: 'Select all', exact: true }).click();
+    await expect(page.locator('text=/1 selected/')).toBeVisible();
+
+    // Open the remove-tag combobox (identified by its placeholder text)
+    const removeTagCombobox = page.locator('[role="combobox"]').filter({ hasText: /Remove tag/i });
+    await removeTagCombobox.click();
+
+    // tagA must be an option — it's on the selected file
+    await expect(page.getByRole('option', { name: tagA })).toBeVisible({ timeout: 5_000 });
+    // tagB must NOT be an option — it belongs only to the unselected file
+    await expect(page.getByRole('option', { name: tagB })).not.toBeVisible();
+  });
+
+  // ── Fix 5: add-to-collection disabled when user has no collections ─────────
+  test('add-to-collection and move-to-collection are both disabled with no collections', async ({ browser }) => {
+    const userCtx = await browser.newContext();
+    const userPage = await userCtx.newPage();
+    await loginAsUser(userPage);
+
+    try {
+      // Delete all collections belonging to this user
+      const collsR = await userPage.request.get('/api/collections');
+      const { collections } = await collsR.json();
+      for (const c of collections) {
+        await userPage.request.delete(`/api/collections/${c.shortId}`);
+      }
+
+      // Upload a file so the gallery isn't empty and a file can be selected
+      await uploadFileViaApi(userPage.request);
+
+      await userPage.goto('/gallery');
+      await userPage.getByRole('button', { name: /^select$/i }).click();
+      await userPage.locator('[role="checkbox"]').first().click();
+      await expect(userPage.locator('text=/1 selected/')).toBeVisible();
+
+      // Both collection buttons must be disabled when no collections exist
+      const addBtn = userPage.getByRole('button', { name: /add to collection/i });
+      const moveBtn = userPage.getByRole('button', { name: /move to collection/i });
+      await expect(addBtn).toBeDisabled();
+      await expect(moveBtn).toBeDisabled();
+    } finally {
+      await userCtx.close();
+    }
+  });
+});

--- a/e2e/bulk-actions-fixes.spec.js
+++ b/e2e/bulk-actions-fixes.spec.js
@@ -28,57 +28,62 @@ test.describe('Bulk action fixes — PR #143', () => {
   });
 
   // ── Fix 1: moveToCollection owner scoping ─────────────────────────────────
-  test('moveToCollection: does not remove file from another users collection', async ({ page, playwright }) => {
+  test('moveToCollection: does not remove file from another users collection', async ({ browser }) => {
     const PORT = process.env.E2E_PORT || '3099';
-    // Create an isolated API context for the regular user (browser.newContext() does not
-    // inherit baseURL from playwright.config.js, but playwright.request.newContext() does
-    // when baseURL is passed explicitly).
-    const userApi = await playwright.request.newContext({
-      baseURL: `http://localhost:${PORT}`,
-    });
+    const baseURL = `http://localhost:${PORT}`;
+
+    // Admin context — restore saved admin session and set baseURL explicitly
+    const adminCtx = await browser.newContext({ baseURL, storageState: 'e2e/.auth/admin.json' });
+    const adminPage = await adminCtx.newPage();
+
+    // Regular user context — fresh browser context with baseURL so loginAsUser can navigate
+    const userCtx = await browser.newContext({ baseURL });
+    const userPage = await userCtx.newPage();
+    await loginAsUser(userPage);
 
     try {
-      // Authenticate as regular user via API
-      const loginR = await userApi.post('/api/auth/login', {
-        data: { username: process.env.E2E_USER, password: process.env.E2E_PASS },
-      });
-      expect(loginR.ok()).toBe(true);
+      // Regular user uploads the file; userCtx.request shares the browser session cookie
+      const shortId = await uploadFileViaApi(userCtx.request);
 
-      // Regular user uploads the file that the admin will also curate
-      const shortId = await uploadFileViaApi(userApi);
-
-      // Admin (page.request) creates a collection and adds that file to it
-      const adminCollR = await page.request.post('/api/collections', {
+      // Admin creates a collection and adds that file to it
+      const adminCollR = await adminPage.request.post('/api/collections', {
         data: { name: `admin-coll-${Date.now()}` },
       });
+      expect(adminCollR.ok()).toBe(true);
       const { shortId: adminCollId } = await adminCollR.json();
-      await page.request.post(`/api/collections/${adminCollId}/files`, {
+
+      const addR = await adminPage.request.post(`/api/collections/${adminCollId}/files`, {
         data: { shortId },
       });
+      expect(addR.ok()).toBe(true);
 
       // Regular user creates a destination collection for the move
-      const targetR = await userApi.post('/api/collections', {
+      const targetR = await userCtx.request.post('/api/collections', {
         data: { name: `user-target-${Date.now()}` },
       });
+      expect(targetR.ok()).toBe(true);
       const { shortId: targetCollId } = await targetR.json();
 
       // Regular user moves the file to their own collection
-      const moveR = await userApi.post('/api/files/bulk', {
+      const moveR = await userCtx.request.post('/api/files/bulk', {
         data: { action: 'moveToCollection', shortIds: [shortId], collectionId: targetCollId },
       });
       expect(moveR.ok()).toBe(true);
 
       // Admin's collection must still contain the file — the pull was scoped to the user's own
-      const adminColl = await page.request.get(`/api/collections/${adminCollId}`);
+      const adminColl = await adminPage.request.get(`/api/collections/${adminCollId}`);
+      expect(adminColl.ok()).toBe(true);
       const { files: adminFiles } = await adminColl.json();
       expect(adminFiles.some((f) => f.shortId === shortId)).toBe(true);
 
       // User's destination collection must now contain the file
-      const targetColl = await userApi.get(`/api/collections/${targetCollId}`);
+      const targetColl = await userCtx.request.get(`/api/collections/${targetCollId}`);
+      expect(targetColl.ok()).toBe(true);
       const { files: targetFiles } = await targetColl.json();
       expect(targetFiles.some((f) => f.shortId === shortId)).toBe(true);
     } finally {
-      await userApi.dispose();
+      await adminCtx.close();
+      await userCtx.close();
     }
   });
 
@@ -148,32 +153,26 @@ test.describe('Bulk action fixes — PR #143', () => {
   });
 
   // ── Fix 5: add-to-collection disabled when user has no collections ─────────
-  test('add-to-collection and move-to-collection are both disabled with no collections', async ({ browser, playwright }) => {
+  test('add-to-collection and move-to-collection are both disabled with no collections', async ({ browser }) => {
     const PORT = process.env.E2E_PORT || '3099';
     const baseURL = `http://localhost:${PORT}`;
 
-    // API context for the regular user (inherits cookies across requests)
-    const userApi = await playwright.request.newContext({ baseURL });
-    const loginR = await userApi.post('/api/auth/login', {
-      data: { username: process.env.E2E_USER, password: process.env.E2E_PASS },
-    });
-    expect(loginR.ok()).toBe(true);
-
-    // Browser context with explicit baseURL so page.goto('/gallery') resolves correctly
+    // Browser context with explicit baseURL so page.goto() resolves relative paths.
+    // userCtx.request shares the browser's cookie jar, so API calls are authenticated.
     const userCtx = await browser.newContext({ baseURL });
     const userPage = await userCtx.newPage();
     await loginAsUser(userPage);
 
     try {
       // Delete all collections belonging to this user
-      const collsR = await userApi.get('/api/collections');
+      const collsR = await userCtx.request.get('/api/collections');
       const { collections } = await collsR.json();
       for (const c of collections) {
-        await userApi.delete(`/api/collections/${c.shortId}`);
+        await userCtx.request.delete(`/api/collections/${c.shortId}`);
       }
 
       // Upload a file so the gallery isn't empty and a file can be selected
-      await uploadFileViaApi(userApi);
+      await uploadFileViaApi(userCtx.request);
 
       await userPage.goto('/gallery');
       await userPage.getByRole('button', { name: /^select$/i }).click();
@@ -186,7 +185,6 @@ test.describe('Bulk action fixes — PR #143', () => {
       await expect(addBtn).toBeDisabled();
       await expect(moveBtn).toBeDisabled();
     } finally {
-      await userApi.dispose();
       await userCtx.close();
     }
   });

--- a/e2e/bulk-actions-fixes.spec.js
+++ b/e2e/bulk-actions-fixes.spec.js
@@ -28,15 +28,16 @@ test.describe('Bulk action fixes — PR #143', () => {
   });
 
   // ── Fix 1: moveToCollection owner scoping ─────────────────────────────────
-  test('moveToCollection: does not remove file from another users collection', async ({ page, browser }) => {
+  test('moveToCollection: does not remove file from another users collection', async ({ browser }) => {
     const PORT = process.env.E2E_PORT || '3099';
     const baseURL = `http://localhost:${PORT}`;
 
-    // page.request is pre-authenticated as admin via storageState (playwright.config.js).
-    const adminApi = page.request;
+    // Both principals get completely fresh browser contexts with no inherited storageState,
+    // so each login creates an independent session — no session-ID sharing possible.
+    const adminCtx = await browser.newContext({ baseURL });
+    const adminPage = await adminCtx.newPage();
+    await loginAsAdmin(adminPage);
 
-    // Isolated browser context for the regular user — loginAsUser navigates to /auth/login
-    // and logs in; the resulting cookies are shared with userCtx.request.
     const userCtx = await browser.newContext({ baseURL });
     const userPage = await userCtx.newPage();
     await loginAsUser(userPage);
@@ -46,16 +47,21 @@ test.describe('Bulk action fixes — PR #143', () => {
       const shortId = await uploadFileViaApi(userCtx.request);
 
       // Admin creates a collection and adds the user's file to it
-      const adminCollR = await adminApi.post('/api/collections', {
+      const adminCollR = await adminCtx.request.post('/api/collections', {
         data: { name: `admin-coll-${Date.now()}` },
       });
       expect(adminCollR.ok()).toBe(true);
       const { shortId: adminCollId } = await adminCollR.json();
 
-      const addR = await adminApi.post(`/api/collections/${adminCollId}/files`, {
+      const addR = await adminCtx.request.post(`/api/collections/${adminCollId}/files`, {
         data: { shortId },
       });
       expect(addR.ok()).toBe(true);
+
+      // Sanity-check: file must be in admin's collection before the move
+      const preMove = await adminCtx.request.get(`/api/collections/${adminCollId}`);
+      const { files: preFiles } = await preMove.json();
+      expect(preFiles.some((f) => f.shortId === shortId)).toBe(true);
 
       // Regular user creates a destination collection and moves the file there
       const targetR = await userCtx.request.post('/api/collections', {
@@ -70,7 +76,7 @@ test.describe('Bulk action fixes — PR #143', () => {
       expect(moveR.ok()).toBe(true);
 
       // Admin's collection must still contain the file — pull was scoped to user's own collections
-      const adminColl = await adminApi.get(`/api/collections/${adminCollId}`);
+      const adminColl = await adminCtx.request.get(`/api/collections/${adminCollId}`);
       expect(adminColl.ok()).toBe(true);
       const { files: adminFiles } = await adminColl.json();
       expect(adminFiles.some((f) => f.shortId === shortId)).toBe(true);
@@ -81,6 +87,7 @@ test.describe('Bulk action fixes — PR #143', () => {
       const { files: targetFiles } = await targetColl.json();
       expect(targetFiles.some((f) => f.shortId === shortId)).toBe(true);
     } finally {
+      await adminCtx.close();
       await userCtx.close();
     }
   });

--- a/e2e/gallery.spec.js
+++ b/e2e/gallery.spec.js
@@ -98,8 +98,9 @@ test.describe('Gallery – UI & Bulk Actions', () => {
     await tagSelects.nth(count - 1).click();
     await page.getByRole('option', { name: 'BulkLabel' }).click();
 
-    // Toast: "Tags added"
-    await expect(page.getByText(/tags added/i)).toBeVisible({ timeout: 5_000 });
+    // Toast: "Tags added" — scope to the status container to avoid strict-mode violations
+    // when both the toast root and the title element match the same text.
+    await expect(page.locator('[role="status"]').filter({ hasText: /tags added/i })).toBeVisible({ timeout: 5_000 });
   });
 
   test('bulk delete removes selected files', async ({ page }) => {
@@ -123,6 +124,6 @@ test.describe('Gallery – UI & Bulk Actions', () => {
     // Confirm in the AlertDialog
     await page.getByRole('button', { name: /delete/i }).last().click();
 
-    await expect(page.getByText(/files deleted|deleted/i)).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[role="status"]').filter({ hasText: /files deleted/i })).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/e2e/gallery.spec.js
+++ b/e2e/gallery.spec.js
@@ -38,7 +38,7 @@ test.describe('Gallery – UI & Bulk Actions', () => {
       name: 'gallery-test.txt', mimeType: 'text/plain', buffer: Buffer.from('gallery test'),
     });
     await page.getByRole('button', { name: /upload \d/i }).click();
-    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[role="status"]').filter({ hasText: /uploaded/i })).toBeVisible({ timeout: 10_000 });
 
     await page.goto('/gallery');
     await page.getByRole('button', { name: /^select$/i }).click();
@@ -61,7 +61,7 @@ test.describe('Gallery – UI & Bulk Actions', () => {
       name: 'bulk-notag.txt', mimeType: 'text/plain', buffer: Buffer.from('no tag test'),
     });
     await page.getByRole('button', { name: /upload \d/i }).click();
-    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[role="status"]').filter({ hasText: /uploaded/i })).toBeVisible({ timeout: 10_000 });
 
     await page.goto('/gallery');
     await page.getByRole('button', { name: /^select$/i }).click();
@@ -82,7 +82,7 @@ test.describe('Gallery – UI & Bulk Actions', () => {
       name: 'bulk-tag-test.txt', mimeType: 'text/plain', buffer: Buffer.from('bulk tag test'),
     });
     await page.getByRole('button', { name: /upload \d/i }).click();
-    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[role="status"]').filter({ hasText: /uploaded/i })).toBeVisible({ timeout: 10_000 });
 
     await page.goto('/gallery');
     await page.getByRole('button', { name: /^select$/i }).click();
@@ -110,7 +110,7 @@ test.describe('Gallery – UI & Bulk Actions', () => {
       name: 'to-delete.txt', mimeType: 'text/plain', buffer: Buffer.from('delete me'),
     });
     await page.getByRole('button', { name: /upload \d/i }).click();
-    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[role="status"]').filter({ hasText: /uploaded/i })).toBeVisible({ timeout: 10_000 });
 
     await page.goto('/gallery');
     await page.getByRole('button', { name: /^select$/i }).click();

--- a/e2e/sharelink.spec.js
+++ b/e2e/sharelink.spec.js
@@ -10,7 +10,7 @@ test.describe('Share Links – download limit', () => {
       buffer: Buffer.from('share link limit test'),
     });
     await page.getByRole('button', { name: /upload \d/i }).click();
-    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[role="status"]').filter({ hasText: /uploaded/i })).toBeVisible({ timeout: 10_000 });
 
     // Get the file shortId from the gallery
     await page.goto('/gallery');

--- a/e2e/tags.spec.js
+++ b/e2e/tags.spec.js
@@ -48,7 +48,7 @@ test.describe('Predefined Tag Management', () => {
       buffer: Buffer.from('tag test content'),
     });
     await page.getByRole('button', { name: /upload \d/i }).click();
-    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[role="status"]').filter({ hasText: /uploaded/i })).toBeVisible({ timeout: 10_000 });
 
     // Go to the file
     await page.goto('/gallery');
@@ -80,7 +80,7 @@ test.describe('Predefined Tag Management', () => {
       buffer: Buffer.from('fileview tag save test'),
     });
     await page.getByRole('button', { name: /upload \d/i }).click();
-    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[role="status"]').filter({ hasText: /uploaded/i })).toBeVisible({ timeout: 10_000 });
 
     // Navigate to the file
     await page.goto('/gallery');
@@ -93,8 +93,9 @@ test.describe('Predefined Tag Management', () => {
     await tagSelect.first().click();
     await page.getByRole('option', { name: 'Frontend' }).click();
 
-    // Toast: "Tags saved"
-    await expect(page.getByText(/tags saved/i)).toBeVisible({ timeout: 5_000 });
+    // Toast: "Tags saved" — scope to the status container to avoid strict-mode
+    // violations from Radix's off-screen screen-reader announce duplicate.
+    await expect(page.locator('[role="status"]').filter({ hasText: /tags saved/i })).toBeVisible({ timeout: 5_000 });
 
     // Tag badge should be visible in the tags card
     await expect(page.getByText('Frontend').first()).toBeVisible();

--- a/e2e/upload.spec.js
+++ b/e2e/upload.spec.js
@@ -20,6 +20,6 @@ test.describe('Upload Page', () => {
     });
     await expect(page.getByText(/1 file selected/i)).toBeVisible();
     await page.getByRole('button', { name: /upload \d/i }).click();
-    await expect(page.getByText(/uploaded/i)).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('[role="status"]').filter({ hasText: /uploaded/i })).toBeVisible({ timeout: 15_000 });
   });
 });

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -269,23 +269,10 @@ router.post('/files/bulk', requireLogin, async (req, res) => {
     if (!isCollOwner && !isAdmin) return res.status(403).json({ error: 'Forbidden' });
     const files = await File.find(filter);
     const fileIds = files.map((f) => f._id);
-    if (isAdmin) {
-      await Collection.updateMany(
-        { files: { $in: fileIds } },
-        { $pull: { files: { $in: fileIds } } },
-      );
-    } else {
-      // Resolve the user's own collection _ids first so the updateMany filter uses
-      // concrete ObjectId values rather than relying on string-to-ObjectId casting.
-      const owned = await Collection.find({ owner: req.session.user.id }, '_id').lean();
-      const ownedIds = owned.map((c) => c._id);
-      if (ownedIds.length > 0) {
-        await Collection.updateMany(
-          { _id: { $in: ownedIds }, files: { $in: fileIds } },
-          { $pull: { files: { $in: fileIds } } },
-        );
-      }
-    }
+    const pullFilter = isAdmin
+      ? { files: { $in: fileIds } }
+      : { owner: req.session.user.id, files: { $in: fileIds } };
+    await Collection.updateMany(pullFilter, { $pull: { files: { $in: fileIds } } });
     await Collection.findOneAndUpdate(
       { shortId: collectionId },
       { $addToSet: { files: { $each: fileIds } } },

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -269,10 +269,23 @@ router.post('/files/bulk', requireLogin, async (req, res) => {
     if (!isCollOwner && !isAdmin) return res.status(403).json({ error: 'Forbidden' });
     const files = await File.find(filter);
     const fileIds = files.map((f) => f._id);
-    const pullFilter = isAdmin
-      ? { files: { $in: fileIds } }
-      : { owner: req.session.user.id, files: { $in: fileIds } };
-    await Collection.updateMany(pullFilter, { $pull: { files: { $in: fileIds } } });
+    if (isAdmin) {
+      await Collection.updateMany(
+        { files: { $in: fileIds } },
+        { $pull: { files: { $in: fileIds } } },
+      );
+    } else {
+      // Resolve the user's own collection _ids first so the updateMany filter uses
+      // concrete ObjectId values rather than relying on string-to-ObjectId casting.
+      const owned = await Collection.find({ owner: req.session.user.id }, '_id').lean();
+      const ownedIds = owned.map((c) => c._id);
+      if (ownedIds.length > 0) {
+        await Collection.updateMany(
+          { _id: { $in: ownedIds }, files: { $in: fileIds } },
+          { $pull: { files: { $in: fileIds } } },
+        );
+      }
+    }
     await Collection.findOneAndUpdate(
       { shortId: collectionId },
       { $addToSet: { files: { $each: fileIds } } },

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -239,7 +239,7 @@ router.post('/files/bulk', requireLogin, async (req, res) => {
   }
 
   if (action === 'removeTag') {
-    const tagsToRemove = (tags || []).map((t) => t.trim()).filter(Boolean);
+    const tagsToRemove = (tags || []).slice(0, 20).map((t) => t.trim().slice(0, 50)).filter(Boolean);
     if (tagsToRemove.length === 0) return res.status(400).json({ error: 'No tags specified' });
     await File.updateMany(filter, { $pull: { tags: { $in: tagsToRemove } } });
     return res.json({ success: true });
@@ -269,13 +269,14 @@ router.post('/files/bulk', requireLogin, async (req, res) => {
     if (!isCollOwner && !isAdmin) return res.status(403).json({ error: 'Forbidden' });
     const files = await File.find(filter);
     const fileIds = files.map((f) => f._id);
-    await Collection.updateMany({}, { $pull: { files: { $in: fileIds } } });
-    for (const fileId of fileIds) {
-      if (!collection.files.some((f) => f.toString() === fileId.toString())) {
-        collection.files.push(fileId);
-      }
-    }
-    await collection.save();
+    const pullFilter = isAdmin
+      ? { files: { $in: fileIds } }
+      : { owner: req.session.user.id, files: { $in: fileIds } };
+    await Collection.updateMany(pullFilter, { $pull: { files: { $in: fileIds } } });
+    await Collection.findOneAndUpdate(
+      { shortId: collectionId },
+      { $addToSet: { files: { $each: fileIds } } },
+    );
     return res.json({ success: true });
   }
 


### PR DESCRIPTION
## Summary
This PR fixes several issues with bulk operations in the Gallery component and their corresponding API endpoints, improving the accuracy and security of tag removal and collection management features.

## Key Changes

### Gallery Component (`client/src/pages/Gallery.jsx`)
- **Smart tag filtering for removal**: Changed the "Remove Tag" dropdown to only show tags that actually exist on the currently selected files, rather than showing all tags in the gallery. This prevents users from attempting to remove tags that don't exist on their selection.
- **Collection button state**: Added a check to disable the "Add to Collection" button when no collections exist, preventing errors when users try to add files to non-existent collections.

### API Endpoint (`src/routes/api.js`)
- **Tag removal validation**: Added limits to prevent abuse - tags are now limited to 20 items with a maximum length of 50 characters per tag.
- **Collection management security**: Fixed a critical issue where admins could inadvertently remove files from all collections. Now:
  - Non-admin users can only remove files from their own collections
  - Admins can remove files from all collections
  - Uses atomic `$addToSet` operation to safely add files to the target collection, preventing duplicates

## Implementation Details
- The removable tags are computed dynamically by filtering the selected files and extracting their tags, ensuring the UI always reflects what can actually be removed.
- The collection update logic now uses proper MongoDB operators (`$addToSet` with `$each`) for atomic, duplicate-safe operations instead of manual array manipulation.

https://claude.ai/code/session_019aWbaGPXhfXuv4xP9S5n6V