### PR TITLE
fix: copy DOCUMENTATION.md into Docker image for /docs route

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --no-cache ffmpeg ghostscript
 COPY app.js ./
 COPY src/ ./src/
 COPY scripts/ ./scripts/
+COPY DOCUMENTATION.md ./
 COPY --from=builder /app/client/dist ./client/dist/
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup \


### PR DESCRIPTION
The docs route reads DOCUMENTATION.md at runtime; without this COPY line the file was absent in the container and the route returned "Documentation not available".

https://claude.ai/code/session_01PQkLzovdCw5kytPV6nZtwS