### PR TITLE
feat(docs): translate full documentation content into all 8 languages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY app.js ./
 COPY src/ ./src/
 COPY scripts/ ./scripts/
 COPY DOCUMENTATION.md ./
+COPY docs/*.md ./docs/
 COPY --from=builder /app/client/dist ./client/dist/
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup \

--- a/docs/en.md
+++ b/docs/en.md
@@ -1,0 +1,1264 @@
+# Sharely — Technical Documentation
+
+> **Version:** 1.0.0 · **License:** MIT · **Node.js:** ≥ 18
+
+---
+
+## Table of Contents
+
+1. [Project Overview](#1-project-overview)
+2. [Architecture](#2-architecture)
+3. [Tech Stack](#3-tech-stack)
+4. [Directory Structure](#4-directory-structure)
+5. [Configuration & Environment Variables](#5-configuration--environment-variables)
+6. [Data Models](#6-data-models)
+7. [REST API](#7-rest-api)
+8. [WebSocket API](#8-websocket-api)
+9. [File Serving Routes](#9-file-serving-routes)
+10. [Authentication & Security](#10-authentication--security)
+11. [Upload System](#11-upload-system)
+12. [Thumbnail Generation](#12-thumbnail-generation)
+13. [Email & SMTP](#13-email--smtp)
+14. [Internationalization](#14-internationalization)
+15. [Frontend (React SPA)](#15-frontend-react-spa)
+16. [Admin Dashboard](#16-admin-dashboard)
+17. [GDPR / Privacy](#17-gdpr--privacy)
+18. [Background Jobs](#18-background-jobs)
+19. [Deployment](#19-deployment)
+20. [Development Environment](#20-development-environment)
+21. [Migrations & Scripts](#21-migrations--scripts)
+22. [End-to-End Tests](#22-end-to-end-tests)
+
+---
+
+## 1. Project Overview
+
+Sharely is a **self-hosted file sharing platform** with a clean web interface, ShareX integration, and API access. Users upload screenshots, files, and media and share them instantly via short links.
+
+### Core Features
+
+| Feature | Description |
+|---|---|
+| Web Upload | Drag-and-drop, up to 500 files at once |
+| Chunked Upload | Files up to 2 GB via parallel multi-part upload |
+| ShareX Integration | `.sxcu` configuration file downloadable with one click |
+| API Upload | Bearer token authentication, compatible with curl/wget |
+| File Viewer | Zoom images, stream videos/audio (HTTP Range), PDFs inline, code syntax-highlighted |
+| Embed Modes | *embed* (OG/Twitter Card HTML) or *raw* (direct redirect) |
+| Thumbnails | Automatic JPEG previews for videos (ffmpeg) and PDFs (ghostscript) |
+| Collections | Group collections of files with optional password and expiry date |
+| Share Links | Per-file links with password, expiry, and download limit |
+| Real-Time UI | WebSocket-based live updates (upload, delete, view counter, admin stats) |
+| Multilingual | 8 languages: EN, DE, FR, ES, IT, PT, JA, ZH |
+| Admin Dashboard | Statistics, user management, file management, audit log (CSV export) |
+| GDPR Compliance | Privacy features compliant with EU GDPR (Art. 17, 20, 32 et al.) |
+| XBackBone Import | Migration of existing XBackBone installations |
+| Docker-ready | `docker compose up -d` starts the complete environment |
+
+---
+
+## 2. Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Browser / Client                      │
+│            React 18 SPA  ·  Vite  ·  Tailwind CSS           │
+│   ┌──────────────────────────────────────────────────────┐   │
+│   │  HTTP REST (/api/*)            WebSocket (/ws)       │   │
+│   └──────────────────────────────────────────────────────┘   │
+└───────────────────────────┬────────────────────┬─────────────┘
+                            │ HTTP               │ WS
+┌───────────────────────────▼────────────────────▼─────────────┐
+│                    Express.js (app.js)                        │
+│                                                               │
+│  ┌──────────────┐  ┌───────────┐  ┌──────────┐  ┌────────┐  │
+│  │  /api/auth   │  │  /api/*   │  │   /f/*   │  │  /s/*  │  │
+│  │  /api/install│  │  routes   │  │  files   │  │ shares │  │
+│  └──────────────┘  └───────────┘  └──────────┘  └────────┘  │
+│                                                               │
+│  Middleware: session · rate-limit · CSRF · CSP · auth        │
+│                                                               │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌────────────┐  │
+│  │  multer  │  │  ws.js   │  │  mailer  │  │ retention  │  │
+│  │  upload  │  │ WebSocket│  │ nodemailer│  │  cleanup   │  │
+│  └──────────┘  └──────────┘  └──────────┘  └────────────┘  │
+└───────────────────────────┬───────────────────────────────────┘
+                            │
+┌───────────────────────────▼───────────────────────────────────┐
+│                      MongoDB (Mongoose)                        │
+│  User · File · Collection · ShareLink · SiteSettings          │
+│  AuditLog                                                      │
+└───────────────────────────────────────────────────────────────┘
+                            │
+              ┌─────────────▼───────────────┐
+              │     Dateisystem (uploads/)   │
+              │  {folderName}/  ·  .chunks/  │
+              │  .thumbnails/   ·  .avatars/ │
+              └─────────────────────────────┘
+```
+
+### Data Flow: Standard Upload
+
+```
+Browser → POST /api/web-upload (multipart/form-data)
+       → multer: Datei in uploads/{folderName}/
+       → File.createUnique() → MongoDB
+       → generateThumbnail() (async, non-blocking)
+       → logAudit()
+       → broadcast('file:uploaded') via WebSocket
+       ← JSON: { files: [...] }
+```
+
+### Data Flow: ShareX Upload
+
+```
+ShareX → POST /upload (token im Formular-Body)
+       → multer: Datei temporär in uploads/
+       → requireApiKey: Token-Lookup → User
+       → fs.renameSync → uploads/{folderName}/
+       → File.create() → MongoDB
+       ← JSON: { url, delete_url }
+```
+
+---
+
+## 3. Tech Stack
+
+| Layer | Technology | Version |
+|---|---|---|
+| **Runtime** | Node.js | ≥ 18 |
+| **Backend Framework** | Express.js | 4.x |
+| **Database** | MongoDB + Mongoose | Mongo 7, Mongoose 8.x |
+| **Sessions** | express-session + connect-mongo | — |
+| **Real-Time** | WebSocket (`ws`) | 8.x |
+| **File Upload** | Multer | 1.x |
+| **Email** | Nodemailer | 8.x |
+| **Password Hashing** | bcryptjs | 2.x (12 Rounds) |
+| **API Key Hashing** | SHA-256 (Node Crypto) | — |
+| **Rate Limiting** | express-rate-limit | 8.x |
+| **XBackBone Import** | sql.js | 1.x |
+| **Frontend Framework** | React 18 | 18.3.x |
+| **Routing (Frontend)** | React Router v6 | 6.x |
+| **Build Tool** | Vite | 6.x |
+| **Styling** | Tailwind CSS + Radix UI | 3.x |
+| **UI Components** | shadcn/ui (Radix primitives) | — |
+| **Icons** | FontAwesome | 6.x |
+| **i18n** | i18next + react-i18next | — |
+| **Syntax Highlighting** | highlight.js | 11.x |
+| **Container** | Docker + Docker Compose | — |
+| **Tests** | Playwright (E2E) | 1.60.x |
+
+---
+
+## 4. Directory Structure
+
+```
+sharely/
+├── app.js                          # Express entry point, startup sequence
+├── package.json
+├── .env.example                    # Template for all environment variables
+├── Dockerfile
+├── docker-compose.yml
+│
+├── src/
+│   ├── config/
+│   │   └── db.js                   # MongoDB connection (Mongoose)
+│   ├── middleware/
+│   │   ├── auth.js                 # requireLogin / requireAdmin / requireApiKey
+│   │   └── upload.js               # Multer configuration, blocklist
+│   ├── models/
+│   │   ├── AuditLog.js             # Audit events (TTL 90 days)
+│   │   ├── Collection.js           # File collections
+│   │   ├── File.js                 # File metadata
+│   │   ├── ShareLink.js            # Per-file share links
+│   │   ├── SiteSettings.js         # Singleton: operator settings
+│   │   └── User.js                 # User accounts + API keys
+│   ├── routes/
+│   │   ├── api.js                  # Main API (upload, gallery, admin, ...)
+│   │   ├── auth.js                 # Login / Register / Password reset
+│   │   ├── files.js                # File serving, OG embeds, range requests
+│   │   ├── import.js               # XBackBone migration
+│   │   ├── install.js              # Initial installation endpoint
+│   │   └── shares.js               # Share link file serving
+│   ├── jobs/
+│   │   └── retentionCleanup.js     # Daily deletion of expired files
+│   ├── migrations/
+│   │   ├── migrateApiKeyHashes.js  # One-time: plaintexts → SHA-256 hashes
+│   │   └── migrateUserFolders.js   # One-time: move files into user folders
+│   ├── utils/
+│   │   ├── audit.js                # logAudit() helper function
+│   │   ├── generateThumbnail.js    # ffmpeg / ghostscript integration
+│   │   ├── mailer.js               # Nodemailer wrapper + i18n email templates
+│   │   └── sanitizeFilename.js     # Sanitize filename
+│   └── ws.js                       # WebSocket server + action dispatcher
+│
+├── client/                         # React frontend
+│   ├── index.html
+│   ├── package.json
+│   ├── vite.config.js
+│   ├── tailwind.config.js
+│   └── src/
+│       ├── main.jsx                # React entry point
+│       ├── App.jsx                 # Router configuration
+│       ├── index.css               # Global styles
+│       ├── context/
+│       │   └── AuthContext.jsx     # Global auth state
+│       ├── hooks/
+│       │   ├── use-toast.js        # Toast notification hook
+│       │   └── useWebSocket.js     # WS connection + event handlers
+│       ├── components/
+│       │   ├── Layout.jsx          # App shell (navbar, sidebar)
+│       │   ├── ProtectedRoute.jsx  # Auth guard
+│       │   ├── ShareLinkDialog.jsx # Share link creation dialog
+│       │   ├── AddToCollectionDialog.jsx
+│       │   ├── CookieBanner.jsx
+│       │   ├── LanguageSelector.jsx
+│       │   ├── RequireEmailDialog.jsx
+│       │   ├── UserAvatar.jsx
+│       │   └── ui/                 # shadcn/ui base components
+│       ├── pages/
+│       │   ├── Upload.jsx          # Upload page
+│       │   ├── Gallery.jsx         # File gallery
+│       │   ├── FileView.jsx        # File detail view
+│       │   ├── Collections.jsx     # Collections overview
+│       │   ├── CollectionView.jsx  # Individual collection
+│       │   ├── ShareView.jsx       # Public share link page
+│       │   ├── Settings.jsx        # User settings
+│       │   ├── Login.jsx
+│       │   ├── Register.jsx
+│       │   ├── ForgotPassword.jsx
+│       │   ├── ResetPassword.jsx
+│       │   ├── Install.jsx         # Initial installation
+│       │   ├── PrivacyPolicy.jsx
+│       │   ├── TermsOfService.jsx
+│       │   └── admin/
+│       │       ├── Dashboard.jsx   # Admin home page
+│       │       ├── Users.jsx       # User management
+│       │       ├── Files.jsx       # File management
+│       │       ├── AuditLog.jsx    # Audit log view
+│       │       ├── SiteSettings.jsx# Operator settings
+│       │       └── Import.jsx      # XBackBone import
+│       ├── i18n/
+│       │   ├── index.js            # i18next configuration
+│       │   └── locales/
+│       │       ├── de.json
+│       │       ├── en.json
+│       │       ├── es.json
+│       │       ├── fr.json
+│       │       ├── it.json
+│       │       ├── ja.json
+│       │       ├── pt.json
+│       │       └── zh.json
+│       └── lib/
+│           └── utils.js            # Tailwind helper (cn())
+│
+├── scripts/
+│   ├── setup-db.js
+│   ├── mongo-init.js               # MongoDB initialization script
+│   ├── migrate-uploads-to-user-folders.js
+│   └── generate-missing-thumbnails.js
+│
+├── e2e/                            # Playwright tests
+│   ├── admin.spec.js
+│   ├── bulk-actions-fixes.spec.js
+│   ├── gallery.spec.js
+│   ├── sharelink.spec.js
+│   ├── tags.spec.js
+│   ├── upload.spec.js
+│   ├── helpers.js
+│   └── global-setup.js
+│
+├── uploads/                        # File uploads (runtime)
+│   ├── .thumbnails/
+│   ├── .avatars/
+│   └── .chunks/                    # Temporary chunks
+│
+└── docs/assets/                    # Screenshots and logo
+```
+
+---
+
+## 5. Configuration & Environment Variables
+
+All variables are loaded from `.env` (via `dotenv`). The file `.env.example` contains the complete template.
+
+### Required Fields
+
+| Variable | Description |
+|---|---|
+| `SESSION_SECRET` | Secret for session encryption — long random string, e.g. `openssl rand -hex 32` |
+| `MONGO_ROOT_PASSWORD` | MongoDB root password (required for Docker Compose only) |
+| `MONGO_APP_PASSWORD` | MongoDB application user password |
+
+### All Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `PORT` | `3000` | TCP port of the HTTP server |
+| `MONGODB_URI` | _(constructed from Docker Compose)_ | Full MongoDB connection URI |
+| `MONGO_ROOT_PASSWORD` | — | MongoDB root password |
+| `MONGO_APP_USER` | `appuser` | MongoDB application username |
+| `MONGO_APP_PASSWORD` | — | MongoDB application user password |
+| `MONGO_DB_NAME` | `sharely` | MongoDB database name |
+| `SESSION_SECRET` | — | **Required** — session encryption secret |
+| `BASE_URL` | `http://localhost:3000` | Public base URL for generated share links (no trailing `/`) |
+| `SITE_NAME` | `sharely` | Site name in Open Graph embeds |
+| `MAX_FILE_SIZE_MB` | `100` | Maximum file size for standard uploads in MB (chunked uploads up to 2 GB independently) |
+| `ALLOW_REGISTRATION` | `true` | `false` disables public registration |
+| `SMTP_HOST` | — | SMTP server hostname; leave empty to disable email features |
+| `SMTP_PORT` | `587` | SMTP port |
+| `SMTP_SECURE` | `false` | `true` for implicit TLS (port 465), `false` for STARTTLS |
+| `SMTP_USER` | — | SMTP username |
+| `SMTP_PASS` | — | SMTP password |
+| `SMTP_FROM` | _(SMTP_USER)_ | Sender address in outgoing emails |
+| `UPLOAD_DIR` | `./uploads` | Absolute path to upload directory |
+| `NODE_ENV` | — | `production` enables secure cookies |
+
+---
+
+## 6. Data Models
+
+### User (`src/models/User.js`)
+
+```
+{
+  username:                    String (3–32, unique, alphanumeric + _-)
+  password:                    String (bcrypt, 12 Rounds)
+  role:                        'admin' | 'user'
+  apiKey:                      String (Legacy, empty after migration)
+  apiKeyHash:                  String (SHA-256, unique, sparse)
+  apiKeyPrefix:                String (first 8 characters of plaintext)
+  folderName:                  String (unique, sparse, max 64)
+  avatarExt:                   String | null (.jpg/.png/.gif/.webp)
+  embedMode:                   'embed' | 'raw'
+  isActive:                    Boolean
+  email:                       String (lowercase, unique, sparse)
+  emailVerified:               Boolean
+  emailVerificationToken:      String | null (SHA-256 hash of plaintext)
+  emailVerificationExpires:    Date | null
+  passwordResetToken:          String | null (SHA-256 hash)
+  passwordResetExpires:        Date | null
+  language:                    'en'|'de'|'fr'|'es'|'it'|'pt'|'ja'|'zh'
+  predefinedTags:              [String] (max 100 tags × 50 characters)
+  createdAt:                   Date
+}
+```
+
+**Important Methods:**
+- `user.comparePassword(candidate)` — bcrypt comparison
+- `user.regenerateApiKey()` — generates new plaintext, stores hash, returns plaintext (visible once only)
+- `User.findByApiKey(plaintext)` — looks up by SHA-256 hash, active users only
+
+### File (`src/models/File.js`)
+
+```
+{
+  shortId:      String (8 hex characters: 6 timestamp + 2 random, unique)
+  deleteToken:  String (32 hex characters, unique)
+  originalName: String (sanitized)
+  storedName:   String (relative path: "folderName/8hex.ext")
+  mimeType:     String
+  size:         Number (bytes)
+  uploader:     ObjectId → User
+  views:        Number
+  tags:         [String] (max 20 × 50 characters)
+  createdAt:    Date
+}
+```
+
+**Virtuals:**
+- `sizeHuman` — human-readable size (B / KB / MB / GB)
+- `displayType` — classification: `image|video|audio|pdf|code|text|file`
+
+**Short ID Algorithm:**
+```
+shortId = hex(seconds_since_2024-01-01, 6 chars) + randomBytes(2).hex()
+```
+
+### Collection (`src/models/Collection.js`)
+
+```
+{
+  shortId:     String (8 Hex, unique)
+  name:        String (max 100)
+  description: String (max 500)
+  owner:       ObjectId → User
+  files:       [ObjectId → File]
+  password:    String | null (bcrypt)
+  expiresAt:   Date | null
+  createdAt:   Date
+}
+```
+
+> Expired collections are automatically deleted by MongoDB TTL index 7 days after expiry.
+
+### ShareLink (`src/models/ShareLink.js`)
+
+```
+{
+  token:         String (32 Hex, unique)
+  file:          ObjectId → File
+  createdBy:     ObjectId → User
+  label:         String (max 100)
+  password:      String | null (bcrypt)
+  expiresAt:     Date | null
+  downloadLimit: Number (-1 = unlimited)
+  downloadCount: Number
+  createdAt:     Date
+}
+```
+
+> Like collections: 7-day grace period after expiry via TTL index.
+
+### SiteSettings (`src/models/SiteSettings.js`)
+
+Singleton document (`_id: 'singleton'`):
+
+```
+{
+  operatorName:        String
+  operatorAddress:     String
+  operatorEmail:       String
+  cloudflareAnalytics: Boolean
+  fileRetentionDays:   Number (0 = disabled)
+  encryptionAtRest:    Boolean
+  sessionDurationDays: Number (default: 7)
+  allowRegistration:   Boolean
+}
+```
+
+### AuditLog (`src/models/AuditLog.js`)
+
+```
+{
+  timestamp: Date (TTL index: 90 days)
+  userId:    ObjectId → User | null
+  username:  String | null
+  action:    String
+  ip:        String | null
+  meta:      Mixed (action-specific metadata)
+}
+```
+
+---
+
+## 7. REST API
+
+### Base URL: `/api`
+
+All JSON endpoints return `Content-Type: application/json`. Errors: `{ "error": "message" }`.
+
+---
+
+### Authentication (`/api/auth`)
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `GET` | `/me` | Session | Currently logged-in user |
+| `POST` | `/login` | — | Log in (rate-limited: 10/15min) |
+| `POST` | `/register` | — | Register (rate-limited, first user becomes admin) |
+| `POST` | `/logout` | — | Log out |
+| `GET` | `/smtp-enabled` | — | Check whether SMTP is configured |
+| `GET` | `/verify-email?token=` | — | Verify email address |
+| `GET` | `/verify-reset-token?token=` | — | Validate reset token |
+| `POST` | `/forgot-password` | — | Send password reset email (rate-limited: 5/hr) |
+| `POST` | `/reset-password` | — | Set new password |
+
+**Login Request:**
+```json
+POST /api/auth/login
+{ "username": "max", "password": "meinPasswort123" }
+```
+
+**Login Response:**
+```json
+{
+  "user": {
+    "id": "...", "username": "max", "role": "user",
+    "avatarUrl": null, "email": "max@example.com",
+    "emailVerified": true, "language": "de"
+  }
+}
+```
+
+---
+
+### File Upload
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `POST` | `/upload` | API Key | ShareX upload (legacy endpoint in `app.js`) |
+| `POST` | `/api/upload` | API Key | ShareX/API upload (field: `file`) |
+| `POST` | `/api/web-upload` | Session | Web upload (field: `files[]`, max 500) |
+| `POST` | `/api/chunk/init` | Session | Initialize chunked upload |
+| `POST` | `/api/chunk/:uploadId` | Session | Upload a single chunk (field: `chunk`) |
+| `POST` | `/api/chunk/:uploadId/complete` | Session | Assemble chunks |
+| `DELETE` | `/api/chunk/:uploadId` | Session | Cancel upload & clean up |
+
+**API Upload Response:**
+```json
+{
+  "url": "https://example.com/f/a1b2c3d4",
+  "raw": "https://example.com/f/a1b2c3d4/raw",
+  "delete_url": "https://example.com/api/delete/a1b2c3d4",
+  "short_id": "a1b2c3d4",
+  "filename": "screenshot.png",
+  "size": 102400
+}
+```
+
+#### Chunked Upload Flow
+
+1. `POST /api/chunk/init` → `{ uploadId: "32hex" }`
+2. `POST /api/chunk/:uploadId` (Body: `chunkIndex=N`, File: `chunk`) → `{ received: N }`  
+   Parallel with 3–5 concurrent chunks
+3. `POST /api/chunk/:uploadId/complete` → `{ files: [fileObject] }`
+
+---
+
+### File Management
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `GET` | `/api/gallery` | Session | Own files (admin: all), paginated (24/page), filters: `q`, `type`, `tag`, `page` |
+| `GET` | `/api/file/:shortId` | — | File metadata (increments view counter) |
+| `PATCH` | `/api/file/:shortId` | Session | Update tags/name |
+| `DELETE` | `/api/file/:shortId` | Session | Delete file |
+| `DELETE` | `/api/delete/:shortId` | API Key | Delete file (API key auth) |
+| `POST` | `/api/files/bulk` | Session | Bulk actions: `delete`, `tag`, `removeTag`, `addToCollection`, `moveToCollection` |
+| `GET` | `/api/tags` | Session | All tag suggestions for the user |
+
+**Gallery Query Parameters:**
+- `q` — search in filename (regex-safe)
+- `type` — `all|image|video|audio|pdf|code`
+- `tag` — exact tag filter
+- `page` — page number (default: 1)
+
+---
+
+### User Settings
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `GET` | `/api/my-key` | Session | Show API key prefix |
+| `POST` | `/api/regen-key` | Session | Regenerate API key |
+| `GET` | `/api/sharex-config` | Session | Download ShareX `.sxcu` (regenerates key) |
+| `PATCH` | `/api/user/username` | Session | Change username (password required) |
+| `PATCH` | `/api/user/password` | Session | Change password |
+| `PATCH` | `/api/user/email` | Session | Change email (sends verification email) |
+| `PATCH` | `/api/user/language` | Session | Set UI language |
+| `PATCH` | `/api/user/embed-mode` | Session | Set embed mode (`embed`/`raw`) |
+| `POST` | `/api/user/resend-verification` | Session | Resend verification email |
+| `GET` | `/api/user/export` | Session | Data export (GDPR Art. 20) as JSON |
+| `DELETE` | `/api/user/account` | Session | Delete account (GDPR Art. 17, password required) |
+| `GET` | `/api/user/predefined-tags` | Session | Retrieve predefined tags |
+| `PATCH` | `/api/user/predefined-tags` | Session | Update predefined tags |
+| `POST` | `/api/user/avatar` | Session | Upload avatar (max 2 MB, JPEG/PNG/GIF/WebP) |
+| `DELETE` | `/api/user/avatar` | Session | Delete avatar |
+| `GET` | `/api/user/avatar/:userId` | — | Serve avatar |
+
+---
+
+### Share Links
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `GET` | `/api/file/:shortId/share-links` | Session (Owner/Admin) | All share links for a file |
+| `POST` | `/api/file/:shortId/share-links` | Session (Owner/Admin) | Create share link |
+| `DELETE` | `/api/share-links/:token` | Session (Owner/Creator/Admin) | Delete share link |
+| `GET` | `/api/share-links/:token` | — | Share link metadata (public) |
+| `POST` | `/api/share-links/:token/verify` | — | Verify share link password |
+
+**Create Share Link:**
+```json
+POST /api/file/a1b2c3d4/share-links
+{
+  "label": "For colleagues",
+  "password": "secret",
+  "expiresAt": "2025-12-31T23:59:59Z",
+  "downloadLimit": 10
+}
+```
+
+---
+
+### Collections
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `GET` | `/api/collections` | Session | Own collections (admin: all) |
+| `POST` | `/api/collections` | Session | Create collection |
+| `GET` | `/api/collections/:id` | — | View collection (public, password if set) |
+| `PATCH` | `/api/collections/:id` | Session (Owner/Admin) | Update collection |
+| `DELETE` | `/api/collections/:id` | Session (Owner/Admin) | Delete collection |
+| `POST` | `/api/collections/:id/files` | Session (Owner/Admin) | Add file to collection |
+| `DELETE` | `/api/collections/:id/files/:fileShortId` | Session (Owner/Admin) | Remove file from collection |
+| `POST` | `/api/collections/:id/verify` | — | Verify collection password |
+
+---
+
+### Admin Endpoints
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `GET` | `/api/admin/stats` | Admin | Dashboard statistics |
+| `GET` | `/api/admin/users` | Admin | All users (including file counts) |
+| `POST` | `/api/admin/users` | Admin | Create user |
+| `PATCH` | `/api/admin/users/:id/toggle` | Admin | Activate/deactivate user |
+| `PATCH` | `/api/admin/users/:id/role` | Admin | Change user role |
+| `DELETE` | `/api/admin/users/:id` | Admin | Delete user |
+| `POST` | `/api/admin/users/:id/regen-key` | Admin | Regenerate API key |
+| `PATCH` | `/api/admin/users/:id/password` | Admin | Set password |
+| `PATCH` | `/api/admin/users/:id/folder` | Admin | Change folder name (moves files) |
+| `GET` | `/api/admin/files` | Admin | All files, paginated (30/page) |
+| `GET` | `/api/admin/site-settings` | Admin | Read operator settings |
+| `PATCH` | `/api/admin/site-settings` | Admin | Update operator settings |
+| `GET` | `/api/admin/audit-log` | Admin | Paginated audit log (50/page) |
+| `GET` | `/api/admin/audit-log/export` | Admin | Download audit log as CSV |
+| `GET` | `/api/site-settings` | — | Public operator info (for privacy page) |
+
+---
+
+### Site Settings (Public)
+
+```json
+GET /api/site-settings
+{
+  "operatorName": "Musterfirma GmbH",
+  "operatorAddress": "Musterstr. 1, 12345 Musterstadt",
+  "operatorEmail": "datenschutz@example.com",
+  "cloudflareAnalytics": false,
+  "fileRetentionDays": 365,
+  "encryptionAtRest": false,
+  "sessionDurationDays": 7
+}
+```
+
+---
+
+## 8. WebSocket API
+
+**Connection:** `wss://example.com/ws` (logged-in users only, session cookie required)
+
+### Protocol
+
+**Client → Server (Request):**
+```json
+{ "id": "req-abc123", "action": "file:list", "payload": { "type": "image", "page": 1 } }
+```
+
+**Server → Client (Response):**
+```json
+{ "id": "req-abc123", "data": { ... } }
+```
+
+**Server → Client (Error):**
+```json
+{ "id": "req-abc123", "error": "Forbidden", "status": 403 }
+```
+
+**Server → Client (Broadcast):**
+```json
+{ "event": "file:uploaded", "data": { "shortId": "a1b2c3d4", "uploaderId": "..." } }
+```
+
+### Available Actions
+
+| Action | Auth | Description |
+|---|---|---|
+| `site-settings:get` | — | Public site settings |
+| `auth:me` | User | Own user data |
+| `file:get` | User | File details (increments views) |
+| `file:list` | User | File list with filter/pagination |
+| `file:delete` | User | Delete file |
+| `user:get-key` | User | API key prefix |
+| `user:regen-key` | User | Regenerate API key |
+| `user:change-password` | User | Change password |
+| `user:change-username` | User | Change username |
+| `user:change-email` | User | Change email |
+| `user:change-language` | User | Set language |
+| `user:change-embed-mode` | User | Set embed mode |
+| `user:resend-verification` | User | Resend verification email |
+| `user:export` | User | Data export |
+| `user:delete-account` | User | Delete account |
+| `admin:stats` | Admin | Dashboard statistics |
+| `admin:settings:get` | Admin | Read site settings |
+| `admin:settings:update` | Admin | Update site settings |
+| `admin:users:list` | Admin | All users |
+| `admin:users:create` | Admin | Create user |
+| `admin:users:toggle` | Admin | Activate/deactivate user |
+| `admin:users:role` | Admin | Change user role |
+| `admin:users:delete` | Admin | Delete user |
+| `admin:users:regen-key` | Admin | Regenerate API key |
+| `admin:users:password` | Admin | Set password |
+| `admin:users:folder` | Admin | Change folder name |
+| `admin:files:list` | Admin | All files |
+| `admin:audit-log:list` | Admin | Paginated audit log |
+
+### Broadcast Events
+
+| Event | Recipients | Payload |
+|---|---|---|
+| `file:uploaded` | Uploader | `{ shortId, uploaderId }` |
+| `file:deleted` | File owner | `{ shortId, uploaderId }` |
+| `file:view` | All | `{ shortId, views }` |
+| `user:created` | Admins | `{ id, username, role, ... }` |
+| `user:deleted` | Admins | `{ id }` |
+| `user:updated` | Admins | `{ id, ...changed fields }` |
+| `audit:log` | Admins | Complete AuditLog object |
+| `settings:updated` | Admins | Updated SiteSettings object |
+| `stats:invalidate` | Admins | `{}` (trigger stats refresh) |
+
+---
+
+## 9. File Serving Routes
+
+### `/f/:shortId` — File Viewer
+
+- **Browser request:** Passes through to React SPA (`index.html`) — SPA renders the viewer.
+- **Social media bot** (Discord, Telegram, Twitter, etc.): Returns a minimal HTML page with Open Graph / Twitter Card meta tags.
+  - `embedMode = 'embed'`: OG HTML with redirect
+  - `embedMode = 'raw'` + image/video/audio: HTTP 302 → `/f/:shortId/raw`
+
+### `/f/:shortId/raw` — Direct Access
+
+Serves the file as an HTTP response with range request support (206 Partial Content). Images/videos/audio: `Content-Disposition: inline`, others: `attachment`.
+
+### `/f/:shortId/download` — Force Download
+
+Like `/raw`, but always `Content-Disposition: attachment`.
+
+### `/f/:shortId/thumb` — Thumbnail
+
+Returns JPEG thumbnail (for videos and PDFs). `Cache-Control: public, max-age=86400`.
+
+### `/f/:shortId/delete/:token` — ShareX Deletion
+
+Deletes file without session via unique delete token.
+
+### `/s/:token` — Share Link File Serving (`src/routes/shares.js`)
+
+Checks password (via session flag), expiry date and download limit, then serves the file.
+
+---
+
+## 10. Authentication & Security
+
+### Session Authentication
+
+- Express session with MongoDB store (`connect-mongo`)
+- Session cookie: `httpOnly: true`, `sameSite: 'strict'`, `secure: true` in production
+- Session duration: configurable via `SiteSettings.sessionDurationDays` (default: 7 days), live-cached for 60 seconds
+
+### API Key Authentication
+
+- API keys are stored as SHA-256 hashes, never in plaintext
+- The first 8 characters are stored as `apiKeyPrefix` (for display purposes)
+- Lookup: `User.findByApiKey(plaintext)` computes hash and searches in `apiKeyHash`
+- When downloading the ShareX config, the key is regenerated — the plaintext is visible only at that moment
+
+### Middleware Chain (`src/middleware/auth.js`)
+
+```
+requireLogin    → checks req.session.user → 401 if not logged in
+requireAdmin    → like requireLogin, additionally role === 'admin' → 403
+requireApiKey   → checks Authorization header or req.body.token
+```
+
+### CSRF Protection
+
+`requireSameOrigin()` in `app.js` compares the `Origin` header with the `Host` header for all API routes. Complements `sameSite: 'strict'` cookies.
+
+### Content Security Policy
+
+```
+default-src 'self';
+script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com;
+style-src 'self' 'unsafe-inline';
+img-src 'self' data: blob:;
+media-src 'self' blob:;
+connect-src 'self' https://cloudflareinsights.com;
+frame-ancestors 'self';
+```
+
+### Security Headers
+
+- `X-Frame-Options: SAMEORIGIN`
+- `X-Content-Type-Options: nosniff`
+
+### Rate Limiting
+
+| Endpoint | Limit | Window |
+|---|---|---|
+| Upload (`/upload`, `/api/upload`, `/api/web-upload`) | 60 requests | 15 minutes |
+| Auth (`/api/auth/login`, `/register`, etc.) | 10 requests | 15 minutes |
+| Password reset | 5 requests | 1 hour |
+
+### File Blocklist
+
+The following MIME types and extensions are rejected on upload:
+
+**Blocked MIME types:** `application/x-executable`, `application/x-sh`, `application/x-csh`, `application/x-bat`
+
+**Blocked extensions:** `.bat`, `.cmd`, `.com`, `.ps1`, `.psm1`, `.psd1`, `.sh`, `.bash`, `.csh`, `.zsh`, `.fish`, `.vbs`, `.vbe`, `.jse`, `.scr`, `.pif`, `.application`, `.gadget`, `.hta`, `.php`, `.php3–5`, `.phtml`, `.asp`, `.aspx`, `.jsp`, `.jspx`, `.cfm`
+
+### Path Traversal Protection
+
+All file accesses via `resolveUploadPath()` verify that the resolved path lies within `UPLOAD_DIR`.
+
+---
+
+## 11. Upload System
+
+### Standard Upload (Multer)
+
+- **Storage:** `multer.diskStorage` → `uploads/{folderName}/{8hex}{.ext}`
+- **Filename:** `crypto.randomBytes(4).hex() + original-extension`
+- **Limit:** `MAX_FILE_SIZE_MB` (default: 100 MB)
+- **Location:** User-specific folder (`user.folderName`)
+
+### Chunked Upload (>250 MB)
+
+The frontend client automatically switches to chunked mode for large files.
+
+**Server-side directory structure:**
+```
+uploads/.chunks/{uploadId}/
+  meta.json          { filename, mimeType, totalSize, totalChunks, userId, createdAt }
+  chunk-0
+  chunk-1
+  ...
+  chunk-N
+```
+
+**Chunk size:** 10–20 MB (max 51 MB accepted for backward compatibility)  
+**Parallelism:** 3–5 concurrent chunk uploads  
+**Assembly:** Stream-based (no full loading into RAM)
+
+### Avatar Upload
+
+- **Storage:** `multer.memoryStorage()` (no disk buffer)
+- **Location:** `uploads/.avatars/{userId}{.ext}`
+- **Limit:** 2 MB
+- **Formats:** JPEG, PNG, GIF, WebP
+
+---
+
+## 12. Thumbnail Generation
+
+Thumbnails are generated asynchronously after upload (`.catch(() => {})` — errors are silently ignored).
+
+### Video Thumbnails (ffmpeg)
+
+```bash
+ffmpeg -y -i <file> -ss 00:00:01 -vframes 1 \
+  -vf "scale=320:320:force_original_aspect_ratio=increase,crop=320:320" \
+  -q:v 3 uploads/.thumbnails/<shortId>.jpg
+```
+
+### PDF Thumbnails (Ghostscript)
+
+```bash
+gs -dNOPAUSE -dBATCH -dSAFER \
+  -sDEVICE=jpeg -dFirstPage=1 -dLastPage=1 \
+  -r72 -dJPEGQ=85 \
+  -sOutputFile=uploads/.thumbnails/<shortId>.jpg \
+  <file>
+```
+
+**Timeout:** 30 seconds per thumbnail generation  
+**Fallback:** If ffmpeg/ghostscript is not available, generation is silently skipped.
+
+### Backfill Script
+
+```bash
+npm run migrate:thumbnails
+# or in container:
+docker exec -it <container> npm run migrate:thumbnails
+```
+
+---
+
+## 13. Email & SMTP
+
+### Configuration
+
+SMTP is activated when `SMTP_HOST` is set. `mailer.isConfigured()` checks this value.
+
+### Email Templates
+
+All emails are sent in the user's language (8 languages). Templates are embedded in `src/utils/mailer.js`.
+
+**Email types sent:**
+
+| Type | Trigger | Token Validity |
+|---|---|---|
+| Email verification | Registration, email change | 24 hours |
+| Password reset | `POST /api/auth/forgot-password` | 1 hour |
+
+### Token Security
+
+- Tokens: `crypto.randomBytes(32).hex()` (64 hex characters)
+- Stored: SHA-256 hash of the token
+- Email contains plaintext token as URL parameter
+- Verification: hash of incoming token compared against stored hash
+
+---
+
+## 14. Internationalization
+
+**Library:** i18next + react-i18next + i18next-browser-languagedetector
+
+**Supported Languages:**
+
+| Code | Language |
+|---|---|
+| `en` | English |
+| `de` | Deutsch |
+| `fr` | Français |
+| `es` | Español |
+| `it` | Italiano |
+| `pt` | Português |
+| `ja` | 日本語 |
+| `zh` | 中文 |
+
+**Language Selection:**
+1. Browser language detection (automatic)
+2. User preference in the database (`user.language`)
+3. Persistence via `PATCH /api/user/language`
+
+Translation files: `client/src/i18n/locales/{code}.json`
+
+---
+
+## 15. Frontend (React SPA)
+
+### Router Configuration (`client/src/App.jsx`)
+
+| Route | Component | Auth |
+|---|---|---|
+| `/` | Redirect → `/gallery` | No |
+| `/auth/login` | Login.jsx | No |
+| `/auth/register` | Register.jsx | No |
+| `/auth/forgot-password` | ForgotPassword.jsx | No |
+| `/auth/reset-password` | ResetPassword.jsx | No |
+| `/install` | Install.jsx | No |
+| `/upload` | Upload.jsx | **Yes** |
+| `/gallery` | Gallery.jsx | **Yes** |
+| `/f/:shortId` | FileView.jsx | **Yes** |
+| `/collections` | Collections.jsx | **Yes** |
+| `/c/:id` | CollectionView.jsx | No (public) |
+| `/s/:token` | ShareView.jsx | No (public) |
+| `/settings` | Settings.jsx | **Yes** |
+| `/admin` | Dashboard.jsx | **Admin** |
+| `/admin/users` | Users.jsx | **Admin** |
+| `/admin/files` | Files.jsx | **Admin** |
+| `/admin/audit-log` | AuditLog.jsx | **Admin** |
+| `/admin/site-settings` | SiteSettings.jsx | **Admin** |
+| `/admin/import` | Import.jsx | **Admin** |
+| `/privacy` | PrivacyPolicy.jsx | No |
+| `/terms` | TermsOfService.jsx | No |
+
+### Auth Context (`client/src/context/AuthContext.jsx`)
+
+Global state for the logged-in user. Initialized at app start via `GET /api/auth/me`.
+
+### WebSocket Hook (`client/src/hooks/useWebSocket.js`)
+
+Manages the persistent WS connection. Provides `sendMessage()` and event handler registration. Reconnect logic on connection drop.
+
+### UI Components
+
+Based on **shadcn/ui** (Radix UI Primitives + Tailwind CSS):
+
+- `Dialog`, `AlertDialog`, `DropdownMenu`, `ContextMenu`, `Popover`
+- `Select`, `Checkbox`, `Input`, `Textarea`, `Label`
+- `Card`, `Badge`, `Button`, `Separator`, `Tabs`, `Table`
+- `Toast` / `Toaster` for notifications
+- `Calendar` / `DateTimePicker` for expiry date selection
+- `Pagination` for paginated lists
+- `ScrollArea`, `Tooltip`
+
+---
+
+## 16. Admin Dashboard
+
+The admin dashboard (`/admin/*`) is accessible only to users with `role: 'admin'`.
+
+### Dashboard (`/admin`)
+
+- Total number of users, files, storage usage
+- 10 most recently uploaded files
+- Live updates via WebSocket (`stats:invalidate`)
+
+### User Management (`/admin/users`)
+
+- All users with file count and storage usage
+- Create users, activate/deactivate, change role
+- Reset password, regenerate API key
+- Change folder name (physical files are moved on the server)
+- Delete user (all files are deleted)
+
+### File Management (`/admin/files`)
+
+- All files from all users, paginated
+- Search by filename
+- Delete file
+
+### Audit Log (`/admin/audit-log`)
+
+- Paginated log of all actions (50/page)
+- Filter by username and action
+- CSV export for regulatory purposes
+
+### Site Settings (`/admin/site-settings`)
+
+- Operator information (name, address, email)
+- Enable Cloudflare Analytics
+- File retention period
+- Session duration
+- Enable/disable registration
+
+### XBackBone Import (`/admin/import`)
+
+- Preview and import from XBackBone SQLite database
+- Users are matched by username
+- Idempotent (already imported files are skipped)
+
+---
+
+## 17. GDPR / Privacy
+
+| Feature | GDPR Article |
+|---|---|
+| Privacy policy (configurable) | Art. 13/14 – Transparency |
+| Terms of service page (configurable) | Art. 13/14 – Transparency |
+| Data export (JSON with URLs) | Art. 20 – Data portability |
+| Account self-deletion (files + data) | Art. 17 – Right to erasure |
+| Audit log (90-day TTL via MongoDB) | Art. 5(2) – Accountability |
+| Audit log CSV export | Art. 5(2) – Accountability |
+| Configurable file retention | Art. 5(1)(e) – Storage limitation |
+| API keys as SHA-256 hash | Art. 32 – Security |
+| Passwords as bcrypt (12 rounds) | Art. 32 – Security |
+| Cookie consent for Cloudflare Analytics | Art. 13 – Transparency |
+| Anonymization on account deletion | Art. 17 – Right to erasure |
+
+### GDPR Deletion Flow
+
+On account deletion (`user:delete-account` / `DELETE /api/user/account`):
+1. All user files are deleted from disk
+2. Thumbnails are deleted
+3. Avatar is deleted
+4. Audit log entries are anonymized (`username: '[deleted]'`, `ip: null`, `userId: null`)
+5. User document is deleted
+6. Session is destroyed
+
+---
+
+## 18. Background Jobs
+
+### Retention Cleanup (`src/jobs/retentionCleanup.js`)
+
+- **Execution:** On startup and then daily (`setInterval(runRetentionCleanup, 24h)`)
+- **Action:** If `SiteSettings.fileRetentionDays > 0`, files older than this value are deleted
+- Deletes: file on disk, thumbnail, MongoDB document
+- Broadcasts `stats:invalidate` to admins
+
+### MongoDB TTL Indexes (automatic)
+
+| Collection | TTL | Trigger |
+|---|---|---|
+| `AuditLog` | 90 days | `timestamp` |
+| `Collection` | 7 days after `expiresAt` | `expiresAt` |
+| `ShareLink` | 7 days after `expiresAt` | `expiresAt` |
+
+---
+
+## 19. Deployment
+
+### Docker (recommended)
+
+```bash
+git clone https://github.com/Christianoooooo/sharely.git
+cd sharely
+cp .env.example .env
+# Edit .env (SESSION_SECRET, MONGO passwords, BASE_URL)
+docker compose up -d
+```
+
+**Services:**
+- `app` — Node.js app (port 3000)
+- `mongo` — MongoDB 7 (port 127.0.0.1:27017, not externally accessible)
+
+**Volumes:**
+- `uploads` — persistent file storage
+- `mongo_data` — MongoDB data
+
+**Health checks:** App checks HTTP 200 on `/`, MongoDB checks `db.adminCommand('ping')`.
+
+### Nginx Reverse Proxy
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name files.example.com;
+
+    client_max_body_size 2100M;  # At least as large as the biggest chunk + buffer
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket support
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+```
+
+> `BASE_URL` in `.env` must match the public domain.
+
+### First Start
+
+The first registered user automatically receives the `admin` role (`User.countDocuments() === 0`).
+
+---
+
+## 20. Development Environment
+
+### Prerequisites
+
+- Node.js ≥ 18
+- MongoDB (local or via Docker)
+- Optional: ffmpeg, ghostscript (for thumbnails)
+
+### Setup
+
+```bash
+# Backend
+npm install
+cp .env.example .env
+# Edit .env
+
+# Frontend
+cd client
+npm install
+```
+
+### Starting
+
+```bash
+# Backend (port 3000, with nodemon)
+npm run dev
+
+# Frontend (port 5173, separate terminal)
+cd client
+npm run dev
+```
+
+The Vite dev server automatically proxies API requests to `localhost:3000`.
+
+### Build
+
+```bash
+npm run build   # Builds client/dist/, backend remains unchanged
+npm start       # Starts the production Express server
+```
+
+---
+
+## 21. Migrations & Scripts
+
+### Automatic Migrations (on every start)
+
+These migrations run at app startup in `app.js` and are idempotent:
+
+| Migration | File | Function |
+|---|---|---|
+| User folder migration | `src/migrations/migrateUserFolders.js` | Moves files from `uploads/` into `uploads/{folderName}/` |
+| API key hash migration | `src/migrations/migrateApiKeyHashes.js` | Converts plaintext API keys to SHA-256 hashes |
+
+### Manual Scripts
+
+```bash
+# Generate thumbnails for already existing files
+npm run migrate:thumbnails
+# or:
+node scripts/generate-missing-thumbnails.js
+
+# Move uploads to user folders (manual)
+npm run migrate:user-folders
+# or:
+node scripts/migrate-uploads-to-user-folders.js
+```
+
+### Database Initialization (Docker)
+
+`scripts/mongo-init.js` is executed on the first start of the MongoDB container and creates the app user with the correct permissions.
+
+---
+
+## 22. End-to-End Tests
+
+**Framework:** Playwright (`@playwright/test`)
+
+### Test Files
+
+| File | Test Suite |
+|---|---|
+| `e2e/upload.spec.js` | Upload flows |
+| `e2e/gallery.spec.js` | Gallery and file management |
+| `e2e/admin.spec.js` | Admin dashboard |
+| `e2e/sharelink.spec.js` | Share link creation and usage |
+| `e2e/tags.spec.js` | Tag management |
+| `e2e/bulk-actions-fixes.spec.js` | Bulk actions |
+
+### Running Tests
+
+```bash
+# All tests
+npm run test:e2e
+
+# With UI
+npm run test:e2e:ui
+```
+
+**Playwright configuration:** `playwright.config.js`  
+**Global setup:** `e2e/global-setup.js` (creates test users, admin, etc.)  
+**Helpers:** `e2e/helpers.js` (shared helper functions)
+
+---
+
+## Appendix: Audit Log Actions
+
+| Action | Trigger |
+|---|---|
+| `login` | Successful login |
+| `logout` | Logout |
+| `register` | Registration |
+| `upload` | File upload |
+| `delete_file` | File deleted |
+| `delete_account` | Account deleted |
+| `change_password` | Password changed |
+| `change_username` | Username changed |
+| `change_email` | Email changed |
+| `verify_email` | Email verified |
+| `forgot_password` | Password reset requested |
+| `reset_password` | Password reset |
+| `regen_api_key` | API key regenerated |
+| `sharex_config` | ShareX configuration downloaded |
+| `export_data` | Data export |
+| `admin_create_user` | Admin: user created |
+| `admin_delete_user` | Admin: user deleted |
+| `admin_toggle_user` | Admin: user activated/deactivated |
+| `admin_change_role` | Admin: user role changed |
+| `admin_change_password` | Admin: password set |
+| `admin_regen_key` | Admin: API key regenerated |
+
+---
+
+*Documentation generated from the source code of sharely v1.0.0*

--- a/docs/es.md
+++ b/docs/es.md
@@ -1,0 +1,1264 @@
+# Sharely — Documentación Técnica
+
+> **Versión:** 1.0.0 · **Licencia:** MIT · **Node.js:** ≥ 18
+
+---
+
+## Índice
+
+1. [Descripción del proyecto](#1-descripción-del-proyecto)
+2. [Arquitectura](#2-arquitectura)
+3. [Stack tecnológico](#3-stack-tecnológico)
+4. [Estructura de directorios](#4-estructura-de-directorios)
+5. [Configuración y variables de entorno](#5-configuración-y-variables-de-entorno)
+6. [Modelos de datos](#6-modelos-de-datos)
+7. [API REST](#7-api-rest)
+8. [API WebSocket](#8-api-websocket)
+9. [Rutas de servicio de archivos](#9-rutas-de-servicio-de-archivos)
+10. [Autenticación y seguridad](#10-autenticación-y-seguridad)
+11. [Sistema de carga](#11-sistema-de-carga)
+12. [Generación de miniaturas](#12-generación-de-miniaturas)
+13. [Correo electrónico y SMTP](#13-correo-electrónico-y-smtp)
+14. [Internacionalización](#14-internacionalización)
+15. [Frontend (React SPA)](#15-frontend-react-spa)
+16. [Panel de administración](#16-panel-de-administración)
+17. [RGPD / Privacidad](#17-rgpd--privacidad)
+18. [Tareas en segundo plano](#18-tareas-en-segundo-plano)
+19. [Despliegue](#19-despliegue)
+20. [Entorno de desarrollo](#20-entorno-de-desarrollo)
+21. [Migraciones y scripts](#21-migraciones-y-scripts)
+22. [Pruebas end-to-end](#22-pruebas-end-to-end)
+
+---
+
+## 1. Descripción del proyecto
+
+Sharely es una **plataforma de intercambio de archivos autoalojada** con una interfaz web limpia, integración con ShareX y acceso mediante API. Los usuarios suben capturas de pantalla, archivos y contenido multimedia, y los comparten al instante mediante enlaces cortos.
+
+### Funcionalidades principales
+
+| Funcionalidad | Descripción |
+|---|---|
+| Carga web | Arrastrar y soltar, hasta 500 archivos simultáneamente |
+| Carga por partes | Archivos de hasta 2 GB mediante carga multi-parte paralela |
+| Integración ShareX | Archivo de configuración `.sxcu` descargable con un clic |
+| Carga por API | Autenticación por token Bearer, compatible con curl/wget |
+| Visor de archivos | Zoom en imágenes, transmisión de vídeo/audio (HTTP Range), PDF en línea, código con resaltado de sintaxis |
+| Modos de incrustación | *embed* (HTML OG/Twitter Card) o *raw* (redirección directa) |
+| Miniaturas | Vistas previas JPEG automáticas para vídeos (ffmpeg) y PDFs (ghostscript) |
+| Colecciones | Agrupaciones de archivos con contraseña y fecha de expiración opcionales |
+| Enlaces de compartición | Enlaces por archivo con contraseña, expiración y límite de descargas |
+| Interfaz en tiempo real | Actualizaciones en vivo por WebSocket (carga, eliminación, contador de visitas, estadísticas admin) |
+| Multilingüe | 8 idiomas: EN, DE, FR, ES, IT, PT, JA, ZH |
+| Panel de administración | Estadísticas, gestión de usuarios, gestión de archivos, registro de auditoría (exportación CSV) |
+| Cumplimiento RGPD | Funcionalidades de privacidad conforme al RGPD (Art. 17, 20, 32, etc.) |
+| Importación XBackBone | Migración de instalaciones XBackBone existentes |
+| Listo para Docker | `docker compose up -d` inicia el entorno completo |
+
+---
+
+## 2. Arquitectura
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Browser / Client                      │
+│            React 18 SPA  ·  Vite  ·  Tailwind CSS           │
+│   ┌──────────────────────────────────────────────────────┐   │
+│   │  HTTP REST (/api/*)            WebSocket (/ws)       │   │
+│   └──────────────────────────────────────────────────────┘   │
+└───────────────────────────┬────────────────────┬─────────────┘
+                            │ HTTP               │ WS
+┌───────────────────────────▼────────────────────▼─────────────┐
+│                    Express.js (app.js)                        │
+│                                                               │
+│  ┌──────────────┐  ┌───────────┐  ┌──────────┐  ┌────────┐  │
+│  │  /api/auth   │  │  /api/*   │  │   /f/*   │  │  /s/*  │  │
+│  │  /api/install│  │  routes   │  │  files   │  │ shares │  │
+│  └──────────────┘  └───────────┘  └──────────┘  └────────┘  │
+│                                                               │
+│  Middleware: session · rate-limit · CSRF · CSP · auth        │
+│                                                               │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌────────────┐  │
+│  │  multer  │  │  ws.js   │  │  mailer  │  │ retention  │  │
+│  │  upload  │  │ WebSocket│  │ nodemailer│  │  cleanup   │  │
+│  └──────────┘  └──────────┘  └──────────┘  └────────────┘  │
+└───────────────────────────┬───────────────────────────────────┘
+                            │
+┌───────────────────────────▼───────────────────────────────────┐
+│                      MongoDB (Mongoose)                        │
+│  User · File · Collection · ShareLink · SiteSettings          │
+│  AuditLog                                                      │
+└───────────────────────────────────────────────────────────────┘
+                            │
+              ┌─────────────▼───────────────┐
+              │     Dateisystem (uploads/)   │
+              │  {folderName}/  ·  .chunks/  │
+              │  .thumbnails/   ·  .avatars/ │
+              └─────────────────────────────┘
+```
+
+### Flujo de datos: Carga estándar
+
+```
+Browser → POST /api/web-upload (multipart/form-data)
+       → multer: Datei in uploads/{folderName}/
+       → File.createUnique() → MongoDB
+       → generateThumbnail() (async, non-blocking)
+       → logAudit()
+       → broadcast('file:uploaded') via WebSocket
+       ← JSON: { files: [...] }
+```
+
+### Flujo de datos: Carga ShareX
+
+```
+ShareX → POST /upload (token im Formular-Body)
+       → multer: Datei temporär in uploads/
+       → requireApiKey: Token-Lookup → User
+       → fs.renameSync → uploads/{folderName}/
+       → File.create() → MongoDB
+       ← JSON: { url, delete_url }
+```
+
+---
+
+## 3. Stack tecnológico
+
+| Capa | Tecnología | Versión |
+|---|---|---|
+| **Runtime** | Node.js | ≥ 18 |
+| **Framework backend** | Express.js | 4.x |
+| **Base de datos** | MongoDB + Mongoose | Mongo 7, Mongoose 8.x |
+| **Sesiones** | express-session + connect-mongo | — |
+| **Tiempo real** | WebSocket (`ws`) | 8.x |
+| **Carga de archivos** | Multer | 1.x |
+| **Correo electrónico** | Nodemailer | 8.x |
+| **Hash de contraseñas** | bcryptjs | 2.x (12 rondas) |
+| **Hash de claves API** | SHA-256 (Node Crypto) | — |
+| **Limitación de tasa** | express-rate-limit | 8.x |
+| **Importación XBackBone** | sql.js | 1.x |
+| **Framework frontend** | React 18 | 18.3.x |
+| **Enrutamiento (frontend)** | React Router v6 | 6.x |
+| **Herramienta de compilación** | Vite | 6.x |
+| **Estilos** | Tailwind CSS + Radix UI | 3.x |
+| **Componentes UI** | shadcn/ui (Radix primitives) | — |
+| **Iconos** | FontAwesome | 6.x |
+| **i18n** | i18next + react-i18next | — |
+| **Resaltado de sintaxis** | highlight.js | 11.x |
+| **Contenedores** | Docker + Docker Compose | — |
+| **Pruebas** | Playwright (E2E) | 1.60.x |
+
+---
+
+## 4. Estructura de directorios
+
+```
+sharely/
+├── app.js                          # Punto de entrada Express, secuencia de inicio
+├── package.json
+├── .env.example                    # Plantilla para todas las variables de entorno
+├── Dockerfile
+├── docker-compose.yml
+│
+├── src/
+│   ├── config/
+│   │   └── db.js                   # Conexión MongoDB (Mongoose)
+│   ├── middleware/
+│   │   ├── auth.js                 # requireLogin / requireAdmin / requireApiKey
+│   │   └── upload.js               # Configuración Multer, lista de bloqueo
+│   ├── models/
+│   │   ├── AuditLog.js             # Eventos de auditoría (TTL 90 días)
+│   │   ├── Collection.js           # Colecciones de archivos
+│   │   ├── File.js                 # Metadatos de archivos
+│   │   ├── ShareLink.js            # Enlaces de compartición por archivo
+│   │   ├── SiteSettings.js         # Singleton: configuración del operador
+│   │   └── User.js                 # Cuentas de usuario + claves API
+│   ├── routes/
+│   │   ├── api.js                  # API principal (carga, galería, admin, ...)
+│   │   ├── auth.js                 # Login / Registro / Restablecimiento de contraseña
+│   │   ├── files.js                # Servicio de archivos, embeds OG, solicitudes de rango
+│   │   ├── import.js               # Migración XBackBone
+│   │   ├── install.js              # Endpoint de instalación inicial
+│   │   └── shares.js               # Servicio de archivos por enlace de compartición
+│   ├── jobs/
+│   │   └── retentionCleanup.js     # Eliminación diaria de archivos expirados
+│   ├── migrations/
+│   │   ├── migrateApiKeyHashes.js  # Única vez: textos en claro → hashes SHA-256
+│   │   └── migrateUserFolders.js   # Única vez: mover archivos a carpetas de usuario
+│   ├── utils/
+│   │   ├── audit.js                # Función auxiliar logAudit()
+│   │   ├── generateThumbnail.js    # Integración ffmpeg / ghostscript
+│   │   ├── mailer.js               # Wrapper Nodemailer + plantillas de email i18n
+│   │   └── sanitizeFilename.js     # Saneamiento de nombre de archivo
+│   └── ws.js                       # Servidor WebSocket + despachador de acciones
+│
+├── client/                         # Frontend React
+│   ├── index.html
+│   ├── package.json
+│   ├── vite.config.js
+│   ├── tailwind.config.js
+│   └── src/
+│       ├── main.jsx                # Punto de entrada React
+│       ├── App.jsx                 # Configuración del enrutador
+│       ├── index.css               # Estilos globales
+│       ├── context/
+│       │   └── AuthContext.jsx     # Estado de autenticación global
+│       ├── hooks/
+│       │   ├── use-toast.js        # Hook de notificaciones toast
+│       │   └── useWebSocket.js     # Conexión WS + manejadores de eventos
+│       ├── components/
+│       │   ├── Layout.jsx          # Shell de la aplicación (barra de navegación, sidebar)
+│       │   ├── ProtectedRoute.jsx  # Guardia de autenticación
+│       │   ├── ShareLinkDialog.jsx # Diálogo de creación de enlace de compartición
+│       │   ├── AddToCollectionDialog.jsx
+│       │   ├── CookieBanner.jsx
+│       │   ├── LanguageSelector.jsx
+│       │   ├── RequireEmailDialog.jsx
+│       │   ├── UserAvatar.jsx
+│       │   └── ui/                 # Componentes base shadcn/ui
+│       ├── pages/
+│       │   ├── Upload.jsx          # Página de carga
+│       │   ├── Gallery.jsx         # Galería de archivos
+│       │   ├── FileView.jsx        # Vista detallada de archivo
+│       │   ├── Collections.jsx     # Vista general de colecciones
+│       │   ├── CollectionView.jsx  # Colección individual
+│       │   ├── ShareView.jsx       # Página pública de enlace de compartición
+│       │   ├── Settings.jsx        # Configuración de usuario
+│       │   ├── Login.jsx
+│       │   ├── Register.jsx
+│       │   ├── ForgotPassword.jsx
+│       │   ├── ResetPassword.jsx
+│       │   ├── Install.jsx         # Instalación inicial
+│       │   ├── PrivacyPolicy.jsx
+│       │   ├── TermsOfService.jsx
+│       │   └── admin/
+│       │       ├── Dashboard.jsx   # Página de inicio admin
+│       │       ├── Users.jsx       # Gestión de usuarios
+│       │       ├── Files.jsx       # Gestión de archivos
+│       │       ├── AuditLog.jsx    # Vista del registro de auditoría
+│       │       ├── SiteSettings.jsx# Configuración del operador
+│       │       └── Import.jsx      # Importación XBackBone
+│       ├── i18n/
+│       │   ├── index.js            # Configuración i18next
+│       │   └── locales/
+│       │       ├── de.json
+│       │       ├── en.json
+│       │       ├── es.json
+│       │       ├── fr.json
+│       │       ├── it.json
+│       │       ├── ja.json
+│       │       ├── pt.json
+│       │       └── zh.json
+│       └── lib/
+│           └── utils.js            # Utilidad Tailwind (cn())
+│
+├── scripts/
+│   ├── setup-db.js
+│   ├── mongo-init.js               # Script de inicialización MongoDB
+│   ├── migrate-uploads-to-user-folders.js
+│   └── generate-missing-thumbnails.js
+│
+├── e2e/                            # Pruebas Playwright
+│   ├── admin.spec.js
+│   ├── bulk-actions-fixes.spec.js
+│   ├── gallery.spec.js
+│   ├── sharelink.spec.js
+│   ├── tags.spec.js
+│   ├── upload.spec.js
+│   ├── helpers.js
+│   └── global-setup.js
+│
+├── uploads/                        # Archivos subidos (runtime)
+│   ├── .thumbnails/
+│   ├── .avatars/
+│   └── .chunks/                    # Fragmentos temporales
+│
+└── docs/assets/                    # Capturas de pantalla y logotipo
+```
+
+---
+
+## 5. Configuración y variables de entorno
+
+Todas las variables se cargan desde `.env` (mediante `dotenv`). El archivo `.env.example` contiene la plantilla completa.
+
+### Campos obligatorios
+
+| Variable | Descripción |
+|---|---|
+| `SESSION_SECRET` | Secreto para el cifrado de sesiones — cadena aleatoria larga, p. ej. `openssl rand -hex 32` |
+| `MONGO_ROOT_PASSWORD` | Contraseña root de MongoDB (requerida solo para Docker Compose) |
+| `MONGO_APP_PASSWORD` | Contraseña del usuario de aplicación de MongoDB |
+
+### Todas las variables de entorno
+
+| Variable | Por defecto | Descripción |
+|---|---|---|
+| `PORT` | `3000` | Puerto TCP del servidor HTTP |
+| `MONGODB_URI` | _(construida desde Docker Compose)_ | URI de conexión MongoDB completa |
+| `MONGO_ROOT_PASSWORD` | — | Contraseña root de MongoDB |
+| `MONGO_APP_USER` | `appuser` | Nombre de usuario de aplicación MongoDB |
+| `MONGO_APP_PASSWORD` | — | Contraseña del usuario de aplicación MongoDB |
+| `MONGO_DB_NAME` | `sharely` | Nombre de la base de datos MongoDB |
+| `SESSION_SECRET` | — | **Obligatorio** — secreto de cifrado de sesiones |
+| `BASE_URL` | `http://localhost:3000` | URL base pública para los enlaces de compartición generados (sin `/` final) |
+| `SITE_NAME` | `sharely` | Nombre del sitio en los embeds Open Graph |
+| `MAX_FILE_SIZE_MB` | `100` | Tamaño máximo de archivo para cargas estándar en MB (cargas por partes hasta 2 GB independientemente) |
+| `ALLOW_REGISTRATION` | `true` | `false` desactiva el registro público |
+| `SMTP_HOST` | — | Nombre de host del servidor SMTP; dejar vacío para desactivar las funciones de email |
+| `SMTP_PORT` | `587` | Puerto SMTP |
+| `SMTP_SECURE` | `false` | `true` para TLS implícito (puerto 465), `false` para STARTTLS |
+| `SMTP_USER` | — | Nombre de usuario SMTP |
+| `SMTP_PASS` | — | Contraseña SMTP |
+| `SMTP_FROM` | _(SMTP_USER)_ | Dirección de remitente en los correos salientes |
+| `UPLOAD_DIR` | `./uploads` | Ruta absoluta al directorio de carga |
+| `NODE_ENV` | — | `production` activa las cookies seguras |
+
+---
+
+## 6. Modelos de datos
+
+### User (`src/models/User.js`)
+
+```
+{
+  username:                    String (3–32, único, alfanumérico + _-)
+  password:                    String (bcrypt, 12 rondas)
+  role:                        'admin' | 'user'
+  apiKey:                      String (legado, vacío tras migración)
+  apiKeyHash:                  String (SHA-256, único, sparse)
+  apiKeyPrefix:                String (primeros 8 caracteres del texto en claro)
+  folderName:                  String (único, sparse, máx. 64)
+  avatarExt:                   String | null (.jpg/.png/.gif/.webp)
+  embedMode:                   'embed' | 'raw'
+  isActive:                    Boolean
+  email:                       String (minúsculas, único, sparse)
+  emailVerified:               Boolean
+  emailVerificationToken:      String | null (hash SHA-256 del texto en claro)
+  emailVerificationExpires:    Date | null
+  passwordResetToken:          String | null (hash SHA-256)
+  passwordResetExpires:        Date | null
+  language:                    'en'|'de'|'fr'|'es'|'it'|'pt'|'ja'|'zh'
+  predefinedTags:              [String] (máx. 100 etiquetas × 50 caracteres)
+  createdAt:                   Date
+}
+```
+
+**Métodos importantes:**
+- `user.comparePassword(candidate)` — comparación bcrypt
+- `user.regenerateApiKey()` — genera nuevo texto en claro, almacena el hash, devuelve el texto en claro (visible solo una vez)
+- `User.findByApiKey(plaintext)` — búsqueda por hash SHA-256, solo usuarios activos
+
+### File (`src/models/File.js`)
+
+```
+{
+  shortId:      String (8 caracteres hexadecimales: 6 timestamp + 2 aleatorios, único)
+  deleteToken:  String (32 caracteres hexadecimales, único)
+  originalName: String (saneado)
+  storedName:   String (ruta relativa: "folderName/8hex.ext")
+  mimeType:     String
+  size:         Number (bytes)
+  uploader:     ObjectId → User
+  views:        Number
+  tags:         [String] (máx. 20 × 50 caracteres)
+  createdAt:    Date
+}
+```
+
+**Propiedades calculadas:**
+- `sizeHuman` — tamaño legible (B / KB / MB / GB)
+- `displayType` — clasificación: `image|video|audio|pdf|code|text|file`
+
+**Algoritmo Short ID:**
+```
+shortId = hex(seconds_since_2024-01-01, 6 chars) + randomBytes(2).hex()
+```
+
+### Collection (`src/models/Collection.js`)
+
+```
+{
+  shortId:     String (8 Hex, único)
+  name:        String (máx. 100)
+  description: String (máx. 500)
+  owner:       ObjectId → User
+  files:       [ObjectId → File]
+  password:    String | null (bcrypt)
+  expiresAt:   Date | null
+  createdAt:   Date
+}
+```
+
+> Las colecciones expiradas son eliminadas automáticamente por el índice TTL de MongoDB 7 días después de su expiración.
+
+### ShareLink (`src/models/ShareLink.js`)
+
+```
+{
+  token:         String (32 Hex, único)
+  file:          ObjectId → File
+  createdBy:     ObjectId → User
+  label:         String (máx. 100)
+  password:      String | null (bcrypt)
+  expiresAt:     Date | null
+  downloadLimit: Number (-1 = ilimitado)
+  downloadCount: Number
+  createdAt:     Date
+}
+```
+
+> Como las colecciones: período de gracia de 7 días después de la expiración mediante índice TTL.
+
+### SiteSettings (`src/models/SiteSettings.js`)
+
+Documento singleton (`_id: 'singleton'`):
+
+```
+{
+  operatorName:        String
+  operatorAddress:     String
+  operatorEmail:       String
+  cloudflareAnalytics: Boolean
+  fileRetentionDays:   Number (0 = desactivado)
+  encryptionAtRest:    Boolean
+  sessionDurationDays: Number (por defecto: 7)
+  allowRegistration:   Boolean
+}
+```
+
+### AuditLog (`src/models/AuditLog.js`)
+
+```
+{
+  timestamp: Date (índice TTL: 90 días)
+  userId:    ObjectId → User | null
+  username:  String | null
+  action:    String
+  ip:        String | null
+  meta:      Mixed (metadatos específicos de la acción)
+}
+```
+
+---
+
+## 7. API REST
+
+### URL base: `/api`
+
+Todos los endpoints JSON devuelven `Content-Type: application/json`. Errores: `{ "error": "mensaje" }`.
+
+---
+
+### Autenticación (`/api/auth`)
+
+| Método | Ruta | Auth | Descripción |
+|---|---|---|---|
+| `GET` | `/me` | Sesión | Usuario actualmente conectado |
+| `POST` | `/login` | — | Iniciar sesión (limitado: 10/15min) |
+| `POST` | `/register` | — | Registrarse (limitado, el primer usuario se convierte en admin) |
+| `POST` | `/logout` | — | Cerrar sesión |
+| `GET` | `/smtp-enabled` | — | Comprobar si SMTP está configurado |
+| `GET` | `/verify-email?token=` | — | Verificar dirección de email |
+| `GET` | `/verify-reset-token?token=` | — | Validar token de restablecimiento |
+| `POST` | `/forgot-password` | — | Enviar email de restablecimiento de contraseña (limitado: 5/h) |
+| `POST` | `/reset-password` | — | Establecer nueva contraseña |
+
+**Petición de inicio de sesión:**
+```json
+POST /api/auth/login
+{ "username": "max", "password": "meinPasswort123" }
+```
+
+**Respuesta de inicio de sesión:**
+```json
+{
+  "user": {
+    "id": "...", "username": "max", "role": "user",
+    "avatarUrl": null, "email": "max@example.com",
+    "emailVerified": true, "language": "de"
+  }
+}
+```
+
+---
+
+### Carga de archivos
+
+| Método | Ruta | Auth | Descripción |
+|---|---|---|---|
+| `POST` | `/upload` | Clave API | Carga ShareX (endpoint legado en `app.js`) |
+| `POST` | `/api/upload` | Clave API | Carga ShareX/API (campo: `file`) |
+| `POST` | `/api/web-upload` | Sesión | Carga web (campo: `files[]`, máx. 500) |
+| `POST` | `/api/chunk/init` | Sesión | Inicializar carga por partes |
+| `POST` | `/api/chunk/:uploadId` | Sesión | Subir un fragmento (campo: `chunk`) |
+| `POST` | `/api/chunk/:uploadId/complete` | Sesión | Ensamblar fragmentos |
+| `DELETE` | `/api/chunk/:uploadId` | Sesión | Cancelar carga y limpiar |
+
+**Respuesta de carga por API:**
+```json
+{
+  "url": "https://example.com/f/a1b2c3d4",
+  "raw": "https://example.com/f/a1b2c3d4/raw",
+  "delete_url": "https://example.com/api/delete/a1b2c3d4",
+  "short_id": "a1b2c3d4",
+  "filename": "screenshot.png",
+  "size": 102400
+}
+```
+
+#### Flujo de carga por partes
+
+1. `POST /api/chunk/init` → `{ uploadId: "32hex" }`
+2. `POST /api/chunk/:uploadId` (Cuerpo: `chunkIndex=N`, Archivo: `chunk`) → `{ received: N }`  
+   En paralelo con 3–5 fragmentos simultáneos
+3. `POST /api/chunk/:uploadId/complete` → `{ files: [fileObject] }`
+
+---
+
+### Gestión de archivos
+
+| Método | Ruta | Auth | Descripción |
+|---|---|---|---|
+| `GET` | `/api/gallery` | Sesión | Archivos propios (admin: todos), paginado (24/página), filtros: `q`, `type`, `tag`, `page` |
+| `GET` | `/api/file/:shortId` | — | Metadatos del archivo (incrementa el contador de vistas) |
+| `PATCH` | `/api/file/:shortId` | Sesión | Actualizar etiquetas/nombre |
+| `DELETE` | `/api/file/:shortId` | Sesión | Eliminar archivo |
+| `DELETE` | `/api/delete/:shortId` | Clave API | Eliminar archivo (autenticación por clave API) |
+| `POST` | `/api/files/bulk` | Sesión | Acciones en masa: `delete`, `tag`, `removeTag`, `addToCollection`, `moveToCollection` |
+| `GET` | `/api/tags` | Sesión | Todas las sugerencias de etiquetas del usuario |
+
+**Parámetros de consulta de la galería:**
+- `q` — búsqueda en el nombre de archivo (seguro para regex)
+- `type` — `all|image|video|audio|pdf|code`
+- `tag` — filtro de etiqueta exacto
+- `page` — número de página (por defecto: 1)
+
+---
+
+### Configuración de usuario
+
+| Método | Ruta | Auth | Descripción |
+|---|---|---|---|
+| `GET` | `/api/my-key` | Sesión | Mostrar prefijo de clave API |
+| `POST` | `/api/regen-key` | Sesión | Regenerar clave API |
+| `GET` | `/api/sharex-config` | Sesión | Descargar ShareX `.sxcu` (regenera la clave) |
+| `PATCH` | `/api/user/username` | Sesión | Cambiar nombre de usuario (contraseña requerida) |
+| `PATCH` | `/api/user/password` | Sesión | Cambiar contraseña |
+| `PATCH` | `/api/user/email` | Sesión | Cambiar email (envía email de verificación) |
+| `PATCH` | `/api/user/language` | Sesión | Establecer idioma de la interfaz |
+| `PATCH` | `/api/user/embed-mode` | Sesión | Establecer modo de incrustación (`embed`/`raw`) |
+| `POST` | `/api/user/resend-verification` | Sesión | Reenviar email de verificación |
+| `GET` | `/api/user/export` | Sesión | Exportación de datos (RGPD Art. 20) como JSON |
+| `DELETE` | `/api/user/account` | Sesión | Eliminar cuenta (RGPD Art. 17, contraseña requerida) |
+| `GET` | `/api/user/predefined-tags` | Sesión | Obtener etiquetas predefinidas |
+| `PATCH` | `/api/user/predefined-tags` | Sesión | Actualizar etiquetas predefinidas |
+| `POST` | `/api/user/avatar` | Sesión | Subir avatar (máx. 2 MB, JPEG/PNG/GIF/WebP) |
+| `DELETE` | `/api/user/avatar` | Sesión | Eliminar avatar |
+| `GET` | `/api/user/avatar/:userId` | — | Servir avatar |
+
+---
+
+### Enlaces de compartición
+
+| Método | Ruta | Auth | Descripción |
+|---|---|---|---|
+| `GET` | `/api/file/:shortId/share-links` | Sesión (Propietario/Admin) | Todos los enlaces de compartición de un archivo |
+| `POST` | `/api/file/:shortId/share-links` | Sesión (Propietario/Admin) | Crear enlace de compartición |
+| `DELETE` | `/api/share-links/:token` | Sesión (Propietario/Creador/Admin) | Eliminar enlace de compartición |
+| `GET` | `/api/share-links/:token` | — | Metadatos del enlace de compartición (público) |
+| `POST` | `/api/share-links/:token/verify` | — | Verificar contraseña del enlace de compartición |
+
+**Crear enlace de compartición:**
+```json
+POST /api/file/a1b2c3d4/share-links
+{
+  "label": "Para colegas",
+  "password": "secreto",
+  "expiresAt": "2025-12-31T23:59:59Z",
+  "downloadLimit": 10
+}
+```
+
+---
+
+### Colecciones
+
+| Método | Ruta | Auth | Descripción |
+|---|---|---|---|
+| `GET` | `/api/collections` | Sesión | Colecciones propias (admin: todas) |
+| `POST` | `/api/collections` | Sesión | Crear colección |
+| `GET` | `/api/collections/:id` | — | Ver colección (pública, contraseña si está definida) |
+| `PATCH` | `/api/collections/:id` | Sesión (Propietario/Admin) | Actualizar colección |
+| `DELETE` | `/api/collections/:id` | Sesión (Propietario/Admin) | Eliminar colección |
+| `POST` | `/api/collections/:id/files` | Sesión (Propietario/Admin) | Añadir archivo a la colección |
+| `DELETE` | `/api/collections/:id/files/:fileShortId` | Sesión (Propietario/Admin) | Eliminar archivo de la colección |
+| `POST` | `/api/collections/:id/verify` | — | Verificar contraseña de la colección |
+
+---
+
+### Endpoints de administración
+
+| Método | Ruta | Auth | Descripción |
+|---|---|---|---|
+| `GET` | `/api/admin/stats` | Admin | Estadísticas del panel de control |
+| `GET` | `/api/admin/users` | Admin | Todos los usuarios (con número de archivos) |
+| `POST` | `/api/admin/users` | Admin | Crear usuario |
+| `PATCH` | `/api/admin/users/:id/toggle` | Admin | Activar/desactivar usuario |
+| `PATCH` | `/api/admin/users/:id/role` | Admin | Cambiar rol de usuario |
+| `DELETE` | `/api/admin/users/:id` | Admin | Eliminar usuario |
+| `POST` | `/api/admin/users/:id/regen-key` | Admin | Regenerar clave API |
+| `PATCH` | `/api/admin/users/:id/password` | Admin | Establecer contraseña |
+| `PATCH` | `/api/admin/users/:id/folder` | Admin | Cambiar nombre de carpeta (mueve archivos) |
+| `GET` | `/api/admin/files` | Admin | Todos los archivos, paginado (30/página) |
+| `GET` | `/api/admin/site-settings` | Admin | Leer configuración del operador |
+| `PATCH` | `/api/admin/site-settings` | Admin | Actualizar configuración del operador |
+| `GET` | `/api/admin/audit-log` | Admin | Registro de auditoría paginado (50/página) |
+| `GET` | `/api/admin/audit-log/export` | Admin | Descargar registro de auditoría como CSV |
+| `GET` | `/api/site-settings` | — | Información pública del operador (para la página de privacidad) |
+
+---
+
+### Configuración del sitio (pública)
+
+```json
+GET /api/site-settings
+{
+  "operatorName": "Musterfirma GmbH",
+  "operatorAddress": "Musterstr. 1, 12345 Musterstadt",
+  "operatorEmail": "datenschutz@example.com",
+  "cloudflareAnalytics": false,
+  "fileRetentionDays": 365,
+  "encryptionAtRest": false,
+  "sessionDurationDays": 7
+}
+```
+
+---
+
+## 8. API WebSocket
+
+**Conexión:** `wss://example.com/ws` (solo para usuarios con sesión iniciada, se requiere cookie de sesión)
+
+### Protocolo
+
+**Cliente → Servidor (Solicitud):**
+```json
+{ "id": "req-abc123", "action": "file:list", "payload": { "type": "image", "page": 1 } }
+```
+
+**Servidor → Cliente (Respuesta):**
+```json
+{ "id": "req-abc123", "data": { ... } }
+```
+
+**Servidor → Cliente (Error):**
+```json
+{ "id": "req-abc123", "error": "Forbidden", "status": 403 }
+```
+
+**Servidor → Cliente (Difusión):**
+```json
+{ "event": "file:uploaded", "data": { "shortId": "a1b2c3d4", "uploaderId": "..." } }
+```
+
+### Acciones disponibles
+
+| Acción | Auth | Descripción |
+|---|---|---|
+| `site-settings:get` | — | Configuración pública del sitio |
+| `auth:me` | Usuario | Datos del usuario conectado |
+| `file:get` | Usuario | Detalles del archivo (incrementa vistas) |
+| `file:list` | Usuario | Lista de archivos con filtro/paginación |
+| `file:delete` | Usuario | Eliminar archivo |
+| `user:get-key` | Usuario | Prefijo de clave API |
+| `user:regen-key` | Usuario | Regenerar clave API |
+| `user:change-password` | Usuario | Cambiar contraseña |
+| `user:change-username` | Usuario | Cambiar nombre de usuario |
+| `user:change-email` | Usuario | Cambiar email |
+| `user:change-language` | Usuario | Establecer idioma |
+| `user:change-embed-mode` | Usuario | Establecer modo de incrustación |
+| `user:resend-verification` | Usuario | Reenviar email de verificación |
+| `user:export` | Usuario | Exportación de datos |
+| `user:delete-account` | Usuario | Eliminar cuenta |
+| `admin:stats` | Admin | Estadísticas del panel |
+| `admin:settings:get` | Admin | Leer configuración del sitio |
+| `admin:settings:update` | Admin | Actualizar configuración del sitio |
+| `admin:users:list` | Admin | Todos los usuarios |
+| `admin:users:create` | Admin | Crear usuario |
+| `admin:users:toggle` | Admin | Activar/desactivar usuario |
+| `admin:users:role` | Admin | Cambiar rol de usuario |
+| `admin:users:delete` | Admin | Eliminar usuario |
+| `admin:users:regen-key` | Admin | Regenerar clave API |
+| `admin:users:password` | Admin | Establecer contraseña |
+| `admin:users:folder` | Admin | Cambiar nombre de carpeta |
+| `admin:files:list` | Admin | Todos los archivos |
+| `admin:audit-log:list` | Admin | Registro de auditoría paginado |
+
+### Eventos de difusión
+
+| Evento | Destinatarios | Carga útil |
+|---|---|---|
+| `file:uploaded` | Cargador | `{ shortId, uploaderId }` |
+| `file:deleted` | Propietario del archivo | `{ shortId, uploaderId }` |
+| `file:view` | Todos | `{ shortId, views }` |
+| `user:created` | Admins | `{ id, username, role, ... }` |
+| `user:deleted` | Admins | `{ id }` |
+| `user:updated` | Admins | `{ id, ...campos modificados }` |
+| `audit:log` | Admins | Objeto AuditLog completo |
+| `settings:updated` | Admins | Objeto SiteSettings actualizado |
+| `stats:invalidate` | Admins | `{}` (activa la actualización de estadísticas) |
+
+---
+
+## 9. Rutas de servicio de archivos
+
+### `/f/:shortId` — Visor de archivos
+
+- **Solicitud de navegador:** Redirige a la React SPA (`index.html`) — la SPA renderiza el visor.
+- **Bot de red social** (Discord, Telegram, Twitter, etc.): Devuelve una página HTML mínima con metaetiquetas Open Graph / Twitter Card.
+  - `embedMode = 'embed'`: HTML OG con redirección
+  - `embedMode = 'raw'` + imagen/vídeo/audio: HTTP 302 → `/f/:shortId/raw`
+
+### `/f/:shortId/raw` — Acceso directo
+
+Sirve el archivo como respuesta HTTP con soporte de solicitudes de rango (206 Partial Content). Imágenes/vídeos/audio: `Content-Disposition: inline`, otros: `attachment`.
+
+### `/f/:shortId/download` — Descarga forzada
+
+Como `/raw`, pero siempre `Content-Disposition: attachment`.
+
+### `/f/:shortId/thumb` — Miniatura
+
+Devuelve la miniatura JPEG (para vídeos y PDFs). `Cache-Control: public, max-age=86400`.
+
+### `/f/:shortId/delete/:token` — Eliminación ShareX
+
+Elimina el archivo sin sesión mediante un token de eliminación único.
+
+### `/s/:token` — Servicio de archivos por enlace de compartición (`src/routes/shares.js`)
+
+Verifica la contraseña (mediante flag de sesión), la fecha de expiración y el límite de descargas, y luego sirve el archivo.
+
+---
+
+## 10. Autenticación y seguridad
+
+### Autenticación por sesión
+
+- Sesión Express con almacenamiento MongoDB (`connect-mongo`)
+- Cookie de sesión: `httpOnly: true`, `sameSite: 'strict'`, `secure: true` en producción
+- Duración de sesión: configurable mediante `SiteSettings.sessionDurationDays` (por defecto: 7 días), con caché en vivo de 60 segundos
+
+### Autenticación por clave API
+
+- Las claves API se almacenan como hashes SHA-256, nunca en texto en claro
+- Los primeros 8 caracteres se almacenan como `apiKeyPrefix` (para visualización)
+- Búsqueda: `User.findByApiKey(plaintext)` calcula el hash y busca en `apiKeyHash`
+- Al descargar la configuración de ShareX, la clave se regenera — el texto en claro solo es visible en ese momento
+
+### Cadena de middleware (`src/middleware/auth.js`)
+
+```
+requireLogin    → verifica req.session.user → 401 si no está conectado
+requireAdmin    → como requireLogin, además role === 'admin' → 403
+requireApiKey   → verifica la cabecera Authorization o req.body.token
+```
+
+### Protección CSRF
+
+`requireSameOrigin()` en `app.js` compara la cabecera `Origin` con la cabecera `Host` para todas las rutas API. Complementa las cookies `sameSite: 'strict'`.
+
+### Política de seguridad de contenido
+
+```
+default-src 'self';
+script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com;
+style-src 'self' 'unsafe-inline';
+img-src 'self' data: blob:;
+media-src 'self' blob:;
+connect-src 'self' https://cloudflareinsights.com;
+frame-ancestors 'self';
+```
+
+### Cabeceras de seguridad
+
+- `X-Frame-Options: SAMEORIGIN`
+- `X-Content-Type-Options: nosniff`
+
+### Limitación de tasa
+
+| Endpoint | Límite | Ventana |
+|---|---|---|
+| Carga (`/upload`, `/api/upload`, `/api/web-upload`) | 60 solicitudes | 15 minutos |
+| Auth (`/api/auth/login`, `/register`, etc.) | 10 solicitudes | 15 minutos |
+| Restablecimiento de contraseña | 5 solicitudes | 1 hora |
+
+### Lista de bloqueo de archivos
+
+Los siguientes tipos MIME y extensiones son rechazados en la carga:
+
+**Tipos MIME bloqueados:** `application/x-executable`, `application/x-sh`, `application/x-csh`, `application/x-bat`
+
+**Extensiones bloqueadas:** `.bat`, `.cmd`, `.com`, `.ps1`, `.psm1`, `.psd1`, `.sh`, `.bash`, `.csh`, `.zsh`, `.fish`, `.vbs`, `.vbe`, `.jse`, `.scr`, `.pif`, `.application`, `.gadget`, `.hta`, `.php`, `.php3–5`, `.phtml`, `.asp`, `.aspx`, `.jsp`, `.jspx`, `.cfm`
+
+### Protección contra path traversal
+
+Todos los accesos a archivos mediante `resolveUploadPath()` verifican que la ruta resuelta se encuentre dentro de `UPLOAD_DIR`.
+
+---
+
+## 11. Sistema de carga
+
+### Carga estándar (Multer)
+
+- **Almacenamiento:** `multer.diskStorage` → `uploads/{folderName}/{8hex}{.ext}`
+- **Nombre de archivo:** `crypto.randomBytes(4).hex() + extensión-original`
+- **Límite:** `MAX_FILE_SIZE_MB` (por defecto: 100 MB)
+- **Ubicación:** Carpeta específica del usuario (`user.folderName`)
+
+### Carga por partes (>250 MB)
+
+El cliente frontend cambia automáticamente al modo de fragmentos para archivos grandes.
+
+**Estructura de directorios en el servidor:**
+```
+uploads/.chunks/{uploadId}/
+  meta.json          { filename, mimeType, totalSize, totalChunks, userId, createdAt }
+  chunk-0
+  chunk-1
+  ...
+  chunk-N
+```
+
+**Tamaño de fragmento:** 10–20 MB (máx. 51 MB aceptado para compatibilidad con versiones anteriores)  
+**Paralelismo:** 3–5 cargas de fragmentos simultáneas  
+**Ensamblado:** Basado en streams (sin carga completa en RAM)
+
+### Carga de avatar
+
+- **Almacenamiento:** `multer.memoryStorage()` (sin búfer de disco)
+- **Ubicación:** `uploads/.avatars/{userId}{.ext}`
+- **Límite:** 2 MB
+- **Formatos:** JPEG, PNG, GIF, WebP
+
+---
+
+## 12. Generación de miniaturas
+
+Las miniaturas se generan de forma asíncrona después de la carga (`.catch(() => {})` — los errores se ignoran silenciosamente).
+
+### Miniaturas de vídeo (ffmpeg)
+
+```bash
+ffmpeg -y -i <file> -ss 00:00:01 -vframes 1 \
+  -vf "scale=320:320:force_original_aspect_ratio=increase,crop=320:320" \
+  -q:v 3 uploads/.thumbnails/<shortId>.jpg
+```
+
+### Miniaturas de PDF (Ghostscript)
+
+```bash
+gs -dNOPAUSE -dBATCH -dSAFER \
+  -sDEVICE=jpeg -dFirstPage=1 -dLastPage=1 \
+  -r72 -dJPEGQ=85 \
+  -sOutputFile=uploads/.thumbnails/<shortId>.jpg \
+  <file>
+```
+
+**Tiempo de espera:** 30 segundos por generación de miniatura  
+**Alternativa:** Si ffmpeg/ghostscript no está disponible, la generación se omite silenciosamente.
+
+### Script de relleno
+
+```bash
+npm run migrate:thumbnails
+# o en el contenedor:
+docker exec -it <container> npm run migrate:thumbnails
+```
+
+---
+
+## 13. Correo electrónico y SMTP
+
+### Configuración
+
+SMTP se activa cuando se establece `SMTP_HOST`. `mailer.isConfigured()` verifica este valor.
+
+### Plantillas de correo electrónico
+
+Todos los correos se envían en el idioma del usuario (8 idiomas). Las plantillas están integradas en `src/utils/mailer.js`.
+
+**Tipos de correos enviados:**
+
+| Tipo | Disparador | Validez del token |
+|---|---|---|
+| Verificación de email | Registro, cambio de email | 24 horas |
+| Restablecimiento de contraseña | `POST /api/auth/forgot-password` | 1 hora |
+
+### Seguridad de los tokens
+
+- Tokens: `crypto.randomBytes(32).hex()` (64 caracteres hexadecimales)
+- Almacenados: hash SHA-256 del token
+- El correo contiene el token en texto en claro como parámetro URL
+- Verificación: hash del token entrante comparado con el hash almacenado
+
+---
+
+## 14. Internacionalización
+
+**Biblioteca:** i18next + react-i18next + i18next-browser-languagedetector
+
+**Idiomas admitidos:**
+
+| Código | Idioma |
+|---|---|
+| `en` | English |
+| `de` | Deutsch |
+| `fr` | Français |
+| `es` | Español |
+| `it` | Italiano |
+| `pt` | Português |
+| `ja` | 日本語 |
+| `zh` | 中文 |
+
+**Selección de idioma:**
+1. Detección del idioma del navegador (automática)
+2. Preferencia del usuario en la base de datos (`user.language`)
+3. Persistencia mediante `PATCH /api/user/language`
+
+Archivos de traducción: `client/src/i18n/locales/{code}.json`
+
+---
+
+## 15. Frontend (React SPA)
+
+### Configuración del enrutador (`client/src/App.jsx`)
+
+| Ruta | Componente | Auth |
+|---|---|---|
+| `/` | Redirección → `/gallery` | No |
+| `/auth/login` | Login.jsx | No |
+| `/auth/register` | Register.jsx | No |
+| `/auth/forgot-password` | ForgotPassword.jsx | No |
+| `/auth/reset-password` | ResetPassword.jsx | No |
+| `/install` | Install.jsx | No |
+| `/upload` | Upload.jsx | **Sí** |
+| `/gallery` | Gallery.jsx | **Sí** |
+| `/f/:shortId` | FileView.jsx | **Sí** |
+| `/collections` | Collections.jsx | **Sí** |
+| `/c/:id` | CollectionView.jsx | No (público) |
+| `/s/:token` | ShareView.jsx | No (público) |
+| `/settings` | Settings.jsx | **Sí** |
+| `/admin` | Dashboard.jsx | **Admin** |
+| `/admin/users` | Users.jsx | **Admin** |
+| `/admin/files` | Files.jsx | **Admin** |
+| `/admin/audit-log` | AuditLog.jsx | **Admin** |
+| `/admin/site-settings` | SiteSettings.jsx | **Admin** |
+| `/admin/import` | Import.jsx | **Admin** |
+| `/privacy` | PrivacyPolicy.jsx | No |
+| `/terms` | TermsOfService.jsx | No |
+
+### Contexto de autenticación (`client/src/context/AuthContext.jsx`)
+
+Estado global para el usuario con sesión iniciada. Inicializado al inicio de la aplicación mediante `GET /api/auth/me`.
+
+### Hook WebSocket (`client/src/hooks/useWebSocket.js`)
+
+Gestiona la conexión WS persistente. Proporciona `sendMessage()` y registro de manejadores de eventos. Lógica de reconexión en caso de desconexión.
+
+### Componentes UI
+
+Basado en **shadcn/ui** (Radix UI Primitives + Tailwind CSS):
+
+- `Dialog`, `AlertDialog`, `DropdownMenu`, `ContextMenu`, `Popover`
+- `Select`, `Checkbox`, `Input`, `Textarea`, `Label`
+- `Card`, `Badge`, `Button`, `Separator`, `Tabs`, `Table`
+- `Toast` / `Toaster` para notificaciones
+- `Calendar` / `DateTimePicker` para la selección de fecha de expiración
+- `Pagination` para listas paginadas
+- `ScrollArea`, `Tooltip`
+
+---
+
+## 16. Panel de administración
+
+El panel de administración (`/admin/*`) es accesible únicamente para usuarios con `role: 'admin'`.
+
+### Panel de control (`/admin`)
+
+- Número total de usuarios, archivos, uso de almacenamiento
+- Los 10 archivos subidos más recientemente
+- Actualizaciones en vivo mediante WebSocket (`stats:invalidate`)
+
+### Gestión de usuarios (`/admin/users`)
+
+- Todos los usuarios con número de archivos y uso de almacenamiento
+- Crear usuarios, activar/desactivar, cambiar rol
+- Restablecer contraseña, regenerar clave API
+- Cambiar nombre de carpeta (los archivos físicos se mueven en el servidor)
+- Eliminar usuario (se eliminan todos los archivos)
+
+### Gestión de archivos (`/admin/files`)
+
+- Todos los archivos de todos los usuarios, paginado
+- Búsqueda por nombre de archivo
+- Eliminar archivo
+
+### Registro de auditoría (`/admin/audit-log`)
+
+- Registro paginado de todas las acciones (50/página)
+- Filtrar por nombre de usuario y acción
+- Exportación CSV para fines regulatorios
+
+### Configuración del sitio (`/admin/site-settings`)
+
+- Información del operador (nombre, dirección, email)
+- Activar Cloudflare Analytics
+- Período de retención de archivos
+- Duración de sesiones
+- Activar/desactivar registro de usuarios
+
+### Importación XBackBone (`/admin/import`)
+
+- Vista previa e importación desde base de datos SQLite de XBackBone
+- Los usuarios se emparejan por nombre de usuario
+- Idempotente (los archivos ya importados se omiten)
+
+---
+
+## 17. RGPD / Privacidad
+
+| Funcionalidad | Artículo RGPD |
+|---|---|
+| Política de privacidad (configurable) | Art. 13/14 – Transparencia |
+| Página de términos de servicio (configurable) | Art. 13/14 – Transparencia |
+| Exportación de datos (JSON con URLs) | Art. 20 – Portabilidad de datos |
+| Autoelimación de cuenta (archivos + datos) | Art. 17 – Derecho de supresión |
+| Registro de auditoría (TTL 90 días vía MongoDB) | Art. 5(2) – Responsabilidad |
+| Exportación CSV del registro de auditoría | Art. 5(2) – Responsabilidad |
+| Retención de archivos configurable | Art. 5(1)(e) – Limitación del plazo de conservación |
+| Claves API como hash SHA-256 | Art. 32 – Seguridad |
+| Contraseñas como bcrypt (12 rondas) | Art. 32 – Seguridad |
+| Consentimiento de cookies para Cloudflare Analytics | Art. 13 – Transparencia |
+| Anonimización al eliminar la cuenta | Art. 17 – Derecho de supresión |
+
+### Flujo de eliminación RGPD
+
+Al eliminar la cuenta (`user:delete-account` / `DELETE /api/user/account`):
+1. Todos los archivos del usuario se eliminan del disco
+2. Las miniaturas se eliminan
+3. El avatar se elimina
+4. Las entradas del registro de auditoría se anonimizan (`username: '[deleted]'`, `ip: null`, `userId: null`)
+5. El documento de usuario se elimina
+6. La sesión se destruye
+
+---
+
+## 18. Tareas en segundo plano
+
+### Limpieza por retención (`src/jobs/retentionCleanup.js`)
+
+- **Ejecución:** Al inicio y luego diariamente (`setInterval(runRetentionCleanup, 24h)`)
+- **Acción:** Si `SiteSettings.fileRetentionDays > 0`, se eliminan los archivos más antiguos que este valor
+- Elimina: archivo en disco, miniatura, documento MongoDB
+- Difunde `stats:invalidate` a los admins
+
+### Índices TTL de MongoDB (automáticos)
+
+| Colección | TTL | Disparador |
+|---|---|---|
+| `AuditLog` | 90 días | `timestamp` |
+| `Collection` | 7 días después de `expiresAt` | `expiresAt` |
+| `ShareLink` | 7 días después de `expiresAt` | `expiresAt` |
+
+---
+
+## 19. Despliegue
+
+### Docker (recomendado)
+
+```bash
+git clone https://github.com/Christianoooooo/sharely.git
+cd sharely
+cp .env.example .env
+# Editar .env (SESSION_SECRET, contraseñas MONGO, BASE_URL)
+docker compose up -d
+```
+
+**Servicios:**
+- `app` — Aplicación Node.js (puerto 3000)
+- `mongo` — MongoDB 7 (puerto 127.0.0.1:27017, no accesible externamente)
+
+**Volúmenes:**
+- `uploads` — almacenamiento persistente de archivos
+- `mongo_data` — datos MongoDB
+
+**Comprobaciones de salud:** La aplicación verifica HTTP 200 en `/`, MongoDB verifica `db.adminCommand('ping')`.
+
+### Proxy inverso Nginx
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name files.example.com;
+
+    client_max_body_size 2100M;  # Al menos tan grande como el fragmento más grande + buffer
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Soporte WebSocket
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+```
+
+> `BASE_URL` en `.env` debe coincidir con el dominio público.
+
+### Primer inicio
+
+El primer usuario registrado recibe automáticamente el rol `admin` (`User.countDocuments() === 0`).
+
+---
+
+## 20. Entorno de desarrollo
+
+### Requisitos previos
+
+- Node.js ≥ 18
+- MongoDB (local o mediante Docker)
+- Opcional: ffmpeg, ghostscript (para miniaturas)
+
+### Configuración
+
+```bash
+# Backend
+npm install
+cp .env.example .env
+# Editar .env
+
+# Frontend
+cd client
+npm install
+```
+
+### Inicio
+
+```bash
+# Backend (puerto 3000, con nodemon)
+npm run dev
+
+# Frontend (puerto 5173, terminal separada)
+cd client
+npm run dev
+```
+
+El servidor de desarrollo Vite redirecciona automáticamente las solicitudes API a `localhost:3000`.
+
+### Compilación
+
+```bash
+npm run build   # Compila client/dist/, el backend permanece sin cambios
+npm start       # Inicia el servidor Express de producción
+```
+
+---
+
+## 21. Migraciones y scripts
+
+### Migraciones automáticas (en cada inicio)
+
+Estas migraciones se ejecutan al iniciar la aplicación en `app.js` y son idempotentes:
+
+| Migración | Archivo | Función |
+|---|---|---|
+| Migración de carpetas de usuario | `src/migrations/migrateUserFolders.js` | Mueve archivos de `uploads/` a `uploads/{folderName}/` |
+| Migración de hashes de claves API | `src/migrations/migrateApiKeyHashes.js` | Convierte claves API en texto en claro a hashes SHA-256 |
+
+### Scripts manuales
+
+```bash
+# Generar miniaturas para archivos existentes
+npm run migrate:thumbnails
+# o:
+node scripts/generate-missing-thumbnails.js
+
+# Mover cargas a carpetas de usuario (manual)
+npm run migrate:user-folders
+# o:
+node scripts/migrate-uploads-to-user-folders.js
+```
+
+### Inicialización de la base de datos (Docker)
+
+`scripts/mongo-init.js` se ejecuta en el primer inicio del contenedor MongoDB y crea el usuario de aplicación con los permisos correctos.
+
+---
+
+## 22. Pruebas end-to-end
+
+**Framework:** Playwright (`@playwright/test`)
+
+### Archivos de prueba
+
+| Archivo | Suite de pruebas |
+|---|---|
+| `e2e/upload.spec.js` | Flujos de carga |
+| `e2e/gallery.spec.js` | Galería y gestión de archivos |
+| `e2e/admin.spec.js` | Panel de administración |
+| `e2e/sharelink.spec.js` | Creación y uso de enlaces de compartición |
+| `e2e/tags.spec.js` | Gestión de etiquetas |
+| `e2e/bulk-actions-fixes.spec.js` | Acciones en masa |
+
+### Ejecución
+
+```bash
+# Todas las pruebas
+npm run test:e2e
+
+# Con interfaz gráfica
+npm run test:e2e:ui
+```
+
+**Configuración Playwright:** `playwright.config.js`  
+**Configuración global:** `e2e/global-setup.js` (crea usuarios de prueba, admin, etc.)  
+**Utilidades:** `e2e/helpers.js` (funciones auxiliares compartidas)
+
+---
+
+## Apéndice: Acciones del registro de auditoría
+
+| Acción | Disparador |
+|---|---|
+| `login` | Inicio de sesión exitoso |
+| `logout` | Cierre de sesión |
+| `register` | Registro |
+| `upload` | Carga de archivo |
+| `delete_file` | Archivo eliminado |
+| `delete_account` | Cuenta eliminada |
+| `change_password` | Contraseña cambiada |
+| `change_username` | Nombre de usuario cambiado |
+| `change_email` | Email cambiado |
+| `verify_email` | Email verificado |
+| `forgot_password` | Restablecimiento de contraseña solicitado |
+| `reset_password` | Contraseña restablecida |
+| `regen_api_key` | Clave API regenerada |
+| `sharex_config` | Configuración ShareX descargada |
+| `export_data` | Exportación de datos |
+| `admin_create_user` | Admin: usuario creado |
+| `admin_delete_user` | Admin: usuario eliminado |
+| `admin_toggle_user` | Admin: usuario activado/desactivado |
+| `admin_change_role` | Admin: rol de usuario cambiado |
+| `admin_change_password` | Admin: contraseña establecida |
+| `admin_regen_key` | Admin: clave API regenerada |
+
+---
+
+*Documentación generada a partir del código fuente de sharely v1.0.0*

--- a/docs/fr.md
+++ b/docs/fr.md
@@ -1,0 +1,1264 @@
+# Sharely — Documentation Technique
+
+> **Version :** 1.0.0 · **Licence :** MIT · **Node.js :** ≥ 18
+
+---
+
+## Table des matières
+
+1. [Présentation du projet](#1-présentation-du-projet)
+2. [Architecture](#2-architecture)
+3. [Stack technique](#3-stack-technique)
+4. [Structure des répertoires](#4-structure-des-répertoires)
+5. [Configuration & Variables d'environnement](#5-configuration--variables-denvironnement)
+6. [Modèles de données](#6-modèles-de-données)
+7. [API REST](#7-api-rest)
+8. [API WebSocket](#8-api-websocket)
+9. [Routes de service des fichiers](#9-routes-de-service-des-fichiers)
+10. [Authentification & Sécurité](#10-authentification--sécurité)
+11. [Système d'upload](#11-système-dupload)
+12. [Génération de miniatures](#12-génération-de-miniatures)
+13. [E-mail & SMTP](#13-e-mail--smtp)
+14. [Internationalisation](#14-internationalisation)
+15. [Frontend (React SPA)](#15-frontend-react-spa)
+16. [Tableau de bord administrateur](#16-tableau-de-bord-administrateur)
+17. [RGPD / Confidentialité](#17-rgpd--confidentialité)
+18. [Tâches en arrière-plan](#18-tâches-en-arrière-plan)
+19. [Déploiement](#19-déploiement)
+20. [Environnement de développement](#20-environnement-de-développement)
+21. [Migrations & Scripts](#21-migrations--scripts)
+22. [Tests end-to-end](#22-tests-end-to-end)
+
+---
+
+## 1. Présentation du projet
+
+Sharely est une **plateforme de partage de fichiers auto-hébergée** dotée d'une interface web épurée, d'une intégration ShareX et d'un accès via API. Les utilisateurs téléversent des captures d'écran, des fichiers et des médias, puis les partagent instantanément via des liens courts.
+
+### Fonctionnalités principales
+
+| Fonctionnalité | Description |
+|---|---|
+| Upload web | Glisser-déposer, jusqu'à 500 fichiers simultanément |
+| Upload par morceaux | Fichiers jusqu'à 2 Go via upload multi-part parallèle |
+| Intégration ShareX | Fichier de configuration `.sxcu` téléchargeable en un clic |
+| Upload via API | Authentification par jeton Bearer, compatible curl/wget |
+| Visionneuse de fichiers | Zoom sur les images, streaming vidéo/audio (HTTP Range), PDF en ligne, code avec coloration syntaxique |
+| Modes d'intégration | *embed* (HTML OG/Twitter Card) ou *raw* (redirection directe) |
+| Miniatures | Aperçus JPEG automatiques pour les vidéos (ffmpeg) et les PDF (ghostscript) |
+| Collections | Regroupements de fichiers avec mot de passe et date d'expiration optionnels |
+| Liens de partage | Liens par fichier avec mot de passe, expiration et limite de téléchargement |
+| Interface temps réel | Mises à jour en direct via WebSocket (upload, suppression, compteur de vues, stats admin) |
+| Multilingue | 8 langues : EN, DE, FR, ES, IT, PT, JA, ZH |
+| Tableau de bord admin | Statistiques, gestion des utilisateurs, gestion des fichiers, journal d'audit (export CSV) |
+| Conformité RGPD | Fonctionnalités de confidentialité conformes au RGPD (Art. 17, 20, 32, etc.) |
+| Import XBackBone | Migration d'installations XBackBone existantes |
+| Prêt pour Docker | `docker compose up -d` démarre l'environnement complet |
+
+---
+
+## 2. Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Browser / Client                      │
+│            React 18 SPA  ·  Vite  ·  Tailwind CSS           │
+│   ┌──────────────────────────────────────────────────────┐   │
+│   │  HTTP REST (/api/*)            WebSocket (/ws)       │   │
+│   └──────────────────────────────────────────────────────┘   │
+└───────────────────────────┬────────────────────┬─────────────┘
+                            │ HTTP               │ WS
+┌───────────────────────────▼────────────────────▼─────────────┐
+│                    Express.js (app.js)                        │
+│                                                               │
+│  ┌──────────────┐  ┌───────────┐  ┌──────────┐  ┌────────┐  │
+│  │  /api/auth   │  │  /api/*   │  │   /f/*   │  │  /s/*  │  │
+│  │  /api/install│  │  routes   │  │  files   │  │ shares │  │
+│  └──────────────┘  └───────────┘  └──────────┘  └────────┘  │
+│                                                               │
+│  Middleware: session · rate-limit · CSRF · CSP · auth        │
+│                                                               │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌────────────┐  │
+│  │  multer  │  │  ws.js   │  │  mailer  │  │ retention  │  │
+│  │  upload  │  │ WebSocket│  │ nodemailer│  │  cleanup   │  │
+│  └──────────┘  └──────────┘  └──────────┘  └────────────┘  │
+└───────────────────────────┬───────────────────────────────────┘
+                            │
+┌───────────────────────────▼───────────────────────────────────┐
+│                      MongoDB (Mongoose)                        │
+│  User · File · Collection · ShareLink · SiteSettings          │
+│  AuditLog                                                      │
+└───────────────────────────────────────────────────────────────┘
+                            │
+              ┌─────────────▼───────────────┐
+              │     Dateisystem (uploads/)   │
+              │  {folderName}/  ·  .chunks/  │
+              │  .thumbnails/   ·  .avatars/ │
+              └─────────────────────────────┘
+```
+
+### Flux de données : Upload standard
+
+```
+Browser → POST /api/web-upload (multipart/form-data)
+       → multer: Datei in uploads/{folderName}/
+       → File.createUnique() → MongoDB
+       → generateThumbnail() (async, non-blocking)
+       → logAudit()
+       → broadcast('file:uploaded') via WebSocket
+       ← JSON: { files: [...] }
+```
+
+### Flux de données : Upload ShareX
+
+```
+ShareX → POST /upload (token im Formular-Body)
+       → multer: Datei temporär in uploads/
+       → requireApiKey: Token-Lookup → User
+       → fs.renameSync → uploads/{folderName}/
+       → File.create() → MongoDB
+       ← JSON: { url, delete_url }
+```
+
+---
+
+## 3. Stack technique
+
+| Couche | Technologie | Version |
+|---|---|---|
+| **Runtime** | Node.js | ≥ 18 |
+| **Framework backend** | Express.js | 4.x |
+| **Base de données** | MongoDB + Mongoose | Mongo 7, Mongoose 8.x |
+| **Sessions** | express-session + connect-mongo | — |
+| **Temps réel** | WebSocket (`ws`) | 8.x |
+| **Upload de fichiers** | Multer | 1.x |
+| **E-mail** | Nodemailer | 8.x |
+| **Hachage des mots de passe** | bcryptjs | 2.x (12 tours) |
+| **Hachage des clés API** | SHA-256 (Node Crypto) | — |
+| **Limitation de débit** | express-rate-limit | 8.x |
+| **Import XBackBone** | sql.js | 1.x |
+| **Framework frontend** | React 18 | 18.3.x |
+| **Routage (frontend)** | React Router v6 | 6.x |
+| **Outil de build** | Vite | 6.x |
+| **Style** | Tailwind CSS + Radix UI | 3.x |
+| **Composants UI** | shadcn/ui (Radix primitives) | — |
+| **Icônes** | FontAwesome | 6.x |
+| **i18n** | i18next + react-i18next | — |
+| **Coloration syntaxique** | highlight.js | 11.x |
+| **Conteneurs** | Docker + Docker Compose | — |
+| **Tests** | Playwright (E2E) | 1.60.x |
+
+---
+
+## 4. Structure des répertoires
+
+```
+sharely/
+├── app.js                          # Point d'entrée Express, séquence de démarrage
+├── package.json
+├── .env.example                    # Modèle pour toutes les variables d'environnement
+├── Dockerfile
+├── docker-compose.yml
+│
+├── src/
+│   ├── config/
+│   │   └── db.js                   # Connexion MongoDB (Mongoose)
+│   ├── middleware/
+│   │   ├── auth.js                 # requireLogin / requireAdmin / requireApiKey
+│   │   └── upload.js               # Configuration Multer, liste de blocage
+│   ├── models/
+│   │   ├── AuditLog.js             # Événements d'audit (TTL 90 jours)
+│   │   ├── Collection.js           # Collections de fichiers
+│   │   ├── File.js                 # Métadonnées des fichiers
+│   │   ├── ShareLink.js            # Liens de partage par fichier
+│   │   ├── SiteSettings.js         # Singleton : paramètres opérateur
+│   │   └── User.js                 # Comptes utilisateurs + clés API
+│   ├── routes/
+│   │   ├── api.js                  # API principale (upload, galerie, admin, ...)
+│   │   ├── auth.js                 # Connexion / Inscription / Réinitialisation du mot de passe
+│   │   ├── files.js                # Service des fichiers, embeds OG, requêtes de plage
+│   │   ├── import.js               # Migration XBackBone
+│   │   ├── install.js              # Endpoint d'installation initiale
+│   │   └── shares.js               # Service des fichiers via lien de partage
+│   ├── jobs/
+│   │   └── retentionCleanup.js     # Suppression quotidienne des fichiers expirés
+│   ├── migrations/
+│   │   ├── migrateApiKeyHashes.js  # Unique : textes en clair → hachages SHA-256
+│   │   └── migrateUserFolders.js   # Unique : déplacement des fichiers dans les dossiers utilisateurs
+│   ├── utils/
+│   │   ├── audit.js                # Fonction utilitaire logAudit()
+│   │   ├── generateThumbnail.js    # Intégration ffmpeg / ghostscript
+│   │   ├── mailer.js               # Wrapper Nodemailer + modèles d'e-mail i18n
+│   │   └── sanitizeFilename.js     # Nettoyage du nom de fichier
+│   └── ws.js                       # Serveur WebSocket + dispatcher d'actions
+│
+├── client/                         # Frontend React
+│   ├── index.html
+│   ├── package.json
+│   ├── vite.config.js
+│   ├── tailwind.config.js
+│   └── src/
+│       ├── main.jsx                # Point d'entrée React
+│       ├── App.jsx                 # Configuration du routeur
+│       ├── index.css               # Styles globaux
+│       ├── context/
+│       │   └── AuthContext.jsx     # État d'authentification global
+│       ├── hooks/
+│       │   ├── use-toast.js        # Hook de notification toast
+│       │   └── useWebSocket.js     # Connexion WS + gestionnaires d'événements
+│       ├── components/
+│       │   ├── Layout.jsx          # Shell de l'application (barre de navigation, sidebar)
+│       │   ├── ProtectedRoute.jsx  # Garde d'authentification
+│       │   ├── ShareLinkDialog.jsx # Dialogue de création de lien de partage
+│       │   ├── AddToCollectionDialog.jsx
+│       │   ├── CookieBanner.jsx
+│       │   ├── LanguageSelector.jsx
+│       │   ├── RequireEmailDialog.jsx
+│       │   ├── UserAvatar.jsx
+│       │   └── ui/                 # Composants de base shadcn/ui
+│       ├── pages/
+│       │   ├── Upload.jsx          # Page d'upload
+│       │   ├── Gallery.jsx         # Galerie de fichiers
+│       │   ├── FileView.jsx        # Vue détaillée d'un fichier
+│       │   ├── Collections.jsx     # Vue d'ensemble des collections
+│       │   ├── CollectionView.jsx  # Collection individuelle
+│       │   ├── ShareView.jsx       # Page publique de lien de partage
+│       │   ├── Settings.jsx        # Paramètres utilisateur
+│       │   ├── Login.jsx
+│       │   ├── Register.jsx
+│       │   ├── ForgotPassword.jsx
+│       │   ├── ResetPassword.jsx
+│       │   ├── Install.jsx         # Installation initiale
+│       │   ├── PrivacyPolicy.jsx
+│       │   ├── TermsOfService.jsx
+│       │   └── admin/
+│       │       ├── Dashboard.jsx   # Page d'accueil admin
+│       │       ├── Users.jsx       # Gestion des utilisateurs
+│       │       ├── Files.jsx       # Gestion des fichiers
+│       │       ├── AuditLog.jsx    # Vue du journal d'audit
+│       │       ├── SiteSettings.jsx# Paramètres opérateur
+│       │       └── Import.jsx      # Import XBackBone
+│       ├── i18n/
+│       │   ├── index.js            # Configuration i18next
+│       │   └── locales/
+│       │       ├── de.json
+│       │       ├── en.json
+│       │       ├── es.json
+│       │       ├── fr.json
+│       │       ├── it.json
+│       │       ├── ja.json
+│       │       ├── pt.json
+│       │       └── zh.json
+│       └── lib/
+│           └── utils.js            # Utilitaire Tailwind (cn())
+│
+├── scripts/
+│   ├── setup-db.js
+│   ├── mongo-init.js               # Script d'initialisation MongoDB
+│   ├── migrate-uploads-to-user-folders.js
+│   └── generate-missing-thumbnails.js
+│
+├── e2e/                            # Tests Playwright
+│   ├── admin.spec.js
+│   ├── bulk-actions-fixes.spec.js
+│   ├── gallery.spec.js
+│   ├── sharelink.spec.js
+│   ├── tags.spec.js
+│   ├── upload.spec.js
+│   ├── helpers.js
+│   └── global-setup.js
+│
+├── uploads/                        # Fichiers uploadés (runtime)
+│   ├── .thumbnails/
+│   ├── .avatars/
+│   └── .chunks/                    # Morceaux temporaires
+│
+└── docs/assets/                    # Captures d'écran et logo
+```
+
+---
+
+## 5. Configuration & Variables d'environnement
+
+Toutes les variables sont chargées depuis `.env` (via `dotenv`). Le fichier `.env.example` contient le modèle complet.
+
+### Champs obligatoires
+
+| Variable | Description |
+|---|---|
+| `SESSION_SECRET` | Secret pour le chiffrement des sessions — chaîne aléatoire longue, ex. `openssl rand -hex 32` |
+| `MONGO_ROOT_PASSWORD` | Mot de passe root MongoDB (requis uniquement pour Docker Compose) |
+| `MONGO_APP_PASSWORD` | Mot de passe de l'utilisateur applicatif MongoDB |
+
+### Toutes les variables d'environnement
+
+| Variable | Par défaut | Description |
+|---|---|---|
+| `PORT` | `3000` | Port TCP du serveur HTTP |
+| `MONGODB_URI` | _(construit depuis Docker Compose)_ | URI de connexion MongoDB complète |
+| `MONGO_ROOT_PASSWORD` | — | Mot de passe root MongoDB |
+| `MONGO_APP_USER` | `appuser` | Nom d'utilisateur applicatif MongoDB |
+| `MONGO_APP_PASSWORD` | — | Mot de passe de l'utilisateur applicatif MongoDB |
+| `MONGO_DB_NAME` | `sharely` | Nom de la base de données MongoDB |
+| `SESSION_SECRET` | — | **Obligatoire** — secret de chiffrement des sessions |
+| `BASE_URL` | `http://localhost:3000` | URL de base publique pour les liens de partage générés (sans `/` final) |
+| `SITE_NAME` | `sharely` | Nom du site dans les embeds Open Graph |
+| `MAX_FILE_SIZE_MB` | `100` | Taille maximale des fichiers pour les uploads standards en Mo (uploads par morceaux jusqu'à 2 Go indépendamment) |
+| `ALLOW_REGISTRATION` | `true` | `false` désactive l'inscription publique |
+| `SMTP_HOST` | — | Nom d'hôte du serveur SMTP ; laisser vide pour désactiver les fonctionnalités e-mail |
+| `SMTP_PORT` | `587` | Port SMTP |
+| `SMTP_SECURE` | `false` | `true` pour TLS implicite (port 465), `false` pour STARTTLS |
+| `SMTP_USER` | — | Nom d'utilisateur SMTP |
+| `SMTP_PASS` | — | Mot de passe SMTP |
+| `SMTP_FROM` | _(SMTP_USER)_ | Adresse d'expédition dans les e-mails sortants |
+| `UPLOAD_DIR` | `./uploads` | Chemin absolu vers le répertoire d'upload |
+| `NODE_ENV` | — | `production` active les cookies sécurisés |
+
+---
+
+## 6. Modèles de données
+
+### User (`src/models/User.js`)
+
+```
+{
+  username:                    String (3–32, unique, alphanumérique + _-)
+  password:                    String (bcrypt, 12 tours)
+  role:                        'admin' | 'user'
+  apiKey:                      String (héritage, vide après migration)
+  apiKeyHash:                  String (SHA-256, unique, sparse)
+  apiKeyPrefix:                String (8 premiers caractères du texte en clair)
+  folderName:                  String (unique, sparse, max 64)
+  avatarExt:                   String | null (.jpg/.png/.gif/.webp)
+  embedMode:                   'embed' | 'raw'
+  isActive:                    Boolean
+  email:                       String (minuscules, unique, sparse)
+  emailVerified:               Boolean
+  emailVerificationToken:      String | null (hachage SHA-256 du texte en clair)
+  emailVerificationExpires:    Date | null
+  passwordResetToken:          String | null (hachage SHA-256)
+  passwordResetExpires:        Date | null
+  language:                    'en'|'de'|'fr'|'es'|'it'|'pt'|'ja'|'zh'
+  predefinedTags:              [String] (max 100 tags × 50 caractères)
+  createdAt:                   Date
+}
+```
+
+**Méthodes importantes :**
+- `user.comparePassword(candidate)` — comparaison bcrypt
+- `user.regenerateApiKey()` — génère un nouveau texte en clair, stocke le hachage, retourne le texte en clair (visible une seule fois)
+- `User.findByApiKey(plaintext)` — recherche par hachage SHA-256, utilisateurs actifs uniquement
+
+### File (`src/models/File.js`)
+
+```
+{
+  shortId:      String (8 caractères hexadécimaux : 6 timestamp + 2 aléatoires, unique)
+  deleteToken:  String (32 caractères hexadécimaux, unique)
+  originalName: String (assaini)
+  storedName:   String (chemin relatif : "folderName/8hex.ext")
+  mimeType:     String
+  size:         Number (octets)
+  uploader:     ObjectId → User
+  views:        Number
+  tags:         [String] (max 20 × 50 caractères)
+  createdAt:    Date
+}
+```
+
+**Propriétés calculées :**
+- `sizeHuman` — taille lisible (B / Ko / Mo / Go)
+- `displayType` — classification : `image|video|audio|pdf|code|text|file`
+
+**Algorithme Short ID :**
+```
+shortId = hex(seconds_since_2024-01-01, 6 chars) + randomBytes(2).hex()
+```
+
+### Collection (`src/models/Collection.js`)
+
+```
+{
+  shortId:     String (8 Hex, unique)
+  name:        String (max 100)
+  description: String (max 500)
+  owner:       ObjectId → User
+  files:       [ObjectId → File]
+  password:    String | null (bcrypt)
+  expiresAt:   Date | null
+  createdAt:   Date
+}
+```
+
+> Les collections expirées sont automatiquement supprimées par l'index TTL MongoDB 7 jours après leur expiration.
+
+### ShareLink (`src/models/ShareLink.js`)
+
+```
+{
+  token:         String (32 Hex, unique)
+  file:          ObjectId → File
+  createdBy:     ObjectId → User
+  label:         String (max 100)
+  password:      String | null (bcrypt)
+  expiresAt:     Date | null
+  downloadLimit: Number (-1 = illimité)
+  downloadCount: Number
+  createdAt:     Date
+}
+```
+
+> Comme les collections : délai de grâce de 7 jours après expiration via l'index TTL.
+
+### SiteSettings (`src/models/SiteSettings.js`)
+
+Document singleton (`_id: 'singleton'`) :
+
+```
+{
+  operatorName:        String
+  operatorAddress:     String
+  operatorEmail:       String
+  cloudflareAnalytics: Boolean
+  fileRetentionDays:   Number (0 = désactivé)
+  encryptionAtRest:    Boolean
+  sessionDurationDays: Number (par défaut : 7)
+  allowRegistration:   Boolean
+}
+```
+
+### AuditLog (`src/models/AuditLog.js`)
+
+```
+{
+  timestamp: Date (index TTL : 90 jours)
+  userId:    ObjectId → User | null
+  username:  String | null
+  action:    String
+  ip:        String | null
+  meta:      Mixed (métadonnées spécifiques à l'action)
+}
+```
+
+---
+
+## 7. API REST
+
+### URL de base : `/api`
+
+Tous les endpoints JSON retournent `Content-Type: application/json`. Erreurs : `{ "error": "message" }`.
+
+---
+
+### Authentification (`/api/auth`)
+
+| Méthode | Chemin | Auth | Description |
+|---|---|---|---|
+| `GET` | `/me` | Session | Utilisateur connecté |
+| `POST` | `/login` | — | Connexion (limité : 10/15min) |
+| `POST` | `/register` | — | Inscription (limité, premier utilisateur devient admin) |
+| `POST` | `/logout` | — | Déconnexion |
+| `GET` | `/smtp-enabled` | — | Vérifie si SMTP est configuré |
+| `GET` | `/verify-email?token=` | — | Vérifier l'adresse e-mail |
+| `GET` | `/verify-reset-token?token=` | — | Valider le jeton de réinitialisation |
+| `POST` | `/forgot-password` | — | Envoyer l'e-mail de réinitialisation du mot de passe (limité : 5/h) |
+| `POST` | `/reset-password` | — | Définir un nouveau mot de passe |
+
+**Requête de connexion :**
+```json
+POST /api/auth/login
+{ "username": "max", "password": "meinPasswort123" }
+```
+
+**Réponse de connexion :**
+```json
+{
+  "user": {
+    "id": "...", "username": "max", "role": "user",
+    "avatarUrl": null, "email": "max@example.com",
+    "emailVerified": true, "language": "de"
+  }
+}
+```
+
+---
+
+### Upload de fichiers
+
+| Méthode | Chemin | Auth | Description |
+|---|---|---|---|
+| `POST` | `/upload` | Clé API | Upload ShareX (endpoint héritage dans `app.js`) |
+| `POST` | `/api/upload` | Clé API | Upload ShareX/API (champ : `file`) |
+| `POST` | `/api/web-upload` | Session | Upload web (champ : `files[]`, max 500) |
+| `POST` | `/api/chunk/init` | Session | Initialiser un upload par morceaux |
+| `POST` | `/api/chunk/:uploadId` | Session | Uploader un morceau (champ : `chunk`) |
+| `POST` | `/api/chunk/:uploadId/complete` | Session | Assembler les morceaux |
+| `DELETE` | `/api/chunk/:uploadId` | Session | Annuler l'upload et nettoyer |
+
+**Réponse d'upload API :**
+```json
+{
+  "url": "https://example.com/f/a1b2c3d4",
+  "raw": "https://example.com/f/a1b2c3d4/raw",
+  "delete_url": "https://example.com/api/delete/a1b2c3d4",
+  "short_id": "a1b2c3d4",
+  "filename": "screenshot.png",
+  "size": 102400
+}
+```
+
+#### Flux d'upload par morceaux
+
+1. `POST /api/chunk/init` → `{ uploadId: "32hex" }`
+2. `POST /api/chunk/:uploadId` (Corps : `chunkIndex=N`, Fichier : `chunk`) → `{ received: N }`  
+   En parallèle avec 3 à 5 morceaux simultanés
+3. `POST /api/chunk/:uploadId/complete` → `{ files: [fileObject] }`
+
+---
+
+### Gestion des fichiers
+
+| Méthode | Chemin | Auth | Description |
+|---|---|---|---|
+| `GET` | `/api/gallery` | Session | Propres fichiers (admin : tous), paginé (24/page), filtres : `q`, `type`, `tag`, `page` |
+| `GET` | `/api/file/:shortId` | — | Métadonnées du fichier (incrémente le compteur de vues) |
+| `PATCH` | `/api/file/:shortId` | Session | Mettre à jour les tags/le nom |
+| `DELETE` | `/api/file/:shortId` | Session | Supprimer un fichier |
+| `DELETE` | `/api/delete/:shortId` | Clé API | Supprimer un fichier (authentification par clé API) |
+| `POST` | `/api/files/bulk` | Session | Actions en masse : `delete`, `tag`, `removeTag`, `addToCollection`, `moveToCollection` |
+| `GET` | `/api/tags` | Session | Toutes les suggestions de tags de l'utilisateur |
+
+**Paramètres de requête de la galerie :**
+- `q` — recherche dans le nom de fichier (sécurisé contre les regex)
+- `type` — `all|image|video|audio|pdf|code`
+- `tag` — filtre de tag exact
+- `page` — numéro de page (par défaut : 1)
+
+---
+
+### Paramètres utilisateur
+
+| Méthode | Chemin | Auth | Description |
+|---|---|---|---|
+| `GET` | `/api/my-key` | Session | Afficher le préfixe de la clé API |
+| `POST` | `/api/regen-key` | Session | Régénérer la clé API |
+| `GET` | `/api/sharex-config` | Session | Télécharger le fichier ShareX `.sxcu` (régénère la clé) |
+| `PATCH` | `/api/user/username` | Session | Changer le nom d'utilisateur (mot de passe requis) |
+| `PATCH` | `/api/user/password` | Session | Changer le mot de passe |
+| `PATCH` | `/api/user/email` | Session | Changer l'e-mail (envoie un e-mail de confirmation) |
+| `PATCH` | `/api/user/language` | Session | Définir la langue de l'interface |
+| `PATCH` | `/api/user/embed-mode` | Session | Définir le mode d'intégration (`embed`/`raw`) |
+| `POST` | `/api/user/resend-verification` | Session | Renvoyer l'e-mail de vérification |
+| `GET` | `/api/user/export` | Session | Export des données (RGPD Art. 20) en JSON |
+| `DELETE` | `/api/user/account` | Session | Supprimer le compte (RGPD Art. 17, mot de passe requis) |
+| `GET` | `/api/user/predefined-tags` | Session | Récupérer les tags prédéfinis |
+| `PATCH` | `/api/user/predefined-tags` | Session | Mettre à jour les tags prédéfinis |
+| `POST` | `/api/user/avatar` | Session | Uploader un avatar (max 2 Mo, JPEG/PNG/GIF/WebP) |
+| `DELETE` | `/api/user/avatar` | Session | Supprimer l'avatar |
+| `GET` | `/api/user/avatar/:userId` | — | Servir l'avatar |
+
+---
+
+### Liens de partage
+
+| Méthode | Chemin | Auth | Description |
+|---|---|---|---|
+| `GET` | `/api/file/:shortId/share-links` | Session (Propriétaire/Admin) | Tous les liens de partage d'un fichier |
+| `POST` | `/api/file/:shortId/share-links` | Session (Propriétaire/Admin) | Créer un lien de partage |
+| `DELETE` | `/api/share-links/:token` | Session (Propriétaire/Créateur/Admin) | Supprimer un lien de partage |
+| `GET` | `/api/share-links/:token` | — | Métadonnées du lien de partage (public) |
+| `POST` | `/api/share-links/:token/verify` | — | Vérifier le mot de passe du lien de partage |
+
+**Créer un lien de partage :**
+```json
+POST /api/file/a1b2c3d4/share-links
+{
+  "label": "Pour les collègues",
+  "password": "secret",
+  "expiresAt": "2025-12-31T23:59:59Z",
+  "downloadLimit": 10
+}
+```
+
+---
+
+### Collections
+
+| Méthode | Chemin | Auth | Description |
+|---|---|---|---|
+| `GET` | `/api/collections` | Session | Propres collections (admin : toutes) |
+| `POST` | `/api/collections` | Session | Créer une collection |
+| `GET` | `/api/collections/:id` | — | Afficher une collection (publique, mot de passe si défini) |
+| `PATCH` | `/api/collections/:id` | Session (Propriétaire/Admin) | Mettre à jour une collection |
+| `DELETE` | `/api/collections/:id` | Session (Propriétaire/Admin) | Supprimer une collection |
+| `POST` | `/api/collections/:id/files` | Session (Propriétaire/Admin) | Ajouter un fichier à la collection |
+| `DELETE` | `/api/collections/:id/files/:fileShortId` | Session (Propriétaire/Admin) | Retirer un fichier de la collection |
+| `POST` | `/api/collections/:id/verify` | — | Vérifier le mot de passe de la collection |
+
+---
+
+### Endpoints d'administration
+
+| Méthode | Chemin | Auth | Description |
+|---|---|---|---|
+| `GET` | `/api/admin/stats` | Admin | Statistiques du tableau de bord |
+| `GET` | `/api/admin/users` | Admin | Tous les utilisateurs (avec nombre de fichiers) |
+| `POST` | `/api/admin/users` | Admin | Créer un utilisateur |
+| `PATCH` | `/api/admin/users/:id/toggle` | Admin | Activer/désactiver un utilisateur |
+| `PATCH` | `/api/admin/users/:id/role` | Admin | Changer le rôle d'un utilisateur |
+| `DELETE` | `/api/admin/users/:id` | Admin | Supprimer un utilisateur |
+| `POST` | `/api/admin/users/:id/regen-key` | Admin | Régénérer la clé API |
+| `PATCH` | `/api/admin/users/:id/password` | Admin | Définir un mot de passe |
+| `PATCH` | `/api/admin/users/:id/folder` | Admin | Changer le nom du dossier (déplace les fichiers) |
+| `GET` | `/api/admin/files` | Admin | Tous les fichiers, paginé (30/page) |
+| `GET` | `/api/admin/site-settings` | Admin | Lire les paramètres opérateur |
+| `PATCH` | `/api/admin/site-settings` | Admin | Mettre à jour les paramètres opérateur |
+| `GET` | `/api/admin/audit-log` | Admin | Journal d'audit paginé (50/page) |
+| `GET` | `/api/admin/audit-log/export` | Admin | Télécharger le journal d'audit en CSV |
+| `GET` | `/api/site-settings` | — | Informations publiques de l'opérateur (pour la page de confidentialité) |
+
+---
+
+### Paramètres du site (publics)
+
+```json
+GET /api/site-settings
+{
+  "operatorName": "Musterfirma GmbH",
+  "operatorAddress": "Musterstr. 1, 12345 Musterstadt",
+  "operatorEmail": "datenschutz@example.com",
+  "cloudflareAnalytics": false,
+  "fileRetentionDays": 365,
+  "encryptionAtRest": false,
+  "sessionDurationDays": 7
+}
+```
+
+---
+
+## 8. API WebSocket
+
+**Connexion :** `wss://example.com/ws` (utilisateurs connectés uniquement, cookie de session requis)
+
+### Protocole
+
+**Client → Serveur (Requête) :**
+```json
+{ "id": "req-abc123", "action": "file:list", "payload": { "type": "image", "page": 1 } }
+```
+
+**Serveur → Client (Réponse) :**
+```json
+{ "id": "req-abc123", "data": { ... } }
+```
+
+**Serveur → Client (Erreur) :**
+```json
+{ "id": "req-abc123", "error": "Forbidden", "status": 403 }
+```
+
+**Serveur → Client (Diffusion) :**
+```json
+{ "event": "file:uploaded", "data": { "shortId": "a1b2c3d4", "uploaderId": "..." } }
+```
+
+### Actions disponibles
+
+| Action | Auth | Description |
+|---|---|---|
+| `site-settings:get` | — | Paramètres publics du site |
+| `auth:me` | Utilisateur | Données de l'utilisateur connecté |
+| `file:get` | Utilisateur | Détails du fichier (incrémente les vues) |
+| `file:list` | Utilisateur | Liste des fichiers avec filtre/pagination |
+| `file:delete` | Utilisateur | Supprimer un fichier |
+| `user:get-key` | Utilisateur | Préfixe de la clé API |
+| `user:regen-key` | Utilisateur | Régénérer la clé API |
+| `user:change-password` | Utilisateur | Changer le mot de passe |
+| `user:change-username` | Utilisateur | Changer le nom d'utilisateur |
+| `user:change-email` | Utilisateur | Changer l'e-mail |
+| `user:change-language` | Utilisateur | Définir la langue |
+| `user:change-embed-mode` | Utilisateur | Définir le mode d'intégration |
+| `user:resend-verification` | Utilisateur | Renvoyer l'e-mail de vérification |
+| `user:export` | Utilisateur | Export des données |
+| `user:delete-account` | Utilisateur | Supprimer le compte |
+| `admin:stats` | Admin | Statistiques du tableau de bord |
+| `admin:settings:get` | Admin | Lire les paramètres du site |
+| `admin:settings:update` | Admin | Mettre à jour les paramètres du site |
+| `admin:users:list` | Admin | Tous les utilisateurs |
+| `admin:users:create` | Admin | Créer un utilisateur |
+| `admin:users:toggle` | Admin | Activer/désactiver un utilisateur |
+| `admin:users:role` | Admin | Changer le rôle d'un utilisateur |
+| `admin:users:delete` | Admin | Supprimer un utilisateur |
+| `admin:users:regen-key` | Admin | Régénérer la clé API |
+| `admin:users:password` | Admin | Définir un mot de passe |
+| `admin:users:folder` | Admin | Changer le nom du dossier |
+| `admin:files:list` | Admin | Tous les fichiers |
+| `admin:audit-log:list` | Admin | Journal d'audit paginé |
+
+### Événements de diffusion
+
+| Événement | Destinataires | Charge utile |
+|---|---|---|
+| `file:uploaded` | Uploadeur | `{ shortId, uploaderId }` |
+| `file:deleted` | Propriétaire du fichier | `{ shortId, uploaderId }` |
+| `file:view` | Tous | `{ shortId, views }` |
+| `user:created` | Admins | `{ id, username, role, ... }` |
+| `user:deleted` | Admins | `{ id }` |
+| `user:updated` | Admins | `{ id, ...champs modifiés }` |
+| `audit:log` | Admins | Objet AuditLog complet |
+| `settings:updated` | Admins | Objet SiteSettings mis à jour |
+| `stats:invalidate` | Admins | `{}` (déclenche le rafraîchissement des stats) |
+
+---
+
+## 9. Routes de service des fichiers
+
+### `/f/:shortId` — Visionneuse de fichiers
+
+- **Requête navigateur :** Redirige vers la React SPA (`index.html`) — la SPA affiche la visionneuse.
+- **Bot de réseau social** (Discord, Telegram, Twitter, etc.) : Retourne une page HTML minimale avec des balises méta Open Graph / Twitter Card.
+  - `embedMode = 'embed'` : HTML OG avec redirection
+  - `embedMode = 'raw'` + image/vidéo/audio : HTTP 302 → `/f/:shortId/raw`
+
+### `/f/:shortId/raw` — Accès direct
+
+Sert le fichier comme réponse HTTP avec support des requêtes de plage (206 Partial Content). Images/vidéos/audio : `Content-Disposition: inline`, autres : `attachment`.
+
+### `/f/:shortId/download` — Téléchargement forcé
+
+Comme `/raw`, mais toujours `Content-Disposition: attachment`.
+
+### `/f/:shortId/thumb` — Miniature
+
+Retourne la miniature JPEG (pour les vidéos et les PDF). `Cache-Control: public, max-age=86400`.
+
+### `/f/:shortId/delete/:token` — Suppression ShareX
+
+Supprime le fichier sans session via un jeton de suppression unique.
+
+### `/s/:token` — Service de fichiers via lien de partage (`src/routes/shares.js`)
+
+Vérifie le mot de passe (via flag de session), la date d'expiration et la limite de téléchargement, puis sert le fichier.
+
+---
+
+## 10. Authentification & Sécurité
+
+### Authentification par session
+
+- Session Express avec stockage MongoDB (`connect-mongo`)
+- Cookie de session : `httpOnly: true`, `sameSite: 'strict'`, `secure: true` en production
+- Durée de session : configurable via `SiteSettings.sessionDurationDays` (par défaut : 7 jours), mis en cache en direct pendant 60 secondes
+
+### Authentification par clé API
+
+- Les clés API sont stockées sous forme de hachages SHA-256, jamais en texte clair
+- Les 8 premiers caractères sont stockés comme `apiKeyPrefix` (à des fins d'affichage)
+- Recherche : `User.findByApiKey(plaintext)` calcule le hachage et le cherche dans `apiKeyHash`
+- Lors du téléchargement de la configuration ShareX, la clé est régénérée — le texte en clair n'est visible qu'à ce moment-là
+
+### Chaîne de middleware (`src/middleware/auth.js`)
+
+```
+requireLogin    → vérifie req.session.user → 401 si non connecté
+requireAdmin    → comme requireLogin, de plus role === 'admin' → 403
+requireApiKey   → vérifie l'en-tête Authorization ou req.body.token
+```
+
+### Protection CSRF
+
+`requireSameOrigin()` dans `app.js` compare l'en-tête `Origin` avec l'en-tête `Host` pour toutes les routes API. Complète les cookies `sameSite: 'strict'`.
+
+### Politique de sécurité du contenu
+
+```
+default-src 'self';
+script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com;
+style-src 'self' 'unsafe-inline';
+img-src 'self' data: blob:;
+media-src 'self' blob:;
+connect-src 'self' https://cloudflareinsights.com;
+frame-ancestors 'self';
+```
+
+### En-têtes de sécurité
+
+- `X-Frame-Options: SAMEORIGIN`
+- `X-Content-Type-Options: nosniff`
+
+### Limitation de débit
+
+| Endpoint | Limite | Fenêtre |
+|---|---|---|
+| Upload (`/upload`, `/api/upload`, `/api/web-upload`) | 60 requêtes | 15 minutes |
+| Auth (`/api/auth/login`, `/register`, etc.) | 10 requêtes | 15 minutes |
+| Réinitialisation du mot de passe | 5 requêtes | 1 heure |
+
+### Liste de blocage des fichiers
+
+Les types MIME et extensions suivants sont rejetés à l'upload :
+
+**Types MIME bloqués :** `application/x-executable`, `application/x-sh`, `application/x-csh`, `application/x-bat`
+
+**Extensions bloquées :** `.bat`, `.cmd`, `.com`, `.ps1`, `.psm1`, `.psd1`, `.sh`, `.bash`, `.csh`, `.zsh`, `.fish`, `.vbs`, `.vbe`, `.jse`, `.scr`, `.pif`, `.application`, `.gadget`, `.hta`, `.php`, `.php3–5`, `.phtml`, `.asp`, `.aspx`, `.jsp`, `.jspx`, `.cfm`
+
+### Protection contre la traversée de chemin
+
+Tous les accès aux fichiers via `resolveUploadPath()` vérifient que le chemin résolu se trouve bien dans `UPLOAD_DIR`.
+
+---
+
+## 11. Système d'upload
+
+### Upload standard (Multer)
+
+- **Stockage :** `multer.diskStorage` → `uploads/{folderName}/{8hex}{.ext}`
+- **Nom de fichier :** `crypto.randomBytes(4).hex() + extension-originale`
+- **Limite :** `MAX_FILE_SIZE_MB` (par défaut : 100 Mo)
+- **Emplacement :** Dossier spécifique à l'utilisateur (`user.folderName`)
+
+### Upload par morceaux (>250 Mo)
+
+Le client frontend bascule automatiquement en mode morceaux pour les fichiers volumineux.
+
+**Structure de répertoires côté serveur :**
+```
+uploads/.chunks/{uploadId}/
+  meta.json          { filename, mimeType, totalSize, totalChunks, userId, createdAt }
+  chunk-0
+  chunk-1
+  ...
+  chunk-N
+```
+
+**Taille des morceaux :** 10–20 Mo (max 51 Mo accepté pour la compatibilité descendante)  
+**Parallélisme :** 3–5 uploads de morceaux simultanés  
+**Assemblage :** Basé sur les flux (pas de chargement complet en RAM)
+
+### Upload d'avatar
+
+- **Stockage :** `multer.memoryStorage()` (pas de tampon disque)
+- **Emplacement :** `uploads/.avatars/{userId}{.ext}`
+- **Limite :** 2 Mo
+- **Formats :** JPEG, PNG, GIF, WebP
+
+---
+
+## 12. Génération de miniatures
+
+Les miniatures sont générées de manière asynchrone après l'upload (`.catch(() => {})` — les erreurs sont ignorées silencieusement).
+
+### Miniatures vidéo (ffmpeg)
+
+```bash
+ffmpeg -y -i <file> -ss 00:00:01 -vframes 1 \
+  -vf "scale=320:320:force_original_aspect_ratio=increase,crop=320:320" \
+  -q:v 3 uploads/.thumbnails/<shortId>.jpg
+```
+
+### Miniatures PDF (Ghostscript)
+
+```bash
+gs -dNOPAUSE -dBATCH -dSAFER \
+  -sDEVICE=jpeg -dFirstPage=1 -dLastPage=1 \
+  -r72 -dJPEGQ=85 \
+  -sOutputFile=uploads/.thumbnails/<shortId>.jpg \
+  <file>
+```
+
+**Délai d'expiration :** 30 secondes par génération de miniature  
+**Repli :** Si ffmpeg/ghostscript n'est pas disponible, la génération est ignorée silencieusement.
+
+### Script de remplissage
+
+```bash
+npm run migrate:thumbnails
+# ou dans le conteneur :
+docker exec -it <container> npm run migrate:thumbnails
+```
+
+---
+
+## 13. E-mail & SMTP
+
+### Configuration
+
+SMTP est activé lorsque `SMTP_HOST` est défini. `mailer.isConfigured()` vérifie cette valeur.
+
+### Modèles d'e-mail
+
+Tous les e-mails sont envoyés dans la langue de l'utilisateur (8 langues). Les modèles sont intégrés dans `src/utils/mailer.js`.
+
+**Types d'e-mails envoyés :**
+
+| Type | Déclencheur | Validité du jeton |
+|---|---|---|
+| Vérification d'e-mail | Inscription, changement d'e-mail | 24 heures |
+| Réinitialisation du mot de passe | `POST /api/auth/forgot-password` | 1 heure |
+
+### Sécurité des jetons
+
+- Jetons : `crypto.randomBytes(32).hex()` (64 caractères hexadécimaux)
+- Stockés : hachage SHA-256 du jeton
+- L'e-mail contient le jeton en texte clair comme paramètre URL
+- Vérification : hachage du jeton entrant comparé au hachage stocké
+
+---
+
+## 14. Internationalisation
+
+**Bibliothèque :** i18next + react-i18next + i18next-browser-languagedetector
+
+**Langues prises en charge :**
+
+| Code | Langue |
+|---|---|
+| `en` | English |
+| `de` | Deutsch |
+| `fr` | Français |
+| `es` | Español |
+| `it` | Italiano |
+| `pt` | Português |
+| `ja` | 日本語 |
+| `zh` | 中文 |
+
+**Sélection de la langue :**
+1. Détection de la langue du navigateur (automatique)
+2. Préférence de l'utilisateur en base de données (`user.language`)
+3. Persistance via `PATCH /api/user/language`
+
+Fichiers de traduction : `client/src/i18n/locales/{code}.json`
+
+---
+
+## 15. Frontend (React SPA)
+
+### Configuration du routeur (`client/src/App.jsx`)
+
+| Route | Composant | Auth |
+|---|---|---|
+| `/` | Redirection → `/gallery` | Non |
+| `/auth/login` | Login.jsx | Non |
+| `/auth/register` | Register.jsx | Non |
+| `/auth/forgot-password` | ForgotPassword.jsx | Non |
+| `/auth/reset-password` | ResetPassword.jsx | Non |
+| `/install` | Install.jsx | Non |
+| `/upload` | Upload.jsx | **Oui** |
+| `/gallery` | Gallery.jsx | **Oui** |
+| `/f/:shortId` | FileView.jsx | **Oui** |
+| `/collections` | Collections.jsx | **Oui** |
+| `/c/:id` | CollectionView.jsx | Non (public) |
+| `/s/:token` | ShareView.jsx | Non (public) |
+| `/settings` | Settings.jsx | **Oui** |
+| `/admin` | Dashboard.jsx | **Admin** |
+| `/admin/users` | Users.jsx | **Admin** |
+| `/admin/files` | Files.jsx | **Admin** |
+| `/admin/audit-log` | AuditLog.jsx | **Admin** |
+| `/admin/site-settings` | SiteSettings.jsx | **Admin** |
+| `/admin/import` | Import.jsx | **Admin** |
+| `/privacy` | PrivacyPolicy.jsx | Non |
+| `/terms` | TermsOfService.jsx | Non |
+
+### Contexte d'authentification (`client/src/context/AuthContext.jsx`)
+
+État global pour l'utilisateur connecté. Initialisé au démarrage de l'application via `GET /api/auth/me`.
+
+### Hook WebSocket (`client/src/hooks/useWebSocket.js`)
+
+Gère la connexion WS persistante. Fournit `sendMessage()` et l'enregistrement des gestionnaires d'événements. Logique de reconnexion en cas de déconnexion.
+
+### Composants UI
+
+Basé sur **shadcn/ui** (Radix UI Primitives + Tailwind CSS) :
+
+- `Dialog`, `AlertDialog`, `DropdownMenu`, `ContextMenu`, `Popover`
+- `Select`, `Checkbox`, `Input`, `Textarea`, `Label`
+- `Card`, `Badge`, `Button`, `Separator`, `Tabs`, `Table`
+- `Toast` / `Toaster` pour les notifications
+- `Calendar` / `DateTimePicker` pour la sélection de date d'expiration
+- `Pagination` pour les listes paginées
+- `ScrollArea`, `Tooltip`
+
+---
+
+## 16. Tableau de bord administrateur
+
+Le tableau de bord administrateur (`/admin/*`) est accessible uniquement aux utilisateurs avec `role: 'admin'`.
+
+### Tableau de bord (`/admin`)
+
+- Nombre total d'utilisateurs, de fichiers, espace de stockage utilisé
+- 10 derniers fichiers uploadés
+- Mises à jour en direct via WebSocket (`stats:invalidate`)
+
+### Gestion des utilisateurs (`/admin/users`)
+
+- Tous les utilisateurs avec nombre de fichiers et utilisation du stockage
+- Créer des utilisateurs, activer/désactiver, changer de rôle
+- Réinitialiser le mot de passe, régénérer la clé API
+- Changer le nom du dossier (les fichiers physiques sont déplacés sur le serveur)
+- Supprimer un utilisateur (tous les fichiers sont supprimés)
+
+### Gestion des fichiers (`/admin/files`)
+
+- Tous les fichiers de tous les utilisateurs, paginé
+- Recherche par nom de fichier
+- Supprimer un fichier
+
+### Journal d'audit (`/admin/audit-log`)
+
+- Journal paginé de toutes les actions (50/page)
+- Filtrer par nom d'utilisateur et action
+- Export CSV à des fins réglementaires
+
+### Paramètres du site (`/admin/site-settings`)
+
+- Informations de l'opérateur (nom, adresse, e-mail)
+- Activer Cloudflare Analytics
+- Période de rétention des fichiers
+- Durée des sessions
+- Activer/désactiver les inscriptions
+
+### Import XBackBone (`/admin/import`)
+
+- Aperçu et import depuis une base de données SQLite XBackBone
+- Les utilisateurs sont associés par nom d'utilisateur
+- Idempotent (les fichiers déjà importés sont ignorés)
+
+---
+
+## 17. RGPD / Confidentialité
+
+| Fonctionnalité | Article RGPD |
+|---|---|
+| Politique de confidentialité (configurable) | Art. 13/14 – Transparence |
+| Page des conditions d'utilisation (configurable) | Art. 13/14 – Transparence |
+| Export des données (JSON avec URLs) | Art. 20 – Portabilité des données |
+| Suppression du compte (fichiers + données) | Art. 17 – Droit à l'effacement |
+| Journal d'audit (TTL 90 jours via MongoDB) | Art. 5(2) – Responsabilité |
+| Export CSV du journal d'audit | Art. 5(2) – Responsabilité |
+| Rétention des fichiers configurable | Art. 5(1)(e) – Limitation de la conservation |
+| Clés API sous forme de hachage SHA-256 | Art. 32 – Sécurité |
+| Mots de passe en bcrypt (12 tours) | Art. 32 – Sécurité |
+| Consentement aux cookies pour Cloudflare Analytics | Art. 13 – Transparence |
+| Anonymisation lors de la suppression du compte | Art. 17 – Droit à l'effacement |
+
+### Flux de suppression RGPD
+
+Lors de la suppression du compte (`user:delete-account` / `DELETE /api/user/account`) :
+1. Tous les fichiers de l'utilisateur sont supprimés du disque
+2. Les miniatures sont supprimées
+3. L'avatar est supprimé
+4. Les entrées du journal d'audit sont anonymisées (`username: '[deleted]'`, `ip: null`, `userId: null`)
+5. Le document utilisateur est supprimé
+6. La session est détruite
+
+---
+
+## 18. Tâches en arrière-plan
+
+### Nettoyage par rétention (`src/jobs/retentionCleanup.js`)
+
+- **Exécution :** Au démarrage puis quotidiennement (`setInterval(runRetentionCleanup, 24h)`)
+- **Action :** Si `SiteSettings.fileRetentionDays > 0`, les fichiers plus anciens que cette valeur sont supprimés
+- Supprime : fichier sur disque, miniature, document MongoDB
+- Diffuse `stats:invalidate` aux admins
+
+### Index TTL MongoDB (automatiques)
+
+| Collection | TTL | Déclencheur |
+|---|---|---|
+| `AuditLog` | 90 jours | `timestamp` |
+| `Collection` | 7 jours après `expiresAt` | `expiresAt` |
+| `ShareLink` | 7 jours après `expiresAt` | `expiresAt` |
+
+---
+
+## 19. Déploiement
+
+### Docker (recommandé)
+
+```bash
+git clone https://github.com/Christianoooooo/sharely.git
+cd sharely
+cp .env.example .env
+# Éditer .env (SESSION_SECRET, mots de passe MONGO, BASE_URL)
+docker compose up -d
+```
+
+**Services :**
+- `app` — Application Node.js (port 3000)
+- `mongo` — MongoDB 7 (port 127.0.0.1:27017, non accessible de l'extérieur)
+
+**Volumes :**
+- `uploads` — stockage de fichiers persistant
+- `mongo_data` — données MongoDB
+
+**Vérifications de santé :** L'application vérifie HTTP 200 sur `/`, MongoDB vérifie `db.adminCommand('ping')`.
+
+### Proxy inverse Nginx
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name files.example.com;
+
+    client_max_body_size 2100M;  # Au moins aussi grand que le plus grand morceau + tampon
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Support WebSocket
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+```
+
+> `BASE_URL` dans `.env` doit correspondre au domaine public.
+
+### Premier démarrage
+
+Le premier utilisateur enregistré reçoit automatiquement le rôle `admin` (`User.countDocuments() === 0`).
+
+---
+
+## 20. Environnement de développement
+
+### Prérequis
+
+- Node.js ≥ 18
+- MongoDB (local ou via Docker)
+- Optionnel : ffmpeg, ghostscript (pour les miniatures)
+
+### Installation
+
+```bash
+# Backend
+npm install
+cp .env.example .env
+# Éditer .env
+
+# Frontend
+cd client
+npm install
+```
+
+### Démarrage
+
+```bash
+# Backend (port 3000, avec nodemon)
+npm run dev
+
+# Frontend (port 5173, terminal séparé)
+cd client
+npm run dev
+```
+
+Le serveur de développement Vite proxie automatiquement les requêtes API vers `localhost:3000`.
+
+### Build
+
+```bash
+npm run build   # Construit client/dist/, le backend reste inchangé
+npm start       # Démarre le serveur Express de production
+```
+
+---
+
+## 21. Migrations & Scripts
+
+### Migrations automatiques (à chaque démarrage)
+
+Ces migrations s'exécutent au démarrage de l'application dans `app.js` et sont idempotentes :
+
+| Migration | Fichier | Fonction |
+|---|---|---|
+| Migration des dossiers utilisateurs | `src/migrations/migrateUserFolders.js` | Déplace les fichiers de `uploads/` vers `uploads/{folderName}/` |
+| Migration des hachages de clés API | `src/migrations/migrateApiKeyHashes.js` | Convertit les clés API en texte clair en hachages SHA-256 |
+
+### Scripts manuels
+
+```bash
+# Générer des miniatures pour les fichiers existants
+npm run migrate:thumbnails
+# ou :
+node scripts/generate-missing-thumbnails.js
+
+# Déplacer les uploads vers les dossiers utilisateurs (manuel)
+npm run migrate:user-folders
+# ou :
+node scripts/migrate-uploads-to-user-folders.js
+```
+
+### Initialisation de la base de données (Docker)
+
+`scripts/mongo-init.js` est exécuté au premier démarrage du conteneur MongoDB et crée l'utilisateur applicatif avec les permissions correctes.
+
+---
+
+## 22. Tests end-to-end
+
+**Framework :** Playwright (`@playwright/test`)
+
+### Fichiers de test
+
+| Fichier | Suite de tests |
+|---|---|
+| `e2e/upload.spec.js` | Flux d'upload |
+| `e2e/gallery.spec.js` | Galerie et gestion des fichiers |
+| `e2e/admin.spec.js` | Tableau de bord admin |
+| `e2e/sharelink.spec.js` | Création et utilisation des liens de partage |
+| `e2e/tags.spec.js` | Gestion des tags |
+| `e2e/bulk-actions-fixes.spec.js` | Actions en masse |
+
+### Exécution
+
+```bash
+# Tous les tests
+npm run test:e2e
+
+# Avec interface graphique
+npm run test:e2e:ui
+```
+
+**Configuration Playwright :** `playwright.config.js`  
+**Configuration globale :** `e2e/global-setup.js` (crée les utilisateurs de test, l'admin, etc.)  
+**Utilitaires :** `e2e/helpers.js` (fonctions utilitaires partagées)
+
+---
+
+## Annexe : Actions du journal d'audit
+
+| Action | Déclencheur |
+|---|---|
+| `login` | Connexion réussie |
+| `logout` | Déconnexion |
+| `register` | Inscription |
+| `upload` | Upload de fichier |
+| `delete_file` | Fichier supprimé |
+| `delete_account` | Compte supprimé |
+| `change_password` | Mot de passe modifié |
+| `change_username` | Nom d'utilisateur modifié |
+| `change_email` | E-mail modifié |
+| `verify_email` | E-mail vérifié |
+| `forgot_password` | Réinitialisation du mot de passe demandée |
+| `reset_password` | Mot de passe réinitialisé |
+| `regen_api_key` | Clé API régénérée |
+| `sharex_config` | Configuration ShareX téléchargée |
+| `export_data` | Export des données |
+| `admin_create_user` | Admin : utilisateur créé |
+| `admin_delete_user` | Admin : utilisateur supprimé |
+| `admin_toggle_user` | Admin : utilisateur activé/désactivé |
+| `admin_change_role` | Admin : rôle utilisateur modifié |
+| `admin_change_password` | Admin : mot de passe défini |
+| `admin_regen_key` | Admin : clé API régénérée |
+
+---
+
+*Documentation générée à partir du code source de sharely v1.0.0*

--- a/docs/it.md
+++ b/docs/it.md
@@ -1,0 +1,1264 @@
+# Sharely — Documentazione Tecnica
+
+> **Versione:** 1.0.0 · **Licenza:** MIT · **Node.js:** ≥ 18
+
+---
+
+## Indice
+
+1. [Panoramica del progetto](#1-panoramica-del-progetto)
+2. [Architettura](#2-architettura)
+3. [Stack tecnologico](#3-stack-tecnologico)
+4. [Struttura delle directory](#4-struttura-delle-directory)
+5. [Configurazione e variabili d'ambiente](#5-configurazione-e-variabili-dambiente)
+6. [Modelli di dati](#6-modelli-di-dati)
+7. [API REST](#7-api-rest)
+8. [API WebSocket](#8-api-websocket)
+9. [Route di servizio dei file](#9-route-di-servizio-dei-file)
+10. [Autenticazione e sicurezza](#10-autenticazione-e-sicurezza)
+11. [Sistema di upload](#11-sistema-di-upload)
+12. [Generazione delle miniature](#12-generazione-delle-miniature)
+13. [Email e SMTP](#13-email-e-smtp)
+14. [Internazionalizzazione](#14-internazionalizzazione)
+15. [Frontend (React SPA)](#15-frontend-react-spa)
+16. [Pannello di amministrazione](#16-pannello-di-amministrazione)
+17. [GDPR / Privacy](#17-gdpr--privacy)
+18. [Job in background](#18-job-in-background)
+19. [Deployment](#19-deployment)
+20. [Ambiente di sviluppo](#20-ambiente-di-sviluppo)
+21. [Migrazioni e script](#21-migrazioni-e-script)
+22. [Test end-to-end](#22-test-end-to-end)
+
+---
+
+## 1. Panoramica del progetto
+
+Sharely è una **piattaforma di condivisione file self-hosted** con un'interfaccia web pulita, integrazione con ShareX e accesso tramite API. Gli utenti caricano screenshot, file e contenuti multimediali e li condividono istantaneamente tramite link brevi.
+
+### Funzionalità principali
+
+| Funzionalità | Descrizione |
+|---|---|
+| Upload web | Drag-and-drop, fino a 500 file contemporaneamente |
+| Upload a blocchi | File fino a 2 GB tramite upload multi-part parallelo |
+| Integrazione ShareX | File di configurazione `.sxcu` scaricabile con un clic |
+| Upload via API | Autenticazione con token Bearer, compatibile con curl/wget |
+| Visualizzatore file | Zoom sulle immagini, streaming video/audio (HTTP Range), PDF inline, codice con evidenziazione della sintassi |
+| Modalità di incorporazione | *embed* (HTML OG/Twitter Card) o *raw* (reindirizzamento diretto) |
+| Miniature | Anteprime JPEG automatiche per video (ffmpeg) e PDF (ghostscript) |
+| Raccolte | Gruppi di file con password e data di scadenza opzionali |
+| Link di condivisione | Link per file con password, scadenza e limite di download |
+| Interfaccia in tempo reale | Aggiornamenti live via WebSocket (upload, eliminazione, contatore visualizzazioni, statistiche admin) |
+| Multilingua | 8 lingue: EN, DE, FR, ES, IT, PT, JA, ZH |
+| Pannello admin | Statistiche, gestione utenti, gestione file, log di audit (esportazione CSV) |
+| Conformità GDPR | Funzionalità privacy conformi al GDPR dell'UE (Art. 17, 20, 32, ecc.) |
+| Importazione XBackBone | Migrazione di installazioni XBackBone esistenti |
+| Pronto per Docker | `docker compose up -d` avvia l'ambiente completo |
+
+---
+
+## 2. Architettura
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Browser / Client                      │
+│            React 18 SPA  ·  Vite  ·  Tailwind CSS           │
+│   ┌──────────────────────────────────────────────────────┐   │
+│   │  HTTP REST (/api/*)            WebSocket (/ws)       │   │
+│   └──────────────────────────────────────────────────────┘   │
+└───────────────────────────┬────────────────────┬─────────────┘
+                            │ HTTP               │ WS
+┌───────────────────────────▼────────────────────▼─────────────┐
+│                    Express.js (app.js)                        │
+│                                                               │
+│  ┌──────────────┐  ┌───────────┐  ┌──────────┐  ┌────────┐  │
+│  │  /api/auth   │  │  /api/*   │  │   /f/*   │  │  /s/*  │  │
+│  │  /api/install│  │  routes   │  │  files   │  │ shares │  │
+│  └──────────────┘  └───────────┘  └──────────┘  └────────┘  │
+│                                                               │
+│  Middleware: session · rate-limit · CSRF · CSP · auth        │
+│                                                               │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌────────────┐  │
+│  │  multer  │  │  ws.js   │  │  mailer  │  │ retention  │  │
+│  │  upload  │  │ WebSocket│  │ nodemailer│  │  cleanup   │  │
+│  └──────────┘  └──────────┘  └──────────┘  └────────────┘  │
+└───────────────────────────┬───────────────────────────────────┘
+                            │
+┌───────────────────────────▼───────────────────────────────────┐
+│                      MongoDB (Mongoose)                        │
+│  User · File · Collection · ShareLink · SiteSettings          │
+│  AuditLog                                                      │
+└───────────────────────────────────────────────────────────────┘
+                            │
+              ┌─────────────▼───────────────┐
+              │     Dateisystem (uploads/)   │
+              │  {folderName}/  ·  .chunks/  │
+              │  .thumbnails/   ·  .avatars/ │
+              └─────────────────────────────┘
+```
+
+### Flusso di dati: Upload standard
+
+```
+Browser → POST /api/web-upload (multipart/form-data)
+       → multer: Datei in uploads/{folderName}/
+       → File.createUnique() → MongoDB
+       → generateThumbnail() (async, non-blocking)
+       → logAudit()
+       → broadcast('file:uploaded') via WebSocket
+       ← JSON: { files: [...] }
+```
+
+### Flusso di dati: Upload ShareX
+
+```
+ShareX → POST /upload (token im Formular-Body)
+       → multer: Datei temporär in uploads/
+       → requireApiKey: Token-Lookup → User
+       → fs.renameSync → uploads/{folderName}/
+       → File.create() → MongoDB
+       ← JSON: { url, delete_url }
+```
+
+---
+
+## 3. Stack tecnologico
+
+| Livello | Tecnologia | Versione |
+|---|---|---|
+| **Runtime** | Node.js | ≥ 18 |
+| **Framework backend** | Express.js | 4.x |
+| **Database** | MongoDB + Mongoose | Mongo 7, Mongoose 8.x |
+| **Sessioni** | express-session + connect-mongo | — |
+| **Tempo reale** | WebSocket (`ws`) | 8.x |
+| **Upload file** | Multer | 1.x |
+| **Email** | Nodemailer | 8.x |
+| **Hashing password** | bcryptjs | 2.x (12 round) |
+| **Hashing chiavi API** | SHA-256 (Node Crypto) | — |
+| **Rate limiting** | express-rate-limit | 8.x |
+| **Importazione XBackBone** | sql.js | 1.x |
+| **Framework frontend** | React 18 | 18.3.x |
+| **Routing (frontend)** | React Router v6 | 6.x |
+| **Strumento di build** | Vite | 6.x |
+| **Stile** | Tailwind CSS + Radix UI | 3.x |
+| **Componenti UI** | shadcn/ui (Radix primitives) | — |
+| **Icone** | FontAwesome | 6.x |
+| **i18n** | i18next + react-i18next | — |
+| **Evidenziazione sintassi** | highlight.js | 11.x |
+| **Container** | Docker + Docker Compose | — |
+| **Test** | Playwright (E2E) | 1.60.x |
+
+---
+
+## 4. Struttura delle directory
+
+```
+sharely/
+├── app.js                          # Punto di ingresso Express, sequenza di avvio
+├── package.json
+├── .env.example                    # Modello per tutte le variabili d'ambiente
+├── Dockerfile
+├── docker-compose.yml
+│
+├── src/
+│   ├── config/
+│   │   └── db.js                   # Connessione MongoDB (Mongoose)
+│   ├── middleware/
+│   │   ├── auth.js                 # requireLogin / requireAdmin / requireApiKey
+│   │   └── upload.js               # Configurazione Multer, lista di blocco
+│   ├── models/
+│   │   ├── AuditLog.js             # Eventi di audit (TTL 90 giorni)
+│   │   ├── Collection.js           # Raccolte di file
+│   │   ├── File.js                 # Metadati dei file
+│   │   ├── ShareLink.js            # Link di condivisione per file
+│   │   ├── SiteSettings.js         # Singleton: impostazioni operatore
+│   │   └── User.js                 # Account utente + chiavi API
+│   ├── routes/
+│   │   ├── api.js                  # API principale (upload, galleria, admin, ...)
+│   │   ├── auth.js                 # Login / Registrazione / Reset password
+│   │   ├── files.js                # Servizio file, embed OG, richieste di intervallo
+│   │   ├── import.js               # Migrazione XBackBone
+│   │   ├── install.js              # Endpoint di installazione iniziale
+│   │   └── shares.js               # Servizio file tramite link di condivisione
+│   ├── jobs/
+│   │   └── retentionCleanup.js     # Eliminazione giornaliera dei file scaduti
+│   ├── migrations/
+│   │   ├── migrateApiKeyHashes.js  # Una tantum: testi in chiaro → hash SHA-256
+│   │   └── migrateUserFolders.js   # Una tantum: spostamento file nelle cartelle utente
+│   ├── utils/
+│   │   ├── audit.js                # Funzione helper logAudit()
+│   │   ├── generateThumbnail.js    # Integrazione ffmpeg / ghostscript
+│   │   ├── mailer.js               # Wrapper Nodemailer + template email i18n
+│   │   └── sanitizeFilename.js     # Sanificazione del nome file
+│   └── ws.js                       # Server WebSocket + dispatcher azioni
+│
+├── client/                         # Frontend React
+│   ├── index.html
+│   ├── package.json
+│   ├── vite.config.js
+│   ├── tailwind.config.js
+│   └── src/
+│       ├── main.jsx                # Punto di ingresso React
+│       ├── App.jsx                 # Configurazione del router
+│       ├── index.css               # Stili globali
+│       ├── context/
+│       │   └── AuthContext.jsx     # Stato di autenticazione globale
+│       ├── hooks/
+│       │   ├── use-toast.js        # Hook per notifiche toast
+│       │   └── useWebSocket.js     # Connessione WS + gestori eventi
+│       ├── components/
+│       │   ├── Layout.jsx          # Shell dell'app (barra di navigazione, sidebar)
+│       │   ├── ProtectedRoute.jsx  # Guardia di autenticazione
+│       │   ├── ShareLinkDialog.jsx # Dialogo di creazione link di condivisione
+│       │   ├── AddToCollectionDialog.jsx
+│       │   ├── CookieBanner.jsx
+│       │   ├── LanguageSelector.jsx
+│       │   ├── RequireEmailDialog.jsx
+│       │   ├── UserAvatar.jsx
+│       │   └── ui/                 # Componenti base shadcn/ui
+│       ├── pages/
+│       │   ├── Upload.jsx          # Pagina di upload
+│       │   ├── Gallery.jsx         # Galleria file
+│       │   ├── FileView.jsx        # Vista dettaglio file
+│       │   ├── Collections.jsx     # Panoramica raccolte
+│       │   ├── CollectionView.jsx  # Raccolta singola
+│       │   ├── ShareView.jsx       # Pagina pubblica del link di condivisione
+│       │   ├── Settings.jsx        # Impostazioni utente
+│       │   ├── Login.jsx
+│       │   ├── Register.jsx
+│       │   ├── ForgotPassword.jsx
+│       │   ├── ResetPassword.jsx
+│       │   ├── Install.jsx         # Installazione iniziale
+│       │   ├── PrivacyPolicy.jsx
+│       │   ├── TermsOfService.jsx
+│       │   └── admin/
+│       │       ├── Dashboard.jsx   # Home page admin
+│       │       ├── Users.jsx       # Gestione utenti
+│       │       ├── Files.jsx       # Gestione file
+│       │       ├── AuditLog.jsx    # Vista log di audit
+│       │       ├── SiteSettings.jsx# Impostazioni operatore
+│       │       └── Import.jsx      # Importazione XBackBone
+│       ├── i18n/
+│       │   ├── index.js            # Configurazione i18next
+│       │   └── locales/
+│       │       ├── de.json
+│       │       ├── en.json
+│       │       ├── es.json
+│       │       ├── fr.json
+│       │       ├── it.json
+│       │       ├── ja.json
+│       │       ├── pt.json
+│       │       └── zh.json
+│       └── lib/
+│           └── utils.js            # Helper Tailwind (cn())
+│
+├── scripts/
+│   ├── setup-db.js
+│   ├── mongo-init.js               # Script di inizializzazione MongoDB
+│   ├── migrate-uploads-to-user-folders.js
+│   └── generate-missing-thumbnails.js
+│
+├── e2e/                            # Test Playwright
+│   ├── admin.spec.js
+│   ├── bulk-actions-fixes.spec.js
+│   ├── gallery.spec.js
+│   ├── sharelink.spec.js
+│   ├── tags.spec.js
+│   ├── upload.spec.js
+│   ├── helpers.js
+│   └── global-setup.js
+│
+├── uploads/                        # File caricati (runtime)
+│   ├── .thumbnails/
+│   ├── .avatars/
+│   └── .chunks/                    # Blocchi temporanei
+│
+└── docs/assets/                    # Screenshot e logo
+```
+
+---
+
+## 5. Configurazione e variabili d'ambiente
+
+Tutte le variabili vengono caricate da `.env` (tramite `dotenv`). Il file `.env.example` contiene il modello completo.
+
+### Campi obbligatori
+
+| Variabile | Descrizione |
+|---|---|
+| `SESSION_SECRET` | Segreto per la crittografia delle sessioni — stringa casuale lunga, es. `openssl rand -hex 32` |
+| `MONGO_ROOT_PASSWORD` | Password root di MongoDB (richiesta solo per Docker Compose) |
+| `MONGO_APP_PASSWORD` | Password dell'utente applicativo MongoDB |
+
+### Tutte le variabili d'ambiente
+
+| Variabile | Predefinito | Descrizione |
+|---|---|---|
+| `PORT` | `3000` | Porta TCP del server HTTP |
+| `MONGODB_URI` | _(costruita da Docker Compose)_ | URI di connessione MongoDB completa |
+| `MONGO_ROOT_PASSWORD` | — | Password root di MongoDB |
+| `MONGO_APP_USER` | `appuser` | Nome utente applicativo MongoDB |
+| `MONGO_APP_PASSWORD` | — | Password dell'utente applicativo MongoDB |
+| `MONGO_DB_NAME` | `sharely` | Nome del database MongoDB |
+| `SESSION_SECRET` | — | **Obbligatorio** — segreto di crittografia delle sessioni |
+| `BASE_URL` | `http://localhost:3000` | URL base pubblica per i link di condivisione generati (senza `/` finale) |
+| `SITE_NAME` | `sharely` | Nome del sito negli embed Open Graph |
+| `MAX_FILE_SIZE_MB` | `100` | Dimensione massima file per gli upload standard in MB (upload a blocchi fino a 2 GB indipendentemente) |
+| `ALLOW_REGISTRATION` | `true` | `false` disabilita la registrazione pubblica |
+| `SMTP_HOST` | — | Hostname del server SMTP; lasciare vuoto per disabilitare le funzionalità email |
+| `SMTP_PORT` | `587` | Porta SMTP |
+| `SMTP_SECURE` | `false` | `true` per TLS implicito (porta 465), `false` per STARTTLS |
+| `SMTP_USER` | — | Nome utente SMTP |
+| `SMTP_PASS` | — | Password SMTP |
+| `SMTP_FROM` | _(SMTP_USER)_ | Indirizzo mittente nelle email in uscita |
+| `UPLOAD_DIR` | `./uploads` | Percorso assoluto alla directory di upload |
+| `NODE_ENV` | — | `production` abilita i cookie sicuri |
+
+---
+
+## 6. Modelli di dati
+
+### User (`src/models/User.js`)
+
+```
+{
+  username:                    String (3–32, unico, alfanumerico + _-)
+  password:                    String (bcrypt, 12 round)
+  role:                        'admin' | 'user'
+  apiKey:                      String (legacy, vuoto dopo la migrazione)
+  apiKeyHash:                  String (SHA-256, unico, sparse)
+  apiKeyPrefix:                String (primi 8 caratteri del testo in chiaro)
+  folderName:                  String (unico, sparse, max 64)
+  avatarExt:                   String | null (.jpg/.png/.gif/.webp)
+  embedMode:                   'embed' | 'raw'
+  isActive:                    Boolean
+  email:                       String (minuscolo, unico, sparse)
+  emailVerified:               Boolean
+  emailVerificationToken:      String | null (hash SHA-256 del testo in chiaro)
+  emailVerificationExpires:    Date | null
+  passwordResetToken:          String | null (hash SHA-256)
+  passwordResetExpires:        Date | null
+  language:                    'en'|'de'|'fr'|'es'|'it'|'pt'|'ja'|'zh'
+  predefinedTags:              [String] (max 100 tag × 50 caratteri)
+  createdAt:                   Date
+}
+```
+
+**Metodi importanti:**
+- `user.comparePassword(candidate)` — confronto bcrypt
+- `user.regenerateApiKey()` — genera nuovo testo in chiaro, memorizza l'hash, restituisce il testo in chiaro (visibile una sola volta)
+- `User.findByApiKey(plaintext)` — ricerca per hash SHA-256, solo utenti attivi
+
+### File (`src/models/File.js`)
+
+```
+{
+  shortId:      String (8 caratteri esadecimali: 6 timestamp + 2 casuali, unico)
+  deleteToken:  String (32 caratteri esadecimali, unico)
+  originalName: String (sanificato)
+  storedName:   String (percorso relativo: "folderName/8hex.ext")
+  mimeType:     String
+  size:         Number (byte)
+  uploader:     ObjectId → User
+  views:        Number
+  tags:         [String] (max 20 × 50 caratteri)
+  createdAt:    Date
+}
+```
+
+**Proprietà calcolate:**
+- `sizeHuman` — dimensione leggibile (B / KB / MB / GB)
+- `displayType` — classificazione: `image|video|audio|pdf|code|text|file`
+
+**Algoritmo Short ID:**
+```
+shortId = hex(seconds_since_2024-01-01, 6 chars) + randomBytes(2).hex()
+```
+
+### Collection (`src/models/Collection.js`)
+
+```
+{
+  shortId:     String (8 Hex, unico)
+  name:        String (max 100)
+  description: String (max 500)
+  owner:       ObjectId → User
+  files:       [ObjectId → File]
+  password:    String | null (bcrypt)
+  expiresAt:   Date | null
+  createdAt:   Date
+}
+```
+
+> Le raccolte scadute vengono eliminate automaticamente dall'indice TTL di MongoDB 7 giorni dopo la scadenza.
+
+### ShareLink (`src/models/ShareLink.js`)
+
+```
+{
+  token:         String (32 Hex, unico)
+  file:          ObjectId → File
+  createdBy:     ObjectId → User
+  label:         String (max 100)
+  password:      String | null (bcrypt)
+  expiresAt:     Date | null
+  downloadLimit: Number (-1 = illimitato)
+  downloadCount: Number
+  createdAt:     Date
+}
+```
+
+> Come le raccolte: periodo di grazia di 7 giorni dopo la scadenza tramite indice TTL.
+
+### SiteSettings (`src/models/SiteSettings.js`)
+
+Documento singleton (`_id: 'singleton'`):
+
+```
+{
+  operatorName:        String
+  operatorAddress:     String
+  operatorEmail:       String
+  cloudflareAnalytics: Boolean
+  fileRetentionDays:   Number (0 = disabilitato)
+  encryptionAtRest:    Boolean
+  sessionDurationDays: Number (predefinito: 7)
+  allowRegistration:   Boolean
+}
+```
+
+### AuditLog (`src/models/AuditLog.js`)
+
+```
+{
+  timestamp: Date (indice TTL: 90 giorni)
+  userId:    ObjectId → User | null
+  username:  String | null
+  action:    String
+  ip:        String | null
+  meta:      Mixed (metadati specifici dell'azione)
+}
+```
+
+---
+
+## 7. API REST
+
+### URL base: `/api`
+
+Tutti gli endpoint JSON restituiscono `Content-Type: application/json`. Errori: `{ "error": "messaggio" }`.
+
+---
+
+### Autenticazione (`/api/auth`)
+
+| Metodo | Percorso | Auth | Descrizione |
+|---|---|---|---|
+| `GET` | `/me` | Sessione | Utente attualmente connesso |
+| `POST` | `/login` | — | Accesso (limitato: 10/15min) |
+| `POST` | `/register` | — | Registrazione (limitata, il primo utente diventa admin) |
+| `POST` | `/logout` | — | Disconnessione |
+| `GET` | `/smtp-enabled` | — | Verifica se SMTP è configurato |
+| `GET` | `/verify-email?token=` | — | Verificare l'indirizzo email |
+| `GET` | `/verify-reset-token?token=` | — | Validare il token di reset |
+| `POST` | `/forgot-password` | — | Inviare l'email di reset password (limitato: 5/h) |
+| `POST` | `/reset-password` | — | Impostare la nuova password |
+
+**Richiesta di accesso:**
+```json
+POST /api/auth/login
+{ "username": "max", "password": "meinPasswort123" }
+```
+
+**Risposta di accesso:**
+```json
+{
+  "user": {
+    "id": "...", "username": "max", "role": "user",
+    "avatarUrl": null, "email": "max@example.com",
+    "emailVerified": true, "language": "de"
+  }
+}
+```
+
+---
+
+### Upload di file
+
+| Metodo | Percorso | Auth | Descrizione |
+|---|---|---|---|
+| `POST` | `/upload` | Chiave API | Upload ShareX (endpoint legacy in `app.js`) |
+| `POST` | `/api/upload` | Chiave API | Upload ShareX/API (campo: `file`) |
+| `POST` | `/api/web-upload` | Sessione | Upload web (campo: `files[]`, max 500) |
+| `POST` | `/api/chunk/init` | Sessione | Inizializzare upload a blocchi |
+| `POST` | `/api/chunk/:uploadId` | Sessione | Caricare un blocco (campo: `chunk`) |
+| `POST` | `/api/chunk/:uploadId/complete` | Sessione | Assemblare i blocchi |
+| `DELETE` | `/api/chunk/:uploadId` | Sessione | Annullare upload e pulire |
+
+**Risposta di upload API:**
+```json
+{
+  "url": "https://example.com/f/a1b2c3d4",
+  "raw": "https://example.com/f/a1b2c3d4/raw",
+  "delete_url": "https://example.com/api/delete/a1b2c3d4",
+  "short_id": "a1b2c3d4",
+  "filename": "screenshot.png",
+  "size": 102400
+}
+```
+
+#### Flusso di upload a blocchi
+
+1. `POST /api/chunk/init` → `{ uploadId: "32hex" }`
+2. `POST /api/chunk/:uploadId` (Body: `chunkIndex=N`, File: `chunk`) → `{ received: N }`  
+   In parallelo con 3–5 blocchi simultanei
+3. `POST /api/chunk/:uploadId/complete` → `{ files: [fileObject] }`
+
+---
+
+### Gestione file
+
+| Metodo | Percorso | Auth | Descrizione |
+|---|---|---|---|
+| `GET` | `/api/gallery` | Sessione | File propri (admin: tutti), paginato (24/pagina), filtri: `q`, `type`, `tag`, `page` |
+| `GET` | `/api/file/:shortId` | — | Metadati del file (incrementa il contatore visualizzazioni) |
+| `PATCH` | `/api/file/:shortId` | Sessione | Aggiornare tag/nome |
+| `DELETE` | `/api/file/:shortId` | Sessione | Eliminare file |
+| `DELETE` | `/api/delete/:shortId` | Chiave API | Eliminare file (autenticazione chiave API) |
+| `POST` | `/api/files/bulk` | Sessione | Azioni in blocco: `delete`, `tag`, `removeTag`, `addToCollection`, `moveToCollection` |
+| `GET` | `/api/tags` | Sessione | Tutti i suggerimenti di tag dell'utente |
+
+**Parametri di query della galleria:**
+- `q` — ricerca nel nome file (sicuro per regex)
+- `type` — `all|image|video|audio|pdf|code`
+- `tag` — filtro tag esatto
+- `page` — numero di pagina (predefinito: 1)
+
+---
+
+### Impostazioni utente
+
+| Metodo | Percorso | Auth | Descrizione |
+|---|---|---|---|
+| `GET` | `/api/my-key` | Sessione | Mostra il prefisso della chiave API |
+| `POST` | `/api/regen-key` | Sessione | Rigenerare la chiave API |
+| `GET` | `/api/sharex-config` | Sessione | Scaricare ShareX `.sxcu` (rigenera la chiave) |
+| `PATCH` | `/api/user/username` | Sessione | Cambiare nome utente (password richiesta) |
+| `PATCH` | `/api/user/password` | Sessione | Cambiare password |
+| `PATCH` | `/api/user/email` | Sessione | Cambiare email (invia email di verifica) |
+| `PATCH` | `/api/user/language` | Sessione | Impostare la lingua dell'interfaccia |
+| `PATCH` | `/api/user/embed-mode` | Sessione | Impostare la modalità di incorporazione (`embed`/`raw`) |
+| `POST` | `/api/user/resend-verification` | Sessione | Reinviare l'email di verifica |
+| `GET` | `/api/user/export` | Sessione | Esportazione dati (GDPR Art. 20) come JSON |
+| `DELETE` | `/api/user/account` | Sessione | Eliminare account (GDPR Art. 17, password richiesta) |
+| `GET` | `/api/user/predefined-tags` | Sessione | Recuperare tag predefiniti |
+| `PATCH` | `/api/user/predefined-tags` | Sessione | Aggiornare tag predefiniti |
+| `POST` | `/api/user/avatar` | Sessione | Caricare avatar (max 2 MB, JPEG/PNG/GIF/WebP) |
+| `DELETE` | `/api/user/avatar` | Sessione | Eliminare avatar |
+| `GET` | `/api/user/avatar/:userId` | — | Servire avatar |
+
+---
+
+### Link di condivisione
+
+| Metodo | Percorso | Auth | Descrizione |
+|---|---|---|---|
+| `GET` | `/api/file/:shortId/share-links` | Sessione (Proprietario/Admin) | Tutti i link di condivisione di un file |
+| `POST` | `/api/file/:shortId/share-links` | Sessione (Proprietario/Admin) | Creare link di condivisione |
+| `DELETE` | `/api/share-links/:token` | Sessione (Proprietario/Creatore/Admin) | Eliminare link di condivisione |
+| `GET` | `/api/share-links/:token` | — | Metadati del link di condivisione (pubblico) |
+| `POST` | `/api/share-links/:token/verify` | — | Verificare la password del link di condivisione |
+
+**Creare link di condivisione:**
+```json
+POST /api/file/a1b2c3d4/share-links
+{
+  "label": "Per i colleghi",
+  "password": "segreto",
+  "expiresAt": "2025-12-31T23:59:59Z",
+  "downloadLimit": 10
+}
+```
+
+---
+
+### Raccolte
+
+| Metodo | Percorso | Auth | Descrizione |
+|---|---|---|---|
+| `GET` | `/api/collections` | Sessione | Raccolte proprie (admin: tutte) |
+| `POST` | `/api/collections` | Sessione | Creare raccolta |
+| `GET` | `/api/collections/:id` | — | Visualizzare raccolta (pubblica, password se impostata) |
+| `PATCH` | `/api/collections/:id` | Sessione (Proprietario/Admin) | Aggiornare raccolta |
+| `DELETE` | `/api/collections/:id` | Sessione (Proprietario/Admin) | Eliminare raccolta |
+| `POST` | `/api/collections/:id/files` | Sessione (Proprietario/Admin) | Aggiungere file alla raccolta |
+| `DELETE` | `/api/collections/:id/files/:fileShortId` | Sessione (Proprietario/Admin) | Rimuovere file dalla raccolta |
+| `POST` | `/api/collections/:id/verify` | — | Verificare la password della raccolta |
+
+---
+
+### Endpoint di amministrazione
+
+| Metodo | Percorso | Auth | Descrizione |
+|---|---|---|---|
+| `GET` | `/api/admin/stats` | Admin | Statistiche del pannello |
+| `GET` | `/api/admin/users` | Admin | Tutti gli utenti (con numero di file) |
+| `POST` | `/api/admin/users` | Admin | Creare utente |
+| `PATCH` | `/api/admin/users/:id/toggle` | Admin | Attivare/disattivare utente |
+| `PATCH` | `/api/admin/users/:id/role` | Admin | Cambiare ruolo utente |
+| `DELETE` | `/api/admin/users/:id` | Admin | Eliminare utente |
+| `POST` | `/api/admin/users/:id/regen-key` | Admin | Rigenerare chiave API |
+| `PATCH` | `/api/admin/users/:id/password` | Admin | Impostare password |
+| `PATCH` | `/api/admin/users/:id/folder` | Admin | Cambiare nome cartella (sposta i file) |
+| `GET` | `/api/admin/files` | Admin | Tutti i file, paginato (30/pagina) |
+| `GET` | `/api/admin/site-settings` | Admin | Leggere impostazioni operatore |
+| `PATCH` | `/api/admin/site-settings` | Admin | Aggiornare impostazioni operatore |
+| `GET` | `/api/admin/audit-log` | Admin | Log di audit paginato (50/pagina) |
+| `GET` | `/api/admin/audit-log/export` | Admin | Scaricare log di audit come CSV |
+| `GET` | `/api/site-settings` | — | Informazioni pubbliche dell'operatore (per la pagina privacy) |
+
+---
+
+### Impostazioni del sito (pubbliche)
+
+```json
+GET /api/site-settings
+{
+  "operatorName": "Musterfirma GmbH",
+  "operatorAddress": "Musterstr. 1, 12345 Musterstadt",
+  "operatorEmail": "datenschutz@example.com",
+  "cloudflareAnalytics": false,
+  "fileRetentionDays": 365,
+  "encryptionAtRest": false,
+  "sessionDurationDays": 7
+}
+```
+
+---
+
+## 8. API WebSocket
+
+**Connessione:** `wss://example.com/ws` (solo per utenti connessi, cookie di sessione richiesto)
+
+### Protocollo
+
+**Client → Server (Richiesta):**
+```json
+{ "id": "req-abc123", "action": "file:list", "payload": { "type": "image", "page": 1 } }
+```
+
+**Server → Client (Risposta):**
+```json
+{ "id": "req-abc123", "data": { ... } }
+```
+
+**Server → Client (Errore):**
+```json
+{ "id": "req-abc123", "error": "Forbidden", "status": 403 }
+```
+
+**Server → Client (Broadcast):**
+```json
+{ "event": "file:uploaded", "data": { "shortId": "a1b2c3d4", "uploaderId": "..." } }
+```
+
+### Azioni disponibili
+
+| Azione | Auth | Descrizione |
+|---|---|---|
+| `site-settings:get` | — | Impostazioni pubbliche del sito |
+| `auth:me` | Utente | Dati dell'utente connesso |
+| `file:get` | Utente | Dettagli del file (incrementa le visualizzazioni) |
+| `file:list` | Utente | Lista file con filtro/paginazione |
+| `file:delete` | Utente | Eliminare file |
+| `user:get-key` | Utente | Prefisso chiave API |
+| `user:regen-key` | Utente | Rigenerare chiave API |
+| `user:change-password` | Utente | Cambiare password |
+| `user:change-username` | Utente | Cambiare nome utente |
+| `user:change-email` | Utente | Cambiare email |
+| `user:change-language` | Utente | Impostare lingua |
+| `user:change-embed-mode` | Utente | Impostare modalità di incorporazione |
+| `user:resend-verification` | Utente | Reinviare email di verifica |
+| `user:export` | Utente | Esportazione dati |
+| `user:delete-account` | Utente | Eliminare account |
+| `admin:stats` | Admin | Statistiche del pannello |
+| `admin:settings:get` | Admin | Leggere impostazioni del sito |
+| `admin:settings:update` | Admin | Aggiornare impostazioni del sito |
+| `admin:users:list` | Admin | Tutti gli utenti |
+| `admin:users:create` | Admin | Creare utente |
+| `admin:users:toggle` | Admin | Attivare/disattivare utente |
+| `admin:users:role` | Admin | Cambiare ruolo utente |
+| `admin:users:delete` | Admin | Eliminare utente |
+| `admin:users:regen-key` | Admin | Rigenerare chiave API |
+| `admin:users:password` | Admin | Impostare password |
+| `admin:users:folder` | Admin | Cambiare nome cartella |
+| `admin:files:list` | Admin | Tutti i file |
+| `admin:audit-log:list` | Admin | Log di audit paginato |
+
+### Eventi broadcast
+
+| Evento | Destinatari | Payload |
+|---|---|---|
+| `file:uploaded` | Uploader | `{ shortId, uploaderId }` |
+| `file:deleted` | Proprietario del file | `{ shortId, uploaderId }` |
+| `file:view` | Tutti | `{ shortId, views }` |
+| `user:created` | Admin | `{ id, username, role, ... }` |
+| `user:deleted` | Admin | `{ id }` |
+| `user:updated` | Admin | `{ id, ...campi modificati }` |
+| `audit:log` | Admin | Oggetto AuditLog completo |
+| `settings:updated` | Admin | Oggetto SiteSettings aggiornato |
+| `stats:invalidate` | Admin | `{}` (attiva l'aggiornamento delle statistiche) |
+
+---
+
+## 9. Route di servizio dei file
+
+### `/f/:shortId` — Visualizzatore file
+
+- **Richiesta del browser:** Passa alla React SPA (`index.html`) — la SPA renderizza il visualizzatore.
+- **Bot di social media** (Discord, Telegram, Twitter, ecc.): Restituisce una pagina HTML minimale con meta tag Open Graph / Twitter Card.
+  - `embedMode = 'embed'`: HTML OG con reindirizzamento
+  - `embedMode = 'raw'` + immagine/video/audio: HTTP 302 → `/f/:shortId/raw`
+
+### `/f/:shortId/raw` — Accesso diretto
+
+Serve il file come risposta HTTP con supporto delle richieste di intervallo (206 Partial Content). Immagini/video/audio: `Content-Disposition: inline`, altri: `attachment`.
+
+### `/f/:shortId/download` — Download forzato
+
+Come `/raw`, ma sempre `Content-Disposition: attachment`.
+
+### `/f/:shortId/thumb` — Miniatura
+
+Restituisce la miniatura JPEG (per video e PDF). `Cache-Control: public, max-age=86400`.
+
+### `/f/:shortId/delete/:token` — Eliminazione ShareX
+
+Elimina il file senza sessione tramite token di eliminazione univoco.
+
+### `/s/:token` — Servizio file tramite link di condivisione (`src/routes/shares.js`)
+
+Verifica la password (tramite flag di sessione), la data di scadenza e il limite di download, poi serve il file.
+
+---
+
+## 10. Autenticazione e sicurezza
+
+### Autenticazione tramite sessione
+
+- Sessione Express con store MongoDB (`connect-mongo`)
+- Cookie di sessione: `httpOnly: true`, `sameSite: 'strict'`, `secure: true` in produzione
+- Durata della sessione: configurabile tramite `SiteSettings.sessionDurationDays` (predefinito: 7 giorni), con cache live di 60 secondi
+
+### Autenticazione tramite chiave API
+
+- Le chiavi API sono memorizzate come hash SHA-256, mai in testo in chiaro
+- I primi 8 caratteri sono memorizzati come `apiKeyPrefix` (per scopi di visualizzazione)
+- Ricerca: `User.findByApiKey(plaintext)` calcola l'hash e cerca in `apiKeyHash`
+- Al download della configurazione ShareX, la chiave viene rigenerata — il testo in chiaro è visibile solo in quel momento
+
+### Catena middleware (`src/middleware/auth.js`)
+
+```
+requireLogin    → verifica req.session.user → 401 se non connesso
+requireAdmin    → come requireLogin, in aggiunta role === 'admin' → 403
+requireApiKey   → verifica l'header Authorization o req.body.token
+```
+
+### Protezione CSRF
+
+`requireSameOrigin()` in `app.js` confronta l'header `Origin` con l'header `Host` per tutte le route API. Complementa i cookie `sameSite: 'strict'`.
+
+### Content Security Policy
+
+```
+default-src 'self';
+script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com;
+style-src 'self' 'unsafe-inline';
+img-src 'self' data: blob:;
+media-src 'self' blob:;
+connect-src 'self' https://cloudflareinsights.com;
+frame-ancestors 'self';
+```
+
+### Header di sicurezza
+
+- `X-Frame-Options: SAMEORIGIN`
+- `X-Content-Type-Options: nosniff`
+
+### Rate limiting
+
+| Endpoint | Limite | Finestra |
+|---|---|---|
+| Upload (`/upload`, `/api/upload`, `/api/web-upload`) | 60 richieste | 15 minuti |
+| Auth (`/api/auth/login`, `/register`, ecc.) | 10 richieste | 15 minuti |
+| Reset password | 5 richieste | 1 ora |
+
+### Lista di blocco dei file
+
+I seguenti tipi MIME ed estensioni vengono rifiutati all'upload:
+
+**Tipi MIME bloccati:** `application/x-executable`, `application/x-sh`, `application/x-csh`, `application/x-bat`
+
+**Estensioni bloccate:** `.bat`, `.cmd`, `.com`, `.ps1`, `.psm1`, `.psd1`, `.sh`, `.bash`, `.csh`, `.zsh`, `.fish`, `.vbs`, `.vbe`, `.jse`, `.scr`, `.pif`, `.application`, `.gadget`, `.hta`, `.php`, `.php3–5`, `.phtml`, `.asp`, `.aspx`, `.jsp`, `.jspx`, `.cfm`
+
+### Protezione da path traversal
+
+Tutti gli accessi ai file tramite `resolveUploadPath()` verificano che il percorso risolto si trovi all'interno di `UPLOAD_DIR`.
+
+---
+
+## 11. Sistema di upload
+
+### Upload standard (Multer)
+
+- **Archiviazione:** `multer.diskStorage` → `uploads/{folderName}/{8hex}{.ext}`
+- **Nome file:** `crypto.randomBytes(4).hex() + estensione-originale`
+- **Limite:** `MAX_FILE_SIZE_MB` (predefinito: 100 MB)
+- **Posizione:** Cartella specifica dell'utente (`user.folderName`)
+
+### Upload a blocchi (>250 MB)
+
+Il client frontend passa automaticamente alla modalità a blocchi per i file di grandi dimensioni.
+
+**Struttura delle directory lato server:**
+```
+uploads/.chunks/{uploadId}/
+  meta.json          { filename, mimeType, totalSize, totalChunks, userId, createdAt }
+  chunk-0
+  chunk-1
+  ...
+  chunk-N
+```
+
+**Dimensione blocco:** 10–20 MB (max 51 MB accettato per compatibilità con versioni precedenti)  
+**Parallelismo:** 3–5 upload di blocchi simultanei  
+**Assemblaggio:** Basato su stream (senza caricamento completo in RAM)
+
+### Upload avatar
+
+- **Archiviazione:** `multer.memoryStorage()` (nessun buffer su disco)
+- **Posizione:** `uploads/.avatars/{userId}{.ext}`
+- **Limite:** 2 MB
+- **Formati:** JPEG, PNG, GIF, WebP
+
+---
+
+## 12. Generazione delle miniature
+
+Le miniature vengono generate in modo asincrono dopo l'upload (`.catch(() => {})` — gli errori vengono ignorati silenziosamente).
+
+### Miniature video (ffmpeg)
+
+```bash
+ffmpeg -y -i <file> -ss 00:00:01 -vframes 1 \
+  -vf "scale=320:320:force_original_aspect_ratio=increase,crop=320:320" \
+  -q:v 3 uploads/.thumbnails/<shortId>.jpg
+```
+
+### Miniature PDF (Ghostscript)
+
+```bash
+gs -dNOPAUSE -dBATCH -dSAFER \
+  -sDEVICE=jpeg -dFirstPage=1 -dLastPage=1 \
+  -r72 -dJPEGQ=85 \
+  -sOutputFile=uploads/.thumbnails/<shortId>.jpg \
+  <file>
+```
+
+**Timeout:** 30 secondi per generazione di miniatura  
+**Fallback:** Se ffmpeg/ghostscript non è disponibile, la generazione viene ignorata silenziosamente.
+
+### Script di backfill
+
+```bash
+npm run migrate:thumbnails
+# o nel container:
+docker exec -it <container> npm run migrate:thumbnails
+```
+
+---
+
+## 13. Email e SMTP
+
+### Configurazione
+
+SMTP viene attivato quando `SMTP_HOST` è impostato. `mailer.isConfigured()` verifica questo valore.
+
+### Template email
+
+Tutte le email vengono inviate nella lingua dell'utente (8 lingue). I template sono incorporati in `src/utils/mailer.js`.
+
+**Tipi di email inviati:**
+
+| Tipo | Trigger | Validità token |
+|---|---|---|
+| Verifica email | Registrazione, cambio email | 24 ore |
+| Reset password | `POST /api/auth/forgot-password` | 1 ora |
+
+### Sicurezza dei token
+
+- Token: `crypto.randomBytes(32).hex()` (64 caratteri esadecimali)
+- Memorizzati: hash SHA-256 del token
+- L'email contiene il token in testo in chiaro come parametro URL
+- Verifica: hash del token in arrivo confrontato con l'hash memorizzato
+
+---
+
+## 14. Internazionalizzazione
+
+**Libreria:** i18next + react-i18next + i18next-browser-languagedetector
+
+**Lingue supportate:**
+
+| Codice | Lingua |
+|---|---|
+| `en` | English |
+| `de` | Deutsch |
+| `fr` | Français |
+| `es` | Español |
+| `it` | Italiano |
+| `pt` | Português |
+| `ja` | 日本語 |
+| `zh` | 中文 |
+
+**Selezione della lingua:**
+1. Rilevamento della lingua del browser (automatico)
+2. Preferenza dell'utente nel database (`user.language`)
+3. Persistenza tramite `PATCH /api/user/language`
+
+File di traduzione: `client/src/i18n/locales/{code}.json`
+
+---
+
+## 15. Frontend (React SPA)
+
+### Configurazione del router (`client/src/App.jsx`)
+
+| Route | Componente | Auth |
+|---|---|---|
+| `/` | Reindirizzamento → `/gallery` | No |
+| `/auth/login` | Login.jsx | No |
+| `/auth/register` | Register.jsx | No |
+| `/auth/forgot-password` | ForgotPassword.jsx | No |
+| `/auth/reset-password` | ResetPassword.jsx | No |
+| `/install` | Install.jsx | No |
+| `/upload` | Upload.jsx | **Sì** |
+| `/gallery` | Gallery.jsx | **Sì** |
+| `/f/:shortId` | FileView.jsx | **Sì** |
+| `/collections` | Collections.jsx | **Sì** |
+| `/c/:id` | CollectionView.jsx | No (pubblico) |
+| `/s/:token` | ShareView.jsx | No (pubblico) |
+| `/settings` | Settings.jsx | **Sì** |
+| `/admin` | Dashboard.jsx | **Admin** |
+| `/admin/users` | Users.jsx | **Admin** |
+| `/admin/files` | Files.jsx | **Admin** |
+| `/admin/audit-log` | AuditLog.jsx | **Admin** |
+| `/admin/site-settings` | SiteSettings.jsx | **Admin** |
+| `/admin/import` | Import.jsx | **Admin** |
+| `/privacy` | PrivacyPolicy.jsx | No |
+| `/terms` | TermsOfService.jsx | No |
+
+### Contesto di autenticazione (`client/src/context/AuthContext.jsx`)
+
+Stato globale per l'utente connesso. Inizializzato all'avvio dell'app tramite `GET /api/auth/me`.
+
+### Hook WebSocket (`client/src/hooks/useWebSocket.js`)
+
+Gestisce la connessione WS persistente. Fornisce `sendMessage()` e la registrazione dei gestori eventi. Logica di riconnessione in caso di interruzione della connessione.
+
+### Componenti UI
+
+Basato su **shadcn/ui** (Radix UI Primitives + Tailwind CSS):
+
+- `Dialog`, `AlertDialog`, `DropdownMenu`, `ContextMenu`, `Popover`
+- `Select`, `Checkbox`, `Input`, `Textarea`, `Label`
+- `Card`, `Badge`, `Button`, `Separator`, `Tabs`, `Table`
+- `Toast` / `Toaster` per le notifiche
+- `Calendar` / `DateTimePicker` per la selezione della data di scadenza
+- `Pagination` per le liste paginate
+- `ScrollArea`, `Tooltip`
+
+---
+
+## 16. Pannello di amministrazione
+
+Il pannello di amministrazione (`/admin/*`) è accessibile solo agli utenti con `role: 'admin'`.
+
+### Dashboard (`/admin`)
+
+- Numero totale di utenti, file, utilizzo dello storage
+- 10 file caricati più di recente
+- Aggiornamenti live via WebSocket (`stats:invalidate`)
+
+### Gestione utenti (`/admin/users`)
+
+- Tutti gli utenti con numero di file e utilizzo dello storage
+- Creare utenti, attivare/disattivare, cambiare ruolo
+- Reimpostare password, rigenerare chiave API
+- Cambiare nome cartella (i file fisici vengono spostati sul server)
+- Eliminare utente (tutti i file vengono eliminati)
+
+### Gestione file (`/admin/files`)
+
+- Tutti i file di tutti gli utenti, paginato
+- Ricerca per nome file
+- Eliminare file
+
+### Log di audit (`/admin/audit-log`)
+
+- Log paginato di tutte le azioni (50/pagina)
+- Filtro per nome utente e azione
+- Esportazione CSV per scopi normativi
+
+### Impostazioni del sito (`/admin/site-settings`)
+
+- Informazioni sull'operatore (nome, indirizzo, email)
+- Abilitare Cloudflare Analytics
+- Periodo di conservazione dei file
+- Durata delle sessioni
+- Abilitare/disabilitare la registrazione
+
+### Importazione XBackBone (`/admin/import`)
+
+- Anteprima e importazione da database SQLite di XBackBone
+- Gli utenti vengono abbinati per nome utente
+- Idempotente (i file già importati vengono ignorati)
+
+---
+
+## 17. GDPR / Privacy
+
+| Funzionalità | Articolo GDPR |
+|---|---|
+| Informativa sulla privacy (configurabile) | Art. 13/14 – Trasparenza |
+| Pagina termini di servizio (configurabile) | Art. 13/14 – Trasparenza |
+| Esportazione dati (JSON con URL) | Art. 20 – Portabilità dei dati |
+| Autoeliminazione account (file + dati) | Art. 17 – Diritto alla cancellazione |
+| Log di audit (TTL 90 giorni via MongoDB) | Art. 5(2) – Responsabilità |
+| Esportazione CSV del log di audit | Art. 5(2) – Responsabilità |
+| Conservazione file configurabile | Art. 5(1)(e) – Limitazione della conservazione |
+| Chiavi API come hash SHA-256 | Art. 32 – Sicurezza |
+| Password come bcrypt (12 round) | Art. 32 – Sicurezza |
+| Consenso cookie per Cloudflare Analytics | Art. 13 – Trasparenza |
+| Anonimizzazione alla cancellazione dell'account | Art. 17 – Diritto alla cancellazione |
+
+### Flusso di eliminazione GDPR
+
+Alla cancellazione dell'account (`user:delete-account` / `DELETE /api/user/account`):
+1. Tutti i file dell'utente vengono eliminati dal disco
+2. Le miniature vengono eliminate
+3. L'avatar viene eliminato
+4. Le voci del log di audit vengono anonimizzate (`username: '[deleted]'`, `ip: null`, `userId: null`)
+5. Il documento utente viene eliminato
+6. La sessione viene distrutta
+
+---
+
+## 18. Job in background
+
+### Pulizia per conservazione (`src/jobs/retentionCleanup.js`)
+
+- **Esecuzione:** All'avvio e poi quotidianamente (`setInterval(runRetentionCleanup, 24h)`)
+- **Azione:** Se `SiteSettings.fileRetentionDays > 0`, i file più vecchi di questo valore vengono eliminati
+- Elimina: file su disco, miniatura, documento MongoDB
+- Invia broadcast `stats:invalidate` agli admin
+
+### Indici TTL MongoDB (automatici)
+
+| Collezione | TTL | Trigger |
+|---|---|---|
+| `AuditLog` | 90 giorni | `timestamp` |
+| `Collection` | 7 giorni dopo `expiresAt` | `expiresAt` |
+| `ShareLink` | 7 giorni dopo `expiresAt` | `expiresAt` |
+
+---
+
+## 19. Deployment
+
+### Docker (consigliato)
+
+```bash
+git clone https://github.com/Christianoooooo/sharely.git
+cd sharely
+cp .env.example .env
+# Modificare .env (SESSION_SECRET, password MONGO, BASE_URL)
+docker compose up -d
+```
+
+**Servizi:**
+- `app` — Applicazione Node.js (porta 3000)
+- `mongo` — MongoDB 7 (porta 127.0.0.1:27017, non accessibile dall'esterno)
+
+**Volumi:**
+- `uploads` — archiviazione persistente dei file
+- `mongo_data` — dati MongoDB
+
+**Health check:** L'app verifica HTTP 200 su `/`, MongoDB verifica `db.adminCommand('ping')`.
+
+### Reverse proxy Nginx
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name files.example.com;
+
+    client_max_body_size 2100M;  # Almeno quanto il blocco più grande + buffer
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Supporto WebSocket
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+```
+
+> `BASE_URL` in `.env` deve corrispondere al dominio pubblico.
+
+### Primo avvio
+
+Il primo utente registrato riceve automaticamente il ruolo `admin` (`User.countDocuments() === 0`).
+
+---
+
+## 20. Ambiente di sviluppo
+
+### Prerequisiti
+
+- Node.js ≥ 18
+- MongoDB (locale o tramite Docker)
+- Opzionale: ffmpeg, ghostscript (per le miniature)
+
+### Configurazione
+
+```bash
+# Backend
+npm install
+cp .env.example .env
+# Modificare .env
+
+# Frontend
+cd client
+npm install
+```
+
+### Avvio
+
+```bash
+# Backend (porta 3000, con nodemon)
+npm run dev
+
+# Frontend (porta 5173, terminale separato)
+cd client
+npm run dev
+```
+
+Il server di sviluppo Vite fa il proxy delle richieste API verso `localhost:3000` automaticamente.
+
+### Build
+
+```bash
+npm run build   # Compila client/dist/, il backend rimane invariato
+npm start       # Avvia il server Express di produzione
+```
+
+---
+
+## 21. Migrazioni e script
+
+### Migrazioni automatiche (a ogni avvio)
+
+Queste migrazioni vengono eseguite all'avvio dell'app in `app.js` e sono idempotenti:
+
+| Migrazione | File | Funzione |
+|---|---|---|
+| Migrazione cartelle utente | `src/migrations/migrateUserFolders.js` | Sposta i file da `uploads/` a `uploads/{folderName}/` |
+| Migrazione hash chiavi API | `src/migrations/migrateApiKeyHashes.js` | Converte le chiavi API in testo in chiaro in hash SHA-256 |
+
+### Script manuali
+
+```bash
+# Generare miniature per i file già esistenti
+npm run migrate:thumbnails
+# oppure:
+node scripts/generate-missing-thumbnails.js
+
+# Spostare gli upload nelle cartelle utente (manuale)
+npm run migrate:user-folders
+# oppure:
+node scripts/migrate-uploads-to-user-folders.js
+```
+
+### Inizializzazione del database (Docker)
+
+`scripts/mongo-init.js` viene eseguito al primo avvio del container MongoDB e crea l'utente applicativo con i permessi corretti.
+
+---
+
+## 22. Test end-to-end
+
+**Framework:** Playwright (`@playwright/test`)
+
+### File di test
+
+| File | Suite di test |
+|---|---|
+| `e2e/upload.spec.js` | Flussi di upload |
+| `e2e/gallery.spec.js` | Galleria e gestione file |
+| `e2e/admin.spec.js` | Pannello di amministrazione |
+| `e2e/sharelink.spec.js` | Creazione e utilizzo dei link di condivisione |
+| `e2e/tags.spec.js` | Gestione dei tag |
+| `e2e/bulk-actions-fixes.spec.js` | Azioni in blocco |
+
+### Esecuzione
+
+```bash
+# Tutti i test
+npm run test:e2e
+
+# Con interfaccia grafica
+npm run test:e2e:ui
+```
+
+**Configurazione Playwright:** `playwright.config.js`  
+**Setup globale:** `e2e/global-setup.js` (crea utenti di test, admin, ecc.)  
+**Helper:** `e2e/helpers.js` (funzioni helper condivise)
+
+---
+
+## Appendice: Azioni del log di audit
+
+| Azione | Trigger |
+|---|---|
+| `login` | Accesso riuscito |
+| `logout` | Disconnessione |
+| `register` | Registrazione |
+| `upload` | Upload file |
+| `delete_file` | File eliminato |
+| `delete_account` | Account eliminato |
+| `change_password` | Password modificata |
+| `change_username` | Nome utente modificato |
+| `change_email` | Email modificata |
+| `verify_email` | Email verificata |
+| `forgot_password` | Reset password richiesto |
+| `reset_password` | Password reimpostata |
+| `regen_api_key` | Chiave API rigenerata |
+| `sharex_config` | Configurazione ShareX scaricata |
+| `export_data` | Esportazione dati |
+| `admin_create_user` | Admin: utente creato |
+| `admin_delete_user` | Admin: utente eliminato |
+| `admin_toggle_user` | Admin: utente attivato/disattivato |
+| `admin_change_role` | Admin: ruolo utente modificato |
+| `admin_change_password` | Admin: password impostata |
+| `admin_regen_key` | Admin: chiave API rigenerata |
+
+---
+
+*Documentazione generata dal codice sorgente di sharely v1.0.0*

--- a/docs/ja.md
+++ b/docs/ja.md
@@ -1,0 +1,1264 @@
+# Sharely — 技術ドキュメント
+
+> **バージョン:** 1.0.0 · **ライセンス:** MIT · **Node.js:** ≥ 18
+
+---
+
+## 目次
+
+1. [プロジェクト概要](#1-プロジェクト概要)
+2. [アーキテクチャ](#2-アーキテクチャ)
+3. [技術スタック](#3-技術スタック)
+4. [ディレクトリ構造](#4-ディレクトリ構造)
+5. [設定と環境変数](#5-設定と環境変数)
+6. [データモデル](#6-データモデル)
+7. [REST API](#7-rest-api)
+8. [WebSocket API](#8-websocket-api)
+9. [ファイル配信ルート](#9-ファイル配信ルート)
+10. [認証とセキュリティ](#10-認証とセキュリティ)
+11. [アップロードシステム](#11-アップロードシステム)
+12. [サムネイル生成](#12-サムネイル生成)
+13. [メールとSMTP](#13-メールとsmtp)
+14. [国際化](#14-国際化)
+15. [フロントエンド（React SPA）](#15-フロントエンドreact-spa)
+16. [管理ダッシュボード](#16-管理ダッシュボード)
+17. [GDPR / プライバシー](#17-gdpr--プライバシー)
+18. [バックグラウンドジョブ](#18-バックグラウンドジョブ)
+19. [デプロイ](#19-デプロイ)
+20. [開発環境](#20-開発環境)
+21. [マイグレーションとスクリプト](#21-マイグレーションとスクリプト)
+22. [エンドツーエンドテスト](#22-エンドツーエンドテスト)
+
+---
+
+## 1. プロジェクト概要
+
+Sharelyは、クリーンなWebインターフェース、ShareX連携、APIアクセスを備えた**セルフホスト型ファイル共有プラットフォーム**です。ユーザーはスクリーンショット、ファイル、メディアをアップロードし、短縮リンクで即座に共有できます。
+
+### 主要機能
+
+| 機能 | 説明 |
+|---|---|
+| Webアップロード | ドラッグ＆ドロップ、最大500ファイルを同時にアップロード可能 |
+| チャンクアップロード | 並列マルチパートアップロードで最大2GBのファイルに対応 |
+| ShareX連携 | ワンクリックで`.sxcu`設定ファイルをダウンロード |
+| APIアップロード | Bearerトークン認証、curl/wget互換 |
+| ファイルビューア | 画像ズーム、動画・音声ストリーミング（HTTP Range）、PDFインライン表示、コードのシンタックスハイライト |
+| 埋め込みモード | *embed*（OG/Twitter Card HTML）または*raw*（直接リダイレクト） |
+| サムネイル | 動画（ffmpeg）とPDF（ghostscript）の自動JPEGプレビュー生成 |
+| コレクション | パスワードと有効期限を設定可能なファイルグループ |
+| 共有リンク | パスワード、有効期限、ダウンロード制限付きのファイル別リンク |
+| リアルタイムUI | WebSocketベースのライブ更新（アップロード、削除、閲覧カウンター、管理統計） |
+| 多言語対応 | 8言語：EN, DE, FR, ES, IT, PT, JA, ZH |
+| 管理ダッシュボード | 統計、ユーザー管理、ファイル管理、監査ログ（CSVエクスポート） |
+| GDPRコンプライアンス | EU GDPRに準拠したプライバシー機能（第17、20、32条など） |
+| XBackBoneインポート | 既存のXBackBoneインストールの移行 |
+| Docker対応 | `docker compose up -d`で完全な環境を起動 |
+
+---
+
+## 2. アーキテクチャ
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Browser / Client                      │
+│            React 18 SPA  ·  Vite  ·  Tailwind CSS           │
+│   ┌──────────────────────────────────────────────────────┐   │
+│   │  HTTP REST (/api/*)            WebSocket (/ws)       │   │
+│   └──────────────────────────────────────────────────────┘   │
+└───────────────────────────┬────────────────────┬─────────────┘
+                            │ HTTP               │ WS
+┌───────────────────────────▼────────────────────▼─────────────┐
+│                    Express.js (app.js)                        │
+│                                                               │
+│  ┌──────────────┐  ┌───────────┐  ┌──────────┐  ┌────────┐  │
+│  │  /api/auth   │  │  /api/*   │  │   /f/*   │  │  /s/*  │  │
+│  │  /api/install│  │  routes   │  │  files   │  │ shares │  │
+│  └──────────────┘  └───────────┘  └──────────┘  └────────┘  │
+│                                                               │
+│  Middleware: session · rate-limit · CSRF · CSP · auth        │
+│                                                               │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌────────────┐  │
+│  │  multer  │  │  ws.js   │  │  mailer  │  │ retention  │  │
+│  │  upload  │  │ WebSocket│  │ nodemailer│  │  cleanup   │  │
+│  └──────────┘  └──────────┘  └──────────┘  └────────────┘  │
+└───────────────────────────┬───────────────────────────────────┘
+                            │
+┌───────────────────────────▼───────────────────────────────────┐
+│                      MongoDB (Mongoose)                        │
+│  User · File · Collection · ShareLink · SiteSettings          │
+│  AuditLog                                                      │
+└───────────────────────────────────────────────────────────────┘
+                            │
+              ┌─────────────▼───────────────┐
+              │     Dateisystem (uploads/)   │
+              │  {folderName}/  ·  .chunks/  │
+              │  .thumbnails/   ·  .avatars/ │
+              └─────────────────────────────┘
+```
+
+### データフロー：標準アップロード
+
+```
+Browser → POST /api/web-upload (multipart/form-data)
+       → multer: Datei in uploads/{folderName}/
+       → File.createUnique() → MongoDB
+       → generateThumbnail() (async, non-blocking)
+       → logAudit()
+       → broadcast('file:uploaded') via WebSocket
+       ← JSON: { files: [...] }
+```
+
+### データフロー：ShareXアップロード
+
+```
+ShareX → POST /upload (token im Formular-Body)
+       → multer: Datei temporär in uploads/
+       → requireApiKey: Token-Lookup → User
+       → fs.renameSync → uploads/{folderName}/
+       → File.create() → MongoDB
+       ← JSON: { url, delete_url }
+```
+
+---
+
+## 3. 技術スタック
+
+| レイヤー | 技術 | バージョン |
+|---|---|---|
+| **ランタイム** | Node.js | ≥ 18 |
+| **バックエンドフレームワーク** | Express.js | 4.x |
+| **データベース** | MongoDB + Mongoose | Mongo 7, Mongoose 8.x |
+| **セッション** | express-session + connect-mongo | — |
+| **リアルタイム** | WebSocket (`ws`) | 8.x |
+| **ファイルアップロード** | Multer | 1.x |
+| **メール** | Nodemailer | 8.x |
+| **パスワードハッシュ** | bcryptjs | 2.x (12ラウンド) |
+| **APIキーハッシュ** | SHA-256 (Node Crypto) | — |
+| **レート制限** | express-rate-limit | 8.x |
+| **XBackBoneインポート** | sql.js | 1.x |
+| **フロントエンドフレームワーク** | React 18 | 18.3.x |
+| **ルーティング（フロントエンド）** | React Router v6 | 6.x |
+| **ビルドツール** | Vite | 6.x |
+| **スタイリング** | Tailwind CSS + Radix UI | 3.x |
+| **UIコンポーネント** | shadcn/ui (Radix primitives) | — |
+| **アイコン** | FontAwesome | 6.x |
+| **i18n** | i18next + react-i18next | — |
+| **シンタックスハイライト** | highlight.js | 11.x |
+| **コンテナ** | Docker + Docker Compose | — |
+| **テスト** | Playwright (E2E) | 1.60.x |
+
+---
+
+## 4. ディレクトリ構造
+
+```
+sharely/
+├── app.js                          # Expressエントリーポイント、起動シーケンス
+├── package.json
+├── .env.example                    # 全環境変数のテンプレート
+├── Dockerfile
+├── docker-compose.yml
+│
+├── src/
+│   ├── config/
+│   │   └── db.js                   # MongoDB接続（Mongoose）
+│   ├── middleware/
+│   │   ├── auth.js                 # requireLogin / requireAdmin / requireApiKey
+│   │   └── upload.js               # Multer設定、ブロックリスト
+│   ├── models/
+│   │   ├── AuditLog.js             # 監査イベント（TTL 90日）
+│   │   ├── Collection.js           # ファイルコレクション
+│   │   ├── File.js                 # ファイルメタデータ
+│   │   ├── ShareLink.js            # ファイル別共有リンク
+│   │   ├── SiteSettings.js         # シングルトン：運営者設定
+│   │   └── User.js                 # ユーザーアカウント + APIキー
+│   ├── routes/
+│   │   ├── api.js                  # メインAPI（アップロード、ギャラリー、管理者など）
+│   │   ├── auth.js                 # ログイン / 登録 / パスワードリセット
+│   │   ├── files.js                # ファイル配信、OG埋め込み、レンジリクエスト
+│   │   ├── import.js               # XBackBone移行
+│   │   ├── install.js              # 初期インストールエンドポイント
+│   │   └── shares.js               # 共有リンクファイル配信
+│   ├── jobs/
+│   │   └── retentionCleanup.js     # 期限切れファイルの日次削除
+│   ├── migrations/
+│   │   ├── migrateApiKeyHashes.js  # 一回限り：平文 → SHA-256ハッシュ
+│   │   └── migrateUserFolders.js   # 一回限り：ユーザーフォルダへのファイル移動
+│   ├── utils/
+│   │   ├── audit.js                # logAudit()ヘルパー関数
+│   │   ├── generateThumbnail.js    # ffmpeg / ghostscript統合
+│   │   ├── mailer.js               # Nodemailerラッパー + i18nメールテンプレート
+│   │   └── sanitizeFilename.js     # ファイル名サニタイゼーション
+│   └── ws.js                       # WebSocketサーバー + アクションディスパッチャー
+│
+├── client/                         # Reactフロントエンド
+│   ├── index.html
+│   ├── package.json
+│   ├── vite.config.js
+│   ├── tailwind.config.js
+│   └── src/
+│       ├── main.jsx                # Reactエントリーポイント
+│       ├── App.jsx                 # ルーター設定
+│       ├── index.css               # グローバルスタイル
+│       ├── context/
+│       │   └── AuthContext.jsx     # グローバル認証状態
+│       ├── hooks/
+│       │   ├── use-toast.js        # トースト通知フック
+│       │   └── useWebSocket.js     # WS接続 + イベントハンドラー
+│       ├── components/
+│       │   ├── Layout.jsx          # アプリシェル（ナビバー、サイドバー）
+│       │   ├── ProtectedRoute.jsx  # 認証ガード
+│       │   ├── ShareLinkDialog.jsx # 共有リンク作成ダイアログ
+│       │   ├── AddToCollectionDialog.jsx
+│       │   ├── CookieBanner.jsx
+│       │   ├── LanguageSelector.jsx
+│       │   ├── RequireEmailDialog.jsx
+│       │   ├── UserAvatar.jsx
+│       │   └── ui/                 # shadcn/ui基底コンポーネント
+│       ├── pages/
+│       │   ├── Upload.jsx          # アップロードページ
+│       │   ├── Gallery.jsx         # ファイルギャラリー
+│       │   ├── FileView.jsx        # ファイル詳細ビュー
+│       │   ├── Collections.jsx     # コレクション一覧
+│       │   ├── CollectionView.jsx  # 個別コレクション
+│       │   ├── ShareView.jsx       # 公開共有リンクページ
+│       │   ├── Settings.jsx        # ユーザー設定
+│       │   ├── Login.jsx
+│       │   ├── Register.jsx
+│       │   ├── ForgotPassword.jsx
+│       │   ├── ResetPassword.jsx
+│       │   ├── Install.jsx         # 初期インストール
+│       │   ├── PrivacyPolicy.jsx
+│       │   ├── TermsOfService.jsx
+│       │   └── admin/
+│       │       ├── Dashboard.jsx   # 管理者ホームページ
+│       │       ├── Users.jsx       # ユーザー管理
+│       │       ├── Files.jsx       # ファイル管理
+│       │       ├── AuditLog.jsx    # 監査ログビュー
+│       │       ├── SiteSettings.jsx# 運営者設定
+│       │       └── Import.jsx      # XBackBoneインポート
+│       ├── i18n/
+│       │   ├── index.js            # i18next設定
+│       │   └── locales/
+│       │       ├── de.json
+│       │       ├── en.json
+│       │       ├── es.json
+│       │       ├── fr.json
+│       │       ├── it.json
+│       │       ├── ja.json
+│       │       ├── pt.json
+│       │       └── zh.json
+│       └── lib/
+│           └── utils.js            # Tailwindヘルパー（cn()）
+│
+├── scripts/
+│   ├── setup-db.js
+│   ├── mongo-init.js               # MongoDB初期化スクリプト
+│   ├── migrate-uploads-to-user-folders.js
+│   └── generate-missing-thumbnails.js
+│
+├── e2e/                            # Playwrightテスト
+│   ├── admin.spec.js
+│   ├── bulk-actions-fixes.spec.js
+│   ├── gallery.spec.js
+│   ├── sharelink.spec.js
+│   ├── tags.spec.js
+│   ├── upload.spec.js
+│   ├── helpers.js
+│   └── global-setup.js
+│
+├── uploads/                        # ファイルアップロード（ランタイム）
+│   ├── .thumbnails/
+│   ├── .avatars/
+│   └── .chunks/                    # 一時チャンク
+│
+└── docs/assets/                    # スクリーンショットとロゴ
+```
+
+---
+
+## 5. 設定と環境変数
+
+すべての変数は`.env`から（`dotenv`経由で）読み込まれます。`.env.example`ファイルには完全なテンプレートが含まれています。
+
+### 必須フィールド
+
+| 変数 | 説明 |
+|---|---|
+| `SESSION_SECRET` | セッション暗号化のシークレット — 長いランダム文字列、例：`openssl rand -hex 32` |
+| `MONGO_ROOT_PASSWORD` | MongoDBルートパスワード（Docker Composeのみ必要） |
+| `MONGO_APP_PASSWORD` | MongoDBアプリケーションユーザーパスワード |
+
+### 全環境変数
+
+| 変数 | デフォルト | 説明 |
+|---|---|---|
+| `PORT` | `3000` | HTTPサーバーのTCPポート |
+| `MONGODB_URI` | _（Docker Composeから構築）_ | 完全なMongoDB接続URI |
+| `MONGO_ROOT_PASSWORD` | — | MongoDBルートパスワード |
+| `MONGO_APP_USER` | `appuser` | MongoDBアプリケーションユーザー名 |
+| `MONGO_APP_PASSWORD` | — | MongoDBアプリケーションユーザーパスワード |
+| `MONGO_DB_NAME` | `sharely` | MongoDBデータベース名 |
+| `SESSION_SECRET` | — | **必須** — セッション暗号化シークレット |
+| `BASE_URL` | `http://localhost:3000` | 生成される共有リンクの公開ベースURL（末尾の`/`なし） |
+| `SITE_NAME` | `sharely` | Open Graph埋め込みのサイト名 |
+| `MAX_FILE_SIZE_MB` | `100` | 標準アップロードの最大ファイルサイズ（MB）（チャンクアップロードは最大2GBまで独立して対応） |
+| `ALLOW_REGISTRATION` | `true` | `false`で公開登録を無効化 |
+| `SMTP_HOST` | — | SMTPサーバーのホスト名；空欄でメール機能を無効化 |
+| `SMTP_PORT` | `587` | SMTPポート |
+| `SMTP_SECURE` | `false` | 暗黙的TLS（ポート465）なら`true`、STARTTLSなら`false` |
+| `SMTP_USER` | — | SMTPユーザー名 |
+| `SMTP_PASS` | — | SMTPパスワード |
+| `SMTP_FROM` | _（SMTP_USER）_ | 送信メールの差出人アドレス |
+| `UPLOAD_DIR` | `./uploads` | アップロードディレクトリの絶対パス |
+| `NODE_ENV` | — | `production`でセキュアCookieを有効化 |
+
+---
+
+## 6. データモデル
+
+### User（`src/models/User.js`）
+
+```
+{
+  username:                    String (3–32、ユニーク、英数字 + _-)
+  password:                    String (bcrypt、12ラウンド)
+  role:                        'admin' | 'user'
+  apiKey:                      String (レガシー、移行後は空)
+  apiKeyHash:                  String (SHA-256、ユニーク、sparse)
+  apiKeyPrefix:                String (平文の最初の8文字)
+  folderName:                  String (ユニーク、sparse、最大64)
+  avatarExt:                   String | null (.jpg/.png/.gif/.webp)
+  embedMode:                   'embed' | 'raw'
+  isActive:                    Boolean
+  email:                       String (小文字、ユニーク、sparse)
+  emailVerified:               Boolean
+  emailVerificationToken:      String | null (平文のSHA-256ハッシュ)
+  emailVerificationExpires:    Date | null
+  passwordResetToken:          String | null (SHA-256ハッシュ)
+  passwordResetExpires:        Date | null
+  language:                    'en'|'de'|'fr'|'es'|'it'|'pt'|'ja'|'zh'
+  predefinedTags:              [String] (最大100タグ × 50文字)
+  createdAt:                   Date
+}
+```
+
+**重要なメソッド：**
+- `user.comparePassword(candidate)` — bcrypt比較
+- `user.regenerateApiKey()` — 新しい平文を生成し、ハッシュを保存し、平文を返す（一度のみ表示）
+- `User.findByApiKey(plaintext)` — SHA-256ハッシュで検索、アクティブユーザーのみ
+
+### File（`src/models/File.js`）
+
+```
+{
+  shortId:      String (16進数8文字：タイムスタンプ6文字 + ランダム2文字、ユニーク)
+  deleteToken:  String (16進数32文字、ユニーク)
+  originalName: String (サニタイズ済み)
+  storedName:   String (相対パス："folderName/8hex.ext")
+  mimeType:     String
+  size:         Number (バイト)
+  uploader:     ObjectId → User
+  views:        Number
+  tags:         [String] (最大20 × 50文字)
+  createdAt:    Date
+}
+```
+
+**仮想プロパティ：**
+- `sizeHuman` — 人間が読めるサイズ（B / KB / MB / GB）
+- `displayType` — 分類：`image|video|audio|pdf|code|text|file`
+
+**Short IDアルゴリズム：**
+```
+shortId = hex(seconds_since_2024-01-01, 6 chars) + randomBytes(2).hex()
+```
+
+### Collection（`src/models/Collection.js`）
+
+```
+{
+  shortId:     String (16進数8文字、ユニーク)
+  name:        String (最大100)
+  description: String (最大500)
+  owner:       ObjectId → User
+  files:       [ObjectId → File]
+  password:    String | null (bcrypt)
+  expiresAt:   Date | null
+  createdAt:   Date
+}
+```
+
+> 期限切れのコレクションは、有効期限後7日でMongoDB TTLインデックスにより自動削除されます。
+
+### ShareLink（`src/models/ShareLink.js`）
+
+```
+{
+  token:         String (16進数32文字、ユニーク)
+  file:          ObjectId → File
+  createdBy:     ObjectId → User
+  label:         String (最大100)
+  password:      String | null (bcrypt)
+  expiresAt:     Date | null
+  downloadLimit: Number (-1 = 無制限)
+  downloadCount: Number
+  createdAt:     Date
+}
+```
+
+> コレクションと同様：TTLインデックスによる有効期限後7日間の猶予期間。
+
+### SiteSettings（`src/models/SiteSettings.js`）
+
+シングルトンドキュメント（`_id: 'singleton'`）：
+
+```
+{
+  operatorName:        String
+  operatorAddress:     String
+  operatorEmail:       String
+  cloudflareAnalytics: Boolean
+  fileRetentionDays:   Number (0 = 無効)
+  encryptionAtRest:    Boolean
+  sessionDurationDays: Number (デフォルト：7)
+  allowRegistration:   Boolean
+}
+```
+
+### AuditLog（`src/models/AuditLog.js`）
+
+```
+{
+  timestamp: Date (TTLインデックス：90日)
+  userId:    ObjectId → User | null
+  username:  String | null
+  action:    String
+  ip:        String | null
+  meta:      Mixed (アクション固有のメタデータ)
+}
+```
+
+---
+
+## 7. REST API
+
+### ベースURL：`/api`
+
+すべてのJSONエンドポイントは`Content-Type: application/json`を返します。エラー：`{ "error": "メッセージ" }`。
+
+---
+
+### 認証（`/api/auth`）
+
+| メソッド | パス | 認証 | 説明 |
+|---|---|---|---|
+| `GET` | `/me` | セッション | 現在ログイン中のユーザー |
+| `POST` | `/login` | — | ログイン（レート制限：10回/15分） |
+| `POST` | `/register` | — | 登録（レート制限あり、最初のユーザーが管理者になる） |
+| `POST` | `/logout` | — | ログアウト |
+| `GET` | `/smtp-enabled` | — | SMTPが設定されているか確認 |
+| `GET` | `/verify-email?token=` | — | メールアドレスを認証 |
+| `GET` | `/verify-reset-token?token=` | — | リセットトークンを検証 |
+| `POST` | `/forgot-password` | — | パスワードリセットメールを送信（レート制限：5回/時間） |
+| `POST` | `/reset-password` | — | 新しいパスワードを設定 |
+
+**ログインリクエスト：**
+```json
+POST /api/auth/login
+{ "username": "max", "password": "meinPasswort123" }
+```
+
+**ログインレスポンス：**
+```json
+{
+  "user": {
+    "id": "...", "username": "max", "role": "user",
+    "avatarUrl": null, "email": "max@example.com",
+    "emailVerified": true, "language": "de"
+  }
+}
+```
+
+---
+
+### ファイルアップロード
+
+| メソッド | パス | 認証 | 説明 |
+|---|---|---|---|
+| `POST` | `/upload` | APIキー | ShareXアップロード（`app.js`のレガシーエンドポイント） |
+| `POST` | `/api/upload` | APIキー | ShareX/APIアップロード（フィールド：`file`） |
+| `POST` | `/api/web-upload` | セッション | Webアップロード（フィールド：`files[]`、最大500） |
+| `POST` | `/api/chunk/init` | セッション | チャンクアップロードの初期化 |
+| `POST` | `/api/chunk/:uploadId` | セッション | チャンクのアップロード（フィールド：`chunk`） |
+| `POST` | `/api/chunk/:uploadId/complete` | セッション | チャンクの結合 |
+| `DELETE` | `/api/chunk/:uploadId` | セッション | アップロードのキャンセルとクリーンアップ |
+
+**APIアップロードレスポンス：**
+```json
+{
+  "url": "https://example.com/f/a1b2c3d4",
+  "raw": "https://example.com/f/a1b2c3d4/raw",
+  "delete_url": "https://example.com/api/delete/a1b2c3d4",
+  "short_id": "a1b2c3d4",
+  "filename": "screenshot.png",
+  "size": 102400
+}
+```
+
+#### チャンクアップロードフロー
+
+1. `POST /api/chunk/init` → `{ uploadId: "32hex" }`
+2. `POST /api/chunk/:uploadId`（ボディ：`chunkIndex=N`、ファイル：`chunk`）→ `{ received: N }`  
+   3〜5チャンクを並列で送信
+3. `POST /api/chunk/:uploadId/complete` → `{ files: [fileObject] }`
+
+---
+
+### ファイル管理
+
+| メソッド | パス | 認証 | 説明 |
+|---|---|---|---|
+| `GET` | `/api/gallery` | セッション | 自分のファイル（管理者：全ファイル）、ページネーション（24件/ページ）、フィルター：`q`、`type`、`tag`、`page` |
+| `GET` | `/api/file/:shortId` | — | ファイルメタデータ（閲覧カウンターを増加） |
+| `PATCH` | `/api/file/:shortId` | セッション | タグ/名前の更新 |
+| `DELETE` | `/api/file/:shortId` | セッション | ファイルの削除 |
+| `DELETE` | `/api/delete/:shortId` | APIキー | ファイルの削除（APIキー認証） |
+| `POST` | `/api/files/bulk` | セッション | 一括操作：`delete`、`tag`、`removeTag`、`addToCollection`、`moveToCollection` |
+| `GET` | `/api/tags` | セッション | ユーザーの全タグ候補 |
+
+**ギャラリークエリパラメーター：**
+- `q` — ファイル名検索（正規表現セーフ）
+- `type` — `all|image|video|audio|pdf|code`
+- `tag` — 完全一致タグフィルター
+- `page` — ページ番号（デフォルト：1）
+
+---
+
+### ユーザー設定
+
+| メソッド | パス | 認証 | 説明 |
+|---|---|---|---|
+| `GET` | `/api/my-key` | セッション | APIキープレフィックスを表示 |
+| `POST` | `/api/regen-key` | セッション | APIキーを再生成 |
+| `GET` | `/api/sharex-config` | セッション | ShareX `.sxcu`をダウンロード（キーを再生成） |
+| `PATCH` | `/api/user/username` | セッション | ユーザー名を変更（パスワード必須） |
+| `PATCH` | `/api/user/password` | セッション | パスワードを変更 |
+| `PATCH` | `/api/user/email` | セッション | メールを変更（確認メールを送信） |
+| `PATCH` | `/api/user/language` | セッション | UI言語を設定 |
+| `PATCH` | `/api/user/embed-mode` | セッション | 埋め込みモードを設定（`embed`/`raw`） |
+| `POST` | `/api/user/resend-verification` | セッション | 確認メールを再送信 |
+| `GET` | `/api/user/export` | セッション | データエクスポート（GDPR第20条）JSONとして |
+| `DELETE` | `/api/user/account` | セッション | アカウントを削除（GDPR第17条、パスワード必須） |
+| `GET` | `/api/user/predefined-tags` | セッション | 定義済みタグを取得 |
+| `PATCH` | `/api/user/predefined-tags` | セッション | 定義済みタグを更新 |
+| `POST` | `/api/user/avatar` | セッション | アバターをアップロード（最大2MB、JPEG/PNG/GIF/WebP） |
+| `DELETE` | `/api/user/avatar` | セッション | アバターを削除 |
+| `GET` | `/api/user/avatar/:userId` | — | アバターを配信 |
+
+---
+
+### 共有リンク
+
+| メソッド | パス | 認証 | 説明 |
+|---|---|---|---|
+| `GET` | `/api/file/:shortId/share-links` | セッション（オーナー/管理者） | ファイルの全共有リンク |
+| `POST` | `/api/file/:shortId/share-links` | セッション（オーナー/管理者） | 共有リンクを作成 |
+| `DELETE` | `/api/share-links/:token` | セッション（オーナー/作成者/管理者） | 共有リンクを削除 |
+| `GET` | `/api/share-links/:token` | — | 共有リンクのメタデータ（公開） |
+| `POST` | `/api/share-links/:token/verify` | — | 共有リンクのパスワードを確認 |
+
+**共有リンクの作成：**
+```json
+POST /api/file/a1b2c3d4/share-links
+{
+  "label": "同僚向け",
+  "password": "シークレット",
+  "expiresAt": "2025-12-31T23:59:59Z",
+  "downloadLimit": 10
+}
+```
+
+---
+
+### コレクション
+
+| メソッド | パス | 認証 | 説明 |
+|---|---|---|---|
+| `GET` | `/api/collections` | セッション | 自分のコレクション（管理者：全コレクション） |
+| `POST` | `/api/collections` | セッション | コレクションを作成 |
+| `GET` | `/api/collections/:id` | — | コレクションを表示（公開、設定されている場合はパスワード） |
+| `PATCH` | `/api/collections/:id` | セッション（オーナー/管理者） | コレクションを更新 |
+| `DELETE` | `/api/collections/:id` | セッション（オーナー/管理者） | コレクションを削除 |
+| `POST` | `/api/collections/:id/files` | セッション（オーナー/管理者） | コレクションにファイルを追加 |
+| `DELETE` | `/api/collections/:id/files/:fileShortId` | セッション（オーナー/管理者） | コレクションからファイルを削除 |
+| `POST` | `/api/collections/:id/verify` | — | コレクションのパスワードを確認 |
+
+---
+
+### 管理者エンドポイント
+
+| メソッド | パス | 認証 | 説明 |
+|---|---|---|---|
+| `GET` | `/api/admin/stats` | 管理者 | ダッシュボード統計 |
+| `GET` | `/api/admin/users` | 管理者 | 全ユーザー（ファイル数を含む） |
+| `POST` | `/api/admin/users` | 管理者 | ユーザーを作成 |
+| `PATCH` | `/api/admin/users/:id/toggle` | 管理者 | ユーザーを有効化/無効化 |
+| `PATCH` | `/api/admin/users/:id/role` | 管理者 | ユーザーロールを変更 |
+| `DELETE` | `/api/admin/users/:id` | 管理者 | ユーザーを削除 |
+| `POST` | `/api/admin/users/:id/regen-key` | 管理者 | APIキーを再生成 |
+| `PATCH` | `/api/admin/users/:id/password` | 管理者 | パスワードを設定 |
+| `PATCH` | `/api/admin/users/:id/folder` | 管理者 | フォルダ名を変更（ファイルを移動） |
+| `GET` | `/api/admin/files` | 管理者 | 全ファイル、ページネーション（30件/ページ） |
+| `GET` | `/api/admin/site-settings` | 管理者 | 運営者設定を読み取り |
+| `PATCH` | `/api/admin/site-settings` | 管理者 | 運営者設定を更新 |
+| `GET` | `/api/admin/audit-log` | 管理者 | ページネーション付き監査ログ（50件/ページ） |
+| `GET` | `/api/admin/audit-log/export` | 管理者 | 監査ログをCSVでダウンロード |
+| `GET` | `/api/site-settings` | — | 運営者の公開情報（プライバシーページ用） |
+
+---
+
+### サイト設定（公開）
+
+```json
+GET /api/site-settings
+{
+  "operatorName": "Musterfirma GmbH",
+  "operatorAddress": "Musterstr. 1, 12345 Musterstadt",
+  "operatorEmail": "datenschutz@example.com",
+  "cloudflareAnalytics": false,
+  "fileRetentionDays": 365,
+  "encryptionAtRest": false,
+  "sessionDurationDays": 7
+}
+```
+
+---
+
+## 8. WebSocket API
+
+**接続：**`wss://example.com/ws`（ログイン済みユーザーのみ、セッションCookieが必要）
+
+### プロトコル
+
+**クライアント → サーバー（リクエスト）：**
+```json
+{ "id": "req-abc123", "action": "file:list", "payload": { "type": "image", "page": 1 } }
+```
+
+**サーバー → クライアント（レスポンス）：**
+```json
+{ "id": "req-abc123", "data": { ... } }
+```
+
+**サーバー → クライアント（エラー）：**
+```json
+{ "id": "req-abc123", "error": "Forbidden", "status": 403 }
+```
+
+**サーバー → クライアント（ブロードキャスト）：**
+```json
+{ "event": "file:uploaded", "data": { "shortId": "a1b2c3d4", "uploaderId": "..." } }
+```
+
+### 利用可能なアクション
+
+| アクション | 認証 | 説明 |
+|---|---|---|
+| `site-settings:get` | — | サイトの公開設定 |
+| `auth:me` | ユーザー | ログイン中のユーザーデータ |
+| `file:get` | ユーザー | ファイルの詳細（閲覧数を増加） |
+| `file:list` | ユーザー | フィルター/ページネーション付きファイルリスト |
+| `file:delete` | ユーザー | ファイルを削除 |
+| `user:get-key` | ユーザー | APIキープレフィックス |
+| `user:regen-key` | ユーザー | APIキーを再生成 |
+| `user:change-password` | ユーザー | パスワードを変更 |
+| `user:change-username` | ユーザー | ユーザー名を変更 |
+| `user:change-email` | ユーザー | メールを変更 |
+| `user:change-language` | ユーザー | 言語を設定 |
+| `user:change-embed-mode` | ユーザー | 埋め込みモードを設定 |
+| `user:resend-verification` | ユーザー | 確認メールを再送信 |
+| `user:export` | ユーザー | データエクスポート |
+| `user:delete-account` | ユーザー | アカウントを削除 |
+| `admin:stats` | 管理者 | ダッシュボード統計 |
+| `admin:settings:get` | 管理者 | サイト設定を読み取り |
+| `admin:settings:update` | 管理者 | サイト設定を更新 |
+| `admin:users:list` | 管理者 | 全ユーザー |
+| `admin:users:create` | 管理者 | ユーザーを作成 |
+| `admin:users:toggle` | 管理者 | ユーザーを有効化/無効化 |
+| `admin:users:role` | 管理者 | ユーザーロールを変更 |
+| `admin:users:delete` | 管理者 | ユーザーを削除 |
+| `admin:users:regen-key` | 管理者 | APIキーを再生成 |
+| `admin:users:password` | 管理者 | パスワードを設定 |
+| `admin:users:folder` | 管理者 | フォルダ名を変更 |
+| `admin:files:list` | 管理者 | 全ファイル |
+| `admin:audit-log:list` | 管理者 | ページネーション付き監査ログ |
+
+### ブロードキャストイベント
+
+| イベント | 受信者 | ペイロード |
+|---|---|---|
+| `file:uploaded` | アップロードしたユーザー | `{ shortId, uploaderId }` |
+| `file:deleted` | ファイルオーナー | `{ shortId, uploaderId }` |
+| `file:view` | 全員 | `{ shortId, views }` |
+| `user:created` | 管理者 | `{ id, username, role, ... }` |
+| `user:deleted` | 管理者 | `{ id }` |
+| `user:updated` | 管理者 | `{ id, ...変更されたフィールド }` |
+| `audit:log` | 管理者 | 完全なAuditLogオブジェクト |
+| `settings:updated` | 管理者 | 更新されたSiteSettingsオブジェクト |
+| `stats:invalidate` | 管理者 | `{}`（統計の更新をトリガー） |
+
+---
+
+## 9. ファイル配信ルート
+
+### `/f/:shortId` — ファイルビューア
+
+- **ブラウザリクエスト：** React SPA（`index.html`）にパスを通す — SPAがビューアをレンダリング。
+- **ソーシャルメディアボット**（Discord、Telegram、Twitterなど）：Open Graph / Twitter Cardメタタグを含む最小限のHTMLページを返す。
+  - `embedMode = 'embed'`：リダイレクト付きOG HTML
+  - `embedMode = 'raw'` + 画像/動画/音声：HTTP 302 → `/f/:shortId/raw`
+
+### `/f/:shortId/raw` — 直接アクセス
+
+レンジリクエスト対応（206 Partial Content）でファイルをHTTPレスポンスとして配信。画像/動画/音声：`Content-Disposition: inline`、その他：`attachment`。
+
+### `/f/:shortId/download` — 強制ダウンロード
+
+`/raw`と同様ですが、常に`Content-Disposition: attachment`。
+
+### `/f/:shortId/thumb` — サムネイル
+
+JPEGサムネイルを返す（動画とPDF用）。`Cache-Control: public, max-age=86400`。
+
+### `/f/:shortId/delete/:token` — ShareX削除
+
+一意の削除トークンを使用して、セッションなしでファイルを削除。
+
+### `/s/:token` — 共有リンクファイル配信（`src/routes/shares.js`）
+
+パスワード（セッションフラグ経由）、有効期限、ダウンロード制限を確認してからファイルを配信。
+
+---
+
+## 10. 認証とセキュリティ
+
+### セッション認証
+
+- MongoDBストア付きExpressセッション（`connect-mongo`）
+- セッションCookie：`httpOnly: true`、`sameSite: 'strict'`、本番環境では`secure: true`
+- セッション期間：`SiteSettings.sessionDurationDays`で設定可能（デフォルト：7日）、60秒間ライブキャッシュ
+
+### APIキー認証
+
+- APIキーはSHA-256ハッシュとして保存され、平文では保存されない
+- 最初の8文字が`apiKeyPrefix`として保存される（表示目的）
+- 検索：`User.findByApiKey(plaintext)`でハッシュを計算し`apiKeyHash`を検索
+- ShareX設定をダウンロードするとキーが再生成される — 平文はその瞬間のみ表示される
+
+### ミドルウェアチェーン（`src/middleware/auth.js`）
+
+```
+requireLogin    → req.session.userを確認 → 未ログインなら401
+requireAdmin    → requireLoginと同様、さらにrole === 'admin' → 403
+requireApiKey   → Authorizationヘッダーまたはreqbody.tokenを確認
+```
+
+### CSRF対策
+
+`app.js`の`requireSameOrigin()`は、すべてのAPIルートで`Origin`ヘッダーを`Host`ヘッダーと比較。`sameSite: 'strict'` Cookieを補完。
+
+### コンテンツセキュリティポリシー
+
+```
+default-src 'self';
+script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com;
+style-src 'self' 'unsafe-inline';
+img-src 'self' data: blob:;
+media-src 'self' blob:;
+connect-src 'self' https://cloudflareinsights.com;
+frame-ancestors 'self';
+```
+
+### セキュリティヘッダー
+
+- `X-Frame-Options: SAMEORIGIN`
+- `X-Content-Type-Options: nosniff`
+
+### レート制限
+
+| エンドポイント | 制限 | ウィンドウ |
+|---|---|---|
+| アップロード（`/upload`、`/api/upload`、`/api/web-upload`） | 60リクエスト | 15分 |
+| 認証（`/api/auth/login`、`/register`など） | 10リクエスト | 15分 |
+| パスワードリセット | 5リクエスト | 1時間 |
+
+### ファイルブロックリスト
+
+以下のMIMEタイプと拡張子はアップロード時に拒否されます：
+
+**ブロックされるMIMEタイプ：** `application/x-executable`、`application/x-sh`、`application/x-csh`、`application/x-bat`
+
+**ブロックされる拡張子：** `.bat`、`.cmd`、`.com`、`.ps1`、`.psm1`、`.psd1`、`.sh`、`.bash`、`.csh`、`.zsh`、`.fish`、`.vbs`、`.vbe`、`.jse`、`.scr`、`.pif`、`.application`、`.gadget`、`.hta`、`.php`、`.php3–5`、`.phtml`、`.asp`、`.aspx`、`.jsp`、`.jspx`、`.cfm`
+
+### パストラバーサル対策
+
+`resolveUploadPath()`経由のすべてのファイルアクセスは、解決されたパスが`UPLOAD_DIR`内にあることを確認します。
+
+---
+
+## 11. アップロードシステム
+
+### 標準アップロード（Multer）
+
+- **ストレージ：** `multer.diskStorage` → `uploads/{folderName}/{8hex}{.ext}`
+- **ファイル名：** `crypto.randomBytes(4).hex() + 元の拡張子`
+- **制限：** `MAX_FILE_SIZE_MB`（デフォルト：100MB）
+- **保存場所：** ユーザー固有のフォルダ（`user.folderName`）
+
+### チャンクアップロード（>250MB）
+
+フロントエンドクライアントは大きなファイルのために自動的にチャンクモードに切り替えます。
+
+**サーバー側のディレクトリ構造：**
+```
+uploads/.chunks/{uploadId}/
+  meta.json          { filename, mimeType, totalSize, totalChunks, userId, createdAt }
+  chunk-0
+  chunk-1
+  ...
+  chunk-N
+```
+
+**チャンクサイズ：** 10〜20MB（後方互換性のため最大51MBを受け入れ）  
+**並列数：** 3〜5チャンクの同時アップロード  
+**結合：** ストリームベース（RAMへの完全読み込みなし）
+
+### アバターアップロード
+
+- **ストレージ：** `multer.memoryStorage()`（ディスクバッファなし）
+- **保存場所：** `uploads/.avatars/{userId}{.ext}`
+- **制限：** 2MB
+- **フォーマット：** JPEG、PNG、GIF、WebP
+
+---
+
+## 12. サムネイル生成
+
+サムネイルはアップロード後に非同期で生成されます（`.catch(() => {})` — エラーは無視されます）。
+
+### 動画サムネイル（ffmpeg）
+
+```bash
+ffmpeg -y -i <file> -ss 00:00:01 -vframes 1 \
+  -vf "scale=320:320:force_original_aspect_ratio=increase,crop=320:320" \
+  -q:v 3 uploads/.thumbnails/<shortId>.jpg
+```
+
+### PDFサムネイル（Ghostscript）
+
+```bash
+gs -dNOPAUSE -dBATCH -dSAFER \
+  -sDEVICE=jpeg -dFirstPage=1 -dLastPage=1 \
+  -r72 -dJPEGQ=85 \
+  -sOutputFile=uploads/.thumbnails/<shortId>.jpg \
+  <file>
+```
+
+**タイムアウト：** サムネイル生成ごとに30秒  
+**フォールバック：** ffmpeg/ghostscriptが利用できない場合、生成はサイレントにスキップされます。
+
+### バックフィルスクリプト
+
+```bash
+npm run migrate:thumbnails
+# またはコンテナ内：
+docker exec -it <container> npm run migrate:thumbnails
+```
+
+---
+
+## 13. メールとSMTP
+
+### 設定
+
+`SMTP_HOST`が設定されている場合にSMTPが有効になります。`mailer.isConfigured()`でこの値を確認します。
+
+### メールテンプレート
+
+すべてのメールはユーザーの言語（8言語）で送信されます。テンプレートは`src/utils/mailer.js`に組み込まれています。
+
+**送信されるメールの種類：**
+
+| 種類 | トリガー | トークン有効期限 |
+|---|---|---|
+| メール認証 | 登録、メール変更 | 24時間 |
+| パスワードリセット | `POST /api/auth/forgot-password` | 1時間 |
+
+### トークンセキュリティ
+
+- トークン：`crypto.randomBytes(32).hex()`（16進数64文字）
+- 保存形式：トークンのSHA-256ハッシュ
+- メールにはURLパラメーターとして平文トークンが含まれる
+- 検証：受信したトークンのハッシュを保存されたハッシュと比較
+
+---
+
+## 14. 国際化
+
+**ライブラリ：** i18next + react-i18next + i18next-browser-languagedetector
+
+**対応言語：**
+
+| コード | 言語 |
+|---|---|
+| `en` | English |
+| `de` | Deutsch |
+| `fr` | Français |
+| `es` | Español |
+| `it` | Italiano |
+| `pt` | Português |
+| `ja` | 日本語 |
+| `zh` | 中文 |
+
+**言語選択：**
+1. ブラウザ言語検出（自動）
+2. データベースのユーザー設定（`user.language`）
+3. `PATCH /api/user/language`で永続化
+
+翻訳ファイル：`client/src/i18n/locales/{code}.json`
+
+---
+
+## 15. フロントエンド（React SPA）
+
+### ルーター設定（`client/src/App.jsx`）
+
+| ルート | コンポーネント | 認証 |
+|---|---|---|
+| `/` | リダイレクト → `/gallery` | 不要 |
+| `/auth/login` | Login.jsx | 不要 |
+| `/auth/register` | Register.jsx | 不要 |
+| `/auth/forgot-password` | ForgotPassword.jsx | 不要 |
+| `/auth/reset-password` | ResetPassword.jsx | 不要 |
+| `/install` | Install.jsx | 不要 |
+| `/upload` | Upload.jsx | **必要** |
+| `/gallery` | Gallery.jsx | **必要** |
+| `/f/:shortId` | FileView.jsx | **必要** |
+| `/collections` | Collections.jsx | **必要** |
+| `/c/:id` | CollectionView.jsx | 不要（公開） |
+| `/s/:token` | ShareView.jsx | 不要（公開） |
+| `/settings` | Settings.jsx | **必要** |
+| `/admin` | Dashboard.jsx | **管理者** |
+| `/admin/users` | Users.jsx | **管理者** |
+| `/admin/files` | Files.jsx | **管理者** |
+| `/admin/audit-log` | AuditLog.jsx | **管理者** |
+| `/admin/site-settings` | SiteSettings.jsx | **管理者** |
+| `/admin/import` | Import.jsx | **管理者** |
+| `/privacy` | PrivacyPolicy.jsx | 不要 |
+| `/terms` | TermsOfService.jsx | 不要 |
+
+### 認証コンテキスト（`client/src/context/AuthContext.jsx`）
+
+ログイン中のユーザーのグローバル状態。アプリ起動時に`GET /api/auth/me`で初期化。
+
+### WebSocketフック（`client/src/hooks/useWebSocket.js`）
+
+永続的なWS接続を管理。`sendMessage()`とイベントハンドラー登録を提供。接続切断時の再接続ロジック付き。
+
+### UIコンポーネント
+
+**shadcn/ui**（Radix UI Primitives + Tailwind CSS）ベース：
+
+- `Dialog`、`AlertDialog`、`DropdownMenu`、`ContextMenu`、`Popover`
+- `Select`、`Checkbox`、`Input`、`Textarea`、`Label`
+- `Card`、`Badge`、`Button`、`Separator`、`Tabs`、`Table`
+- 通知用の`Toast` / `Toaster`
+- 有効期限選択用の`Calendar` / `DateTimePicker`
+- ページネーションリスト用の`Pagination`
+- `ScrollArea`、`Tooltip`
+
+---
+
+## 16. 管理ダッシュボード
+
+管理ダッシュボード（`/admin/*`）は`role: 'admin'`のユーザーのみアクセス可能です。
+
+### ダッシュボード（`/admin`）
+
+- ユーザー、ファイル、ストレージ使用量の合計
+- 最近アップロードされた10件のファイル
+- WebSocket経由のライブ更新（`stats:invalidate`）
+
+### ユーザー管理（`/admin/users`）
+
+- ファイル数とストレージ使用量付きの全ユーザー
+- ユーザーの作成、有効化/無効化、ロール変更
+- パスワードリセット、APIキー再生成
+- フォルダ名の変更（物理ファイルはサーバー上で移動）
+- ユーザーの削除（全ファイルが削除される）
+
+### ファイル管理（`/admin/files`）
+
+- 全ユーザーの全ファイル、ページネーション付き
+- ファイル名で検索
+- ファイルを削除
+
+### 監査ログ（`/admin/audit-log`）
+
+- 全アクションのページネーション付きログ（50件/ページ）
+- ユーザー名とアクションでフィルター
+- 規制目的のCSVエクスポート
+
+### サイト設定（`/admin/site-settings`）
+
+- 運営者情報（名前、住所、メール）
+- Cloudflare Analyticsの有効化
+- ファイル保持期間
+- セッション期間
+- 登録の有効化/無効化
+
+### XBackBoneインポート（`/admin/import`）
+
+- XBackBone SQLiteデータベースからのプレビューとインポート
+- ユーザー名でユーザーをマッチング
+- 冪等性あり（既にインポートされたファイルはスキップ）
+
+---
+
+## 17. GDPR / プライバシー
+
+| 機能 | GDPR条項 |
+|---|---|
+| プライバシーポリシー（設定可能） | 第13/14条 – 透明性 |
+| 利用規約ページ（設定可能） | 第13/14条 – 透明性 |
+| データエクスポート（URLを含むJSON） | 第20条 – データポータビリティ |
+| アカウント自己削除（ファイル+データ） | 第17条 – 削除権 |
+| 監査ログ（MongoDB経由90日TTL） | 第5条(2) – 説明責任 |
+| 監査ログCSVエクスポート | 第5条(2) – 説明責任 |
+| 設定可能なファイル保持 | 第5条(1)(e) – 保存制限 |
+| SHA-256ハッシュとしてのAPIキー | 第32条 – セキュリティ |
+| bcrypt（12ラウンド）としてのパスワード | 第32条 – セキュリティ |
+| Cloudflare Analytics用Cookieの同意 | 第13条 – 透明性 |
+| アカウント削除時の匿名化 | 第17条 – 削除権 |
+
+### GDPR削除フロー
+
+アカウント削除時（`user:delete-account` / `DELETE /api/user/account`）：
+1. ユーザーの全ファイルがディスクから削除される
+2. サムネイルが削除される
+3. アバターが削除される
+4. 監査ログエントリが匿名化される（`username: '[deleted]'`、`ip: null`、`userId: null`）
+5. ユーザードキュメントが削除される
+6. セッションが破棄される
+
+---
+
+## 18. バックグラウンドジョブ
+
+### 保持クリーンアップ（`src/jobs/retentionCleanup.js`）
+
+- **実行タイミング：** 起動時と以降は毎日（`setInterval(runRetentionCleanup, 24h)`）
+- **処理内容：** `SiteSettings.fileRetentionDays > 0`の場合、この値より古いファイルを削除
+- 削除対象：ディスク上のファイル、サムネイル、MongoDBドキュメント
+- 管理者に`stats:invalidate`をブロードキャスト
+
+### MongoDB TTLインデックス（自動）
+
+| コレクション | TTL | トリガー |
+|---|---|---|
+| `AuditLog` | 90日 | `timestamp` |
+| `Collection` | `expiresAt`の7日後 | `expiresAt` |
+| `ShareLink` | `expiresAt`の7日後 | `expiresAt` |
+
+---
+
+## 19. デプロイ
+
+### Docker（推奨）
+
+```bash
+git clone https://github.com/Christianoooooo/sharely.git
+cd sharely
+cp .env.example .env
+# .envを編集（SESSION_SECRET、MONGOパスワード、BASE_URL）
+docker compose up -d
+```
+
+**サービス：**
+- `app` — Node.jsアプリ（ポート3000）
+- `mongo` — MongoDB 7（ポート127.0.0.1:27017、外部からアクセス不可）
+
+**ボリューム：**
+- `uploads` — 永続的なファイルストレージ
+- `mongo_data` — MongoDBデータ
+
+**ヘルスチェック：** アプリは`/`でHTTP 200を確認、MongoDBは`db.adminCommand('ping')`を確認。
+
+### Nginxリバースプロキシ
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name files.example.com;
+
+    client_max_body_size 2100M;  # 最大チャンクサイズ+バッファ以上に設定
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocketサポート
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+```
+
+> `.env`の`BASE_URL`は公開ドメインと一致する必要があります。
+
+### 初回起動
+
+最初に登録したユーザーは自動的に`admin`ロールを付与されます（`User.countDocuments() === 0`）。
+
+---
+
+## 20. 開発環境
+
+### 前提条件
+
+- Node.js ≥ 18
+- MongoDB（ローカルまたはDocker経由）
+- オプション：ffmpeg、ghostscript（サムネイル用）
+
+### セットアップ
+
+```bash
+# バックエンド
+npm install
+cp .env.example .env
+# .envを編集
+
+# フロントエンド
+cd client
+npm install
+```
+
+### 起動
+
+```bash
+# バックエンド（ポート3000、nodemonあり）
+npm run dev
+
+# フロントエンド（ポート5173、別ターミナル）
+cd client
+npm run dev
+```
+
+Vite開発サーバーはAPIリクエストを自動的に`localhost:3000`にプロキシします。
+
+### ビルド
+
+```bash
+npm run build   # client/dist/をビルド、バックエンドは変更なし
+npm start       # 本番Expressサーバーを起動
+```
+
+---
+
+## 21. マイグレーションとスクリプト
+
+### 自動マイグレーション（毎起動時）
+
+これらのマイグレーションは`app.js`の起動時に実行され、冪等性があります：
+
+| マイグレーション | ファイル | 機能 |
+|---|---|---|
+| ユーザーフォルダマイグレーション | `src/migrations/migrateUserFolders.js` | `uploads/`から`uploads/{folderName}/`にファイルを移動 |
+| APIキーハッシュマイグレーション | `src/migrations/migrateApiKeyHashes.js` | 平文APIキーをSHA-256ハッシュに変換 |
+
+### 手動スクリプト
+
+```bash
+# 既存ファイルのサムネイルを生成
+npm run migrate:thumbnails
+# または：
+node scripts/generate-missing-thumbnails.js
+
+# アップロードをユーザーフォルダに移動（手動）
+npm run migrate:user-folders
+# または：
+node scripts/migrate-uploads-to-user-folders.js
+```
+
+### データベース初期化（Docker）
+
+`scripts/mongo-init.js`はMongoDBコンテナの初回起動時に実行され、適切な権限でアプリユーザーを作成します。
+
+---
+
+## 22. エンドツーエンドテスト
+
+**フレームワーク：** Playwright（`@playwright/test`）
+
+### テストファイル
+
+| ファイル | テストスイート |
+|---|---|
+| `e2e/upload.spec.js` | アップロードフロー |
+| `e2e/gallery.spec.js` | ギャラリーとファイル管理 |
+| `e2e/admin.spec.js` | 管理ダッシュボード |
+| `e2e/sharelink.spec.js` | 共有リンクの作成と利用 |
+| `e2e/tags.spec.js` | タグ管理 |
+| `e2e/bulk-actions-fixes.spec.js` | 一括操作 |
+
+### 実行
+
+```bash
+# 全テスト
+npm run test:e2e
+
+# UIあり
+npm run test:e2e:ui
+```
+
+**Playwright設定：** `playwright.config.js`  
+**グローバルセットアップ：** `e2e/global-setup.js`（テストユーザー、管理者などを作成）  
+**ヘルパー：** `e2e/helpers.js`（共有ヘルパー関数）
+
+---
+
+## 付録：監査ログアクション
+
+| アクション | トリガー |
+|---|---|
+| `login` | ログイン成功 |
+| `logout` | ログアウト |
+| `register` | 登録 |
+| `upload` | ファイルアップロード |
+| `delete_file` | ファイル削除 |
+| `delete_account` | アカウント削除 |
+| `change_password` | パスワード変更 |
+| `change_username` | ユーザー名変更 |
+| `change_email` | メール変更 |
+| `verify_email` | メール認証 |
+| `forgot_password` | パスワードリセットリクエスト |
+| `reset_password` | パスワードリセット |
+| `regen_api_key` | APIキー再生成 |
+| `sharex_config` | ShareX設定ダウンロード |
+| `export_data` | データエクスポート |
+| `admin_create_user` | 管理者：ユーザー作成 |
+| `admin_delete_user` | 管理者：ユーザー削除 |
+| `admin_toggle_user` | 管理者：ユーザー有効化/無効化 |
+| `admin_change_role` | 管理者：ユーザーロール変更 |
+| `admin_change_password` | 管理者：パスワード設定 |
+| `admin_regen_key` | 管理者：APIキー再生成 |
+
+---
+
+*sharely v1.0.0のソースコードから生成されたドキュメント*

--- a/docs/pt.md
+++ b/docs/pt.md
@@ -1,0 +1,1264 @@
+# Sharely — Documentação Técnica
+
+> **Versão:** 1.0.0 · **Licença:** MIT · **Node.js:** ≥ 18
+
+---
+
+## Índice
+
+1. [Visão geral do projeto](#1-visão-geral-do-projeto)
+2. [Arquitetura](#2-arquitetura)
+3. [Stack tecnológico](#3-stack-tecnológico)
+4. [Estrutura de diretórios](#4-estrutura-de-diretórios)
+5. [Configuração e variáveis de ambiente](#5-configuração-e-variáveis-de-ambiente)
+6. [Modelos de dados](#6-modelos-de-dados)
+7. [API REST](#7-api-rest)
+8. [API WebSocket](#8-api-websocket)
+9. [Rotas de serviço de arquivos](#9-rotas-de-serviço-de-arquivos)
+10. [Autenticação e segurança](#10-autenticação-e-segurança)
+11. [Sistema de upload](#11-sistema-de-upload)
+12. [Geração de miniaturas](#12-geração-de-miniaturas)
+13. [E-mail e SMTP](#13-e-mail-e-smtp)
+14. [Internacionalização](#14-internacionalização)
+15. [Frontend (React SPA)](#15-frontend-react-spa)
+16. [Painel de administração](#16-painel-de-administração)
+17. [LGPD / Privacidade](#17-lgpd--privacidade)
+18. [Jobs em segundo plano](#18-jobs-em-segundo-plano)
+19. [Implantação](#19-implantação)
+20. [Ambiente de desenvolvimento](#20-ambiente-de-desenvolvimento)
+21. [Migrações e scripts](#21-migrações-e-scripts)
+22. [Testes end-to-end](#22-testes-end-to-end)
+
+---
+
+## 1. Visão geral do projeto
+
+Sharely é uma **plataforma de compartilhamento de arquivos auto-hospedada** com uma interface web limpa, integração com ShareX e acesso via API. Os usuários fazem upload de capturas de tela, arquivos e mídias e os compartilham instantaneamente por meio de links curtos.
+
+### Funcionalidades principais
+
+| Funcionalidade | Descrição |
+|---|---|
+| Upload web | Arrastar e soltar, até 500 arquivos simultaneamente |
+| Upload em partes | Arquivos de até 2 GB via upload multi-part paralelo |
+| Integração ShareX | Arquivo de configuração `.sxcu` disponível para download com um clique |
+| Upload via API | Autenticação por token Bearer, compatível com curl/wget |
+| Visualizador de arquivos | Zoom em imagens, streaming de vídeo/áudio (HTTP Range), PDFs inline, código com destaque de sintaxe |
+| Modos de incorporação | *embed* (HTML OG/Twitter Card) ou *raw* (redirecionamento direto) |
+| Miniaturas | Pré-visualizações JPEG automáticas para vídeos (ffmpeg) e PDFs (ghostscript) |
+| Coleções | Agrupamentos de arquivos com senha e data de expiração opcionais |
+| Links de compartilhamento | Links por arquivo com senha, expiração e limite de downloads |
+| Interface em tempo real | Atualizações ao vivo via WebSocket (upload, exclusão, contador de visualizações, estatísticas admin) |
+| Multilíngue | 8 idiomas: EN, DE, FR, ES, IT, PT, JA, ZH |
+| Painel admin | Estatísticas, gerenciamento de usuários, gerenciamento de arquivos, log de auditoria (exportação CSV) |
+| Conformidade LGPD/GDPR | Funcionalidades de privacidade em conformidade com o GDPR da UE (Art. 17, 20, 32, etc.) |
+| Importação XBackBone | Migração de instalações XBackBone existentes |
+| Pronto para Docker | `docker compose up -d` inicia o ambiente completo |
+
+---
+
+## 2. Arquitetura
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Browser / Client                      │
+│            React 18 SPA  ·  Vite  ·  Tailwind CSS           │
+│   ┌──────────────────────────────────────────────────────┐   │
+│   │  HTTP REST (/api/*)            WebSocket (/ws)       │   │
+│   └──────────────────────────────────────────────────────┘   │
+└───────────────────────────┬────────────────────┬─────────────┘
+                            │ HTTP               │ WS
+┌───────────────────────────▼────────────────────▼─────────────┐
+│                    Express.js (app.js)                        │
+│                                                               │
+│  ┌──────────────┐  ┌───────────┐  ┌──────────┐  ┌────────┐  │
+│  │  /api/auth   │  │  /api/*   │  │   /f/*   │  │  /s/*  │  │
+│  │  /api/install│  │  routes   │  │  files   │  │ shares │  │
+│  └──────────────┘  └───────────┘  └──────────┘  └────────┘  │
+│                                                               │
+│  Middleware: session · rate-limit · CSRF · CSP · auth        │
+│                                                               │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌────────────┐  │
+│  │  multer  │  │  ws.js   │  │  mailer  │  │ retention  │  │
+│  │  upload  │  │ WebSocket│  │ nodemailer│  │  cleanup   │  │
+│  └──────────┘  └──────────┘  └──────────┘  └────────────┘  │
+└───────────────────────────┬───────────────────────────────────┘
+                            │
+┌───────────────────────────▼───────────────────────────────────┐
+│                      MongoDB (Mongoose)                        │
+│  User · File · Collection · ShareLink · SiteSettings          │
+│  AuditLog                                                      │
+└───────────────────────────────────────────────────────────────┘
+                            │
+              ┌─────────────▼───────────────┐
+              │     Dateisystem (uploads/)   │
+              │  {folderName}/  ·  .chunks/  │
+              │  .thumbnails/   ·  .avatars/ │
+              └─────────────────────────────┘
+```
+
+### Fluxo de dados: Upload padrão
+
+```
+Browser → POST /api/web-upload (multipart/form-data)
+       → multer: Datei in uploads/{folderName}/
+       → File.createUnique() → MongoDB
+       → generateThumbnail() (async, non-blocking)
+       → logAudit()
+       → broadcast('file:uploaded') via WebSocket
+       ← JSON: { files: [...] }
+```
+
+### Fluxo de dados: Upload ShareX
+
+```
+ShareX → POST /upload (token im Formular-Body)
+       → multer: Datei temporär in uploads/
+       → requireApiKey: Token-Lookup → User
+       → fs.renameSync → uploads/{folderName}/
+       → File.create() → MongoDB
+       ← JSON: { url, delete_url }
+```
+
+---
+
+## 3. Stack tecnológico
+
+| Camada | Tecnologia | Versão |
+|---|---|---|
+| **Runtime** | Node.js | ≥ 18 |
+| **Framework backend** | Express.js | 4.x |
+| **Banco de dados** | MongoDB + Mongoose | Mongo 7, Mongoose 8.x |
+| **Sessões** | express-session + connect-mongo | — |
+| **Tempo real** | WebSocket (`ws`) | 8.x |
+| **Upload de arquivos** | Multer | 1.x |
+| **E-mail** | Nodemailer | 8.x |
+| **Hash de senhas** | bcryptjs | 2.x (12 rounds) |
+| **Hash de chaves API** | SHA-256 (Node Crypto) | — |
+| **Limitação de taxa** | express-rate-limit | 8.x |
+| **Importação XBackBone** | sql.js | 1.x |
+| **Framework frontend** | React 18 | 18.3.x |
+| **Roteamento (frontend)** | React Router v6 | 6.x |
+| **Ferramenta de build** | Vite | 6.x |
+| **Estilização** | Tailwind CSS + Radix UI | 3.x |
+| **Componentes UI** | shadcn/ui (Radix primitives) | — |
+| **Ícones** | FontAwesome | 6.x |
+| **i18n** | i18next + react-i18next | — |
+| **Destaque de sintaxe** | highlight.js | 11.x |
+| **Contêineres** | Docker + Docker Compose | — |
+| **Testes** | Playwright (E2E) | 1.60.x |
+
+---
+
+## 4. Estrutura de diretórios
+
+```
+sharely/
+├── app.js                          # Ponto de entrada Express, sequência de inicialização
+├── package.json
+├── .env.example                    # Modelo para todas as variáveis de ambiente
+├── Dockerfile
+├── docker-compose.yml
+│
+├── src/
+│   ├── config/
+│   │   └── db.js                   # Conexão MongoDB (Mongoose)
+│   ├── middleware/
+│   │   ├── auth.js                 # requireLogin / requireAdmin / requireApiKey
+│   │   └── upload.js               # Configuração Multer, lista de bloqueio
+│   ├── models/
+│   │   ├── AuditLog.js             # Eventos de auditoria (TTL 90 dias)
+│   │   ├── Collection.js           # Coleções de arquivos
+│   │   ├── File.js                 # Metadados de arquivos
+│   │   ├── ShareLink.js            # Links de compartilhamento por arquivo
+│   │   ├── SiteSettings.js         # Singleton: configurações do operador
+│   │   └── User.js                 # Contas de usuário + chaves API
+│   ├── routes/
+│   │   ├── api.js                  # API principal (upload, galeria, admin, ...)
+│   │   ├── auth.js                 # Login / Registro / Redefinição de senha
+│   │   ├── files.js                # Serviço de arquivos, embeds OG, requisições de intervalo
+│   │   ├── import.js               # Migração XBackBone
+│   │   ├── install.js              # Endpoint de instalação inicial
+│   │   └── shares.js               # Serviço de arquivos via link de compartilhamento
+│   ├── jobs/
+│   │   └── retentionCleanup.js     # Exclusão diária de arquivos expirados
+│   ├── migrations/
+│   │   ├── migrateApiKeyHashes.js  # Única vez: textos simples → hashes SHA-256
+│   │   └── migrateUserFolders.js   # Única vez: mover arquivos para pastas de usuário
+│   ├── utils/
+│   │   ├── audit.js                # Função auxiliar logAudit()
+│   │   ├── generateThumbnail.js    # Integração ffmpeg / ghostscript
+│   │   ├── mailer.js               # Wrapper Nodemailer + templates de e-mail i18n
+│   │   └── sanitizeFilename.js     # Sanitização do nome de arquivo
+│   └── ws.js                       # Servidor WebSocket + despachador de ações
+│
+├── client/                         # Frontend React
+│   ├── index.html
+│   ├── package.json
+│   ├── vite.config.js
+│   ├── tailwind.config.js
+│   └── src/
+│       ├── main.jsx                # Ponto de entrada React
+│       ├── App.jsx                 # Configuração do roteador
+│       ├── index.css               # Estilos globais
+│       ├── context/
+│       │   └── AuthContext.jsx     # Estado de autenticação global
+│       ├── hooks/
+│       │   ├── use-toast.js        # Hook de notificações toast
+│       │   └── useWebSocket.js     # Conexão WS + manipuladores de eventos
+│       ├── components/
+│       │   ├── Layout.jsx          # Shell do app (barra de navegação, sidebar)
+│       │   ├── ProtectedRoute.jsx  # Guarda de autenticação
+│       │   ├── ShareLinkDialog.jsx # Diálogo de criação de link de compartilhamento
+│       │   ├── AddToCollectionDialog.jsx
+│       │   ├── CookieBanner.jsx
+│       │   ├── LanguageSelector.jsx
+│       │   ├── RequireEmailDialog.jsx
+│       │   ├── UserAvatar.jsx
+│       │   └── ui/                 # Componentes base shadcn/ui
+│       ├── pages/
+│       │   ├── Upload.jsx          # Página de upload
+│       │   ├── Gallery.jsx         # Galeria de arquivos
+│       │   ├── FileView.jsx        # Visualização detalhada de arquivo
+│       │   ├── Collections.jsx     # Visão geral de coleções
+│       │   ├── CollectionView.jsx  # Coleção individual
+│       │   ├── ShareView.jsx       # Página pública do link de compartilhamento
+│       │   ├── Settings.jsx        # Configurações do usuário
+│       │   ├── Login.jsx
+│       │   ├── Register.jsx
+│       │   ├── ForgotPassword.jsx
+│       │   ├── ResetPassword.jsx
+│       │   ├── Install.jsx         # Instalação inicial
+│       │   ├── PrivacyPolicy.jsx
+│       │   ├── TermsOfService.jsx
+│       │   └── admin/
+│       │       ├── Dashboard.jsx   # Página inicial do admin
+│       │       ├── Users.jsx       # Gerenciamento de usuários
+│       │       ├── Files.jsx       # Gerenciamento de arquivos
+│       │       ├── AuditLog.jsx    # Visualização do log de auditoria
+│       │       ├── SiteSettings.jsx# Configurações do operador
+│       │       └── Import.jsx      # Importação XBackBone
+│       ├── i18n/
+│       │   ├── index.js            # Configuração i18next
+│       │   └── locales/
+│       │       ├── de.json
+│       │       ├── en.json
+│       │       ├── es.json
+│       │       ├── fr.json
+│       │       ├── it.json
+│       │       ├── ja.json
+│       │       ├── pt.json
+│       │       └── zh.json
+│       └── lib/
+│           └── utils.js            # Utilitário Tailwind (cn())
+│
+├── scripts/
+│   ├── setup-db.js
+│   ├── mongo-init.js               # Script de inicialização MongoDB
+│   ├── migrate-uploads-to-user-folders.js
+│   └── generate-missing-thumbnails.js
+│
+├── e2e/                            # Testes Playwright
+│   ├── admin.spec.js
+│   ├── bulk-actions-fixes.spec.js
+│   ├── gallery.spec.js
+│   ├── sharelink.spec.js
+│   ├── tags.spec.js
+│   ├── upload.spec.js
+│   ├── helpers.js
+│   └── global-setup.js
+│
+├── uploads/                        # Arquivos enviados (runtime)
+│   ├── .thumbnails/
+│   ├── .avatars/
+│   └── .chunks/                    # Partes temporárias
+│
+└── docs/assets/                    # Capturas de tela e logotipo
+```
+
+---
+
+## 5. Configuração e variáveis de ambiente
+
+Todas as variáveis são carregadas de `.env` (via `dotenv`). O arquivo `.env.example` contém o modelo completo.
+
+### Campos obrigatórios
+
+| Variável | Descrição |
+|---|---|
+| `SESSION_SECRET` | Segredo para criptografia de sessões — string aleatória longa, ex. `openssl rand -hex 32` |
+| `MONGO_ROOT_PASSWORD` | Senha root do MongoDB (necessária apenas para Docker Compose) |
+| `MONGO_APP_PASSWORD` | Senha do usuário de aplicação do MongoDB |
+
+### Todas as variáveis de ambiente
+
+| Variável | Padrão | Descrição |
+|---|---|---|
+| `PORT` | `3000` | Porta TCP do servidor HTTP |
+| `MONGODB_URI` | _(construída pelo Docker Compose)_ | URI de conexão MongoDB completa |
+| `MONGO_ROOT_PASSWORD` | — | Senha root do MongoDB |
+| `MONGO_APP_USER` | `appuser` | Nome de usuário de aplicação MongoDB |
+| `MONGO_APP_PASSWORD` | — | Senha do usuário de aplicação MongoDB |
+| `MONGO_DB_NAME` | `sharely` | Nome do banco de dados MongoDB |
+| `SESSION_SECRET` | — | **Obrigatório** — segredo de criptografia de sessões |
+| `BASE_URL` | `http://localhost:3000` | URL base pública para os links de compartilhamento gerados (sem `/` final) |
+| `SITE_NAME` | `sharely` | Nome do site nos embeds Open Graph |
+| `MAX_FILE_SIZE_MB` | `100` | Tamanho máximo de arquivo para uploads padrão em MB (uploads em partes até 2 GB independentemente) |
+| `ALLOW_REGISTRATION` | `true` | `false` desativa o registro público |
+| `SMTP_HOST` | — | Hostname do servidor SMTP; deixar vazio para desativar as funcionalidades de e-mail |
+| `SMTP_PORT` | `587` | Porta SMTP |
+| `SMTP_SECURE` | `false` | `true` para TLS implícito (porta 465), `false` para STARTTLS |
+| `SMTP_USER` | — | Nome de usuário SMTP |
+| `SMTP_PASS` | — | Senha SMTP |
+| `SMTP_FROM` | _(SMTP_USER)_ | Endereço do remetente nos e-mails enviados |
+| `UPLOAD_DIR` | `./uploads` | Caminho absoluto para o diretório de upload |
+| `NODE_ENV` | — | `production` ativa os cookies seguros |
+
+---
+
+## 6. Modelos de dados
+
+### User (`src/models/User.js`)
+
+```
+{
+  username:                    String (3–32, único, alfanumérico + _-)
+  password:                    String (bcrypt, 12 rounds)
+  role:                        'admin' | 'user'
+  apiKey:                      String (legado, vazio após migração)
+  apiKeyHash:                  String (SHA-256, único, sparse)
+  apiKeyPrefix:                String (primeiros 8 caracteres do texto simples)
+  folderName:                  String (único, sparse, máx. 64)
+  avatarExt:                   String | null (.jpg/.png/.gif/.webp)
+  embedMode:                   'embed' | 'raw'
+  isActive:                    Boolean
+  email:                       String (minúsculas, único, sparse)
+  emailVerified:               Boolean
+  emailVerificationToken:      String | null (hash SHA-256 do texto simples)
+  emailVerificationExpires:    Date | null
+  passwordResetToken:          String | null (hash SHA-256)
+  passwordResetExpires:        Date | null
+  language:                    'en'|'de'|'fr'|'es'|'it'|'pt'|'ja'|'zh'
+  predefinedTags:              [String] (máx. 100 tags × 50 caracteres)
+  createdAt:                   Date
+}
+```
+
+**Métodos importantes:**
+- `user.comparePassword(candidate)` — comparação bcrypt
+- `user.regenerateApiKey()` — gera novo texto simples, armazena o hash, retorna o texto simples (visível apenas uma vez)
+- `User.findByApiKey(plaintext)` — busca por hash SHA-256, somente usuários ativos
+
+### File (`src/models/File.js`)
+
+```
+{
+  shortId:      String (8 caracteres hexadecimais: 6 timestamp + 2 aleatórios, único)
+  deleteToken:  String (32 caracteres hexadecimais, único)
+  originalName: String (sanitizado)
+  storedName:   String (caminho relativo: "folderName/8hex.ext")
+  mimeType:     String
+  size:         Number (bytes)
+  uploader:     ObjectId → User
+  views:        Number
+  tags:         [String] (máx. 20 × 50 caracteres)
+  createdAt:    Date
+}
+```
+
+**Propriedades virtuais:**
+- `sizeHuman` — tamanho legível (B / KB / MB / GB)
+- `displayType` — classificação: `image|video|audio|pdf|code|text|file`
+
+**Algoritmo Short ID:**
+```
+shortId = hex(seconds_since_2024-01-01, 6 chars) + randomBytes(2).hex()
+```
+
+### Collection (`src/models/Collection.js`)
+
+```
+{
+  shortId:     String (8 Hex, único)
+  name:        String (máx. 100)
+  description: String (máx. 500)
+  owner:       ObjectId → User
+  files:       [ObjectId → File]
+  password:    String | null (bcrypt)
+  expiresAt:   Date | null
+  createdAt:   Date
+}
+```
+
+> As coleções expiradas são excluídas automaticamente pelo índice TTL do MongoDB 7 dias após a expiração.
+
+### ShareLink (`src/models/ShareLink.js`)
+
+```
+{
+  token:         String (32 Hex, único)
+  file:          ObjectId → File
+  createdBy:     ObjectId → User
+  label:         String (máx. 100)
+  password:      String | null (bcrypt)
+  expiresAt:     Date | null
+  downloadLimit: Number (-1 = ilimitado)
+  downloadCount: Number
+  createdAt:     Date
+}
+```
+
+> Como as coleções: período de carência de 7 dias após expiração via índice TTL.
+
+### SiteSettings (`src/models/SiteSettings.js`)
+
+Documento singleton (`_id: 'singleton'`):
+
+```
+{
+  operatorName:        String
+  operatorAddress:     String
+  operatorEmail:       String
+  cloudflareAnalytics: Boolean
+  fileRetentionDays:   Number (0 = desativado)
+  encryptionAtRest:    Boolean
+  sessionDurationDays: Number (padrão: 7)
+  allowRegistration:   Boolean
+}
+```
+
+### AuditLog (`src/models/AuditLog.js`)
+
+```
+{
+  timestamp: Date (índice TTL: 90 dias)
+  userId:    ObjectId → User | null
+  username:  String | null
+  action:    String
+  ip:        String | null
+  meta:      Mixed (metadados específicos da ação)
+}
+```
+
+---
+
+## 7. API REST
+
+### URL base: `/api`
+
+Todos os endpoints JSON retornam `Content-Type: application/json`. Erros: `{ "error": "mensagem" }`.
+
+---
+
+### Autenticação (`/api/auth`)
+
+| Método | Caminho | Auth | Descrição |
+|---|---|---|---|
+| `GET` | `/me` | Sessão | Usuário atualmente conectado |
+| `POST` | `/login` | — | Fazer login (limitado: 10/15min) |
+| `POST` | `/register` | — | Registrar-se (limitado, primeiro usuário torna-se admin) |
+| `POST` | `/logout` | — | Fazer logout |
+| `GET` | `/smtp-enabled` | — | Verificar se SMTP está configurado |
+| `GET` | `/verify-email?token=` | — | Verificar endereço de e-mail |
+| `GET` | `/verify-reset-token?token=` | — | Validar token de redefinição |
+| `POST` | `/forgot-password` | — | Enviar e-mail de redefinição de senha (limitado: 5/h) |
+| `POST` | `/reset-password` | — | Definir nova senha |
+
+**Requisição de login:**
+```json
+POST /api/auth/login
+{ "username": "max", "password": "meinPasswort123" }
+```
+
+**Resposta de login:**
+```json
+{
+  "user": {
+    "id": "...", "username": "max", "role": "user",
+    "avatarUrl": null, "email": "max@example.com",
+    "emailVerified": true, "language": "de"
+  }
+}
+```
+
+---
+
+### Upload de arquivos
+
+| Método | Caminho | Auth | Descrição |
+|---|---|---|---|
+| `POST` | `/upload` | Chave API | Upload ShareX (endpoint legado em `app.js`) |
+| `POST` | `/api/upload` | Chave API | Upload ShareX/API (campo: `file`) |
+| `POST` | `/api/web-upload` | Sessão | Upload web (campo: `files[]`, máx. 500) |
+| `POST` | `/api/chunk/init` | Sessão | Inicializar upload em partes |
+| `POST` | `/api/chunk/:uploadId` | Sessão | Enviar uma parte (campo: `chunk`) |
+| `POST` | `/api/chunk/:uploadId/complete` | Sessão | Montar as partes |
+| `DELETE` | `/api/chunk/:uploadId` | Sessão | Cancelar upload e limpar |
+
+**Resposta de upload via API:**
+```json
+{
+  "url": "https://example.com/f/a1b2c3d4",
+  "raw": "https://example.com/f/a1b2c3d4/raw",
+  "delete_url": "https://example.com/api/delete/a1b2c3d4",
+  "short_id": "a1b2c3d4",
+  "filename": "screenshot.png",
+  "size": 102400
+}
+```
+
+#### Fluxo de upload em partes
+
+1. `POST /api/chunk/init` → `{ uploadId: "32hex" }`
+2. `POST /api/chunk/:uploadId` (Body: `chunkIndex=N`, Arquivo: `chunk`) → `{ received: N }`  
+   Em paralelo com 3–5 partes simultâneas
+3. `POST /api/chunk/:uploadId/complete` → `{ files: [fileObject] }`
+
+---
+
+### Gerenciamento de arquivos
+
+| Método | Caminho | Auth | Descrição |
+|---|---|---|---|
+| `GET` | `/api/gallery` | Sessão | Arquivos próprios (admin: todos), paginado (24/página), filtros: `q`, `type`, `tag`, `page` |
+| `GET` | `/api/file/:shortId` | — | Metadados do arquivo (incrementa o contador de visualizações) |
+| `PATCH` | `/api/file/:shortId` | Sessão | Atualizar tags/nome |
+| `DELETE` | `/api/file/:shortId` | Sessão | Excluir arquivo |
+| `DELETE` | `/api/delete/:shortId` | Chave API | Excluir arquivo (autenticação por chave API) |
+| `POST` | `/api/files/bulk` | Sessão | Ações em lote: `delete`, `tag`, `removeTag`, `addToCollection`, `moveToCollection` |
+| `GET` | `/api/tags` | Sessão | Todas as sugestões de tags do usuário |
+
+**Parâmetros de consulta da galeria:**
+- `q` — busca no nome do arquivo (seguro para regex)
+- `type` — `all|image|video|audio|pdf|code`
+- `tag` — filtro de tag exato
+- `page` — número da página (padrão: 1)
+
+---
+
+### Configurações do usuário
+
+| Método | Caminho | Auth | Descrição |
+|---|---|---|---|
+| `GET` | `/api/my-key` | Sessão | Exibir prefixo da chave API |
+| `POST` | `/api/regen-key` | Sessão | Regenerar chave API |
+| `GET` | `/api/sharex-config` | Sessão | Baixar ShareX `.sxcu` (regenera a chave) |
+| `PATCH` | `/api/user/username` | Sessão | Alterar nome de usuário (senha obrigatória) |
+| `PATCH` | `/api/user/password` | Sessão | Alterar senha |
+| `PATCH` | `/api/user/email` | Sessão | Alterar e-mail (envia e-mail de verificação) |
+| `PATCH` | `/api/user/language` | Sessão | Definir idioma da interface |
+| `PATCH` | `/api/user/embed-mode` | Sessão | Definir modo de incorporação (`embed`/`raw`) |
+| `POST` | `/api/user/resend-verification` | Sessão | Reenviar e-mail de verificação |
+| `GET` | `/api/user/export` | Sessão | Exportação de dados (LGPD/GDPR Art. 20) como JSON |
+| `DELETE` | `/api/user/account` | Sessão | Excluir conta (LGPD/GDPR Art. 17, senha obrigatória) |
+| `GET` | `/api/user/predefined-tags` | Sessão | Recuperar tags predefinidas |
+| `PATCH` | `/api/user/predefined-tags` | Sessão | Atualizar tags predefinidas |
+| `POST` | `/api/user/avatar` | Sessão | Fazer upload de avatar (máx. 2 MB, JPEG/PNG/GIF/WebP) |
+| `DELETE` | `/api/user/avatar` | Sessão | Excluir avatar |
+| `GET` | `/api/user/avatar/:userId` | — | Servir avatar |
+
+---
+
+### Links de compartilhamento
+
+| Método | Caminho | Auth | Descrição |
+|---|---|---|---|
+| `GET` | `/api/file/:shortId/share-links` | Sessão (Proprietário/Admin) | Todos os links de compartilhamento de um arquivo |
+| `POST` | `/api/file/:shortId/share-links` | Sessão (Proprietário/Admin) | Criar link de compartilhamento |
+| `DELETE` | `/api/share-links/:token` | Sessão (Proprietário/Criador/Admin) | Excluir link de compartilhamento |
+| `GET` | `/api/share-links/:token` | — | Metadados do link de compartilhamento (público) |
+| `POST` | `/api/share-links/:token/verify` | — | Verificar senha do link de compartilhamento |
+
+**Criar link de compartilhamento:**
+```json
+POST /api/file/a1b2c3d4/share-links
+{
+  "label": "Para colegas",
+  "password": "secreto",
+  "expiresAt": "2025-12-31T23:59:59Z",
+  "downloadLimit": 10
+}
+```
+
+---
+
+### Coleções
+
+| Método | Caminho | Auth | Descrição |
+|---|---|---|---|
+| `GET` | `/api/collections` | Sessão | Coleções próprias (admin: todas) |
+| `POST` | `/api/collections` | Sessão | Criar coleção |
+| `GET` | `/api/collections/:id` | — | Visualizar coleção (pública, senha se definida) |
+| `PATCH` | `/api/collections/:id` | Sessão (Proprietário/Admin) | Atualizar coleção |
+| `DELETE` | `/api/collections/:id` | Sessão (Proprietário/Admin) | Excluir coleção |
+| `POST` | `/api/collections/:id/files` | Sessão (Proprietário/Admin) | Adicionar arquivo à coleção |
+| `DELETE` | `/api/collections/:id/files/:fileShortId` | Sessão (Proprietário/Admin) | Remover arquivo da coleção |
+| `POST` | `/api/collections/:id/verify` | — | Verificar senha da coleção |
+
+---
+
+### Endpoints de administração
+
+| Método | Caminho | Auth | Descrição |
+|---|---|---|---|
+| `GET` | `/api/admin/stats` | Admin | Estatísticas do painel |
+| `GET` | `/api/admin/users` | Admin | Todos os usuários (com contagem de arquivos) |
+| `POST` | `/api/admin/users` | Admin | Criar usuário |
+| `PATCH` | `/api/admin/users/:id/toggle` | Admin | Ativar/desativar usuário |
+| `PATCH` | `/api/admin/users/:id/role` | Admin | Alterar papel do usuário |
+| `DELETE` | `/api/admin/users/:id` | Admin | Excluir usuário |
+| `POST` | `/api/admin/users/:id/regen-key` | Admin | Regenerar chave API |
+| `PATCH` | `/api/admin/users/:id/password` | Admin | Definir senha |
+| `PATCH` | `/api/admin/users/:id/folder` | Admin | Alterar nome da pasta (move arquivos) |
+| `GET` | `/api/admin/files` | Admin | Todos os arquivos, paginado (30/página) |
+| `GET` | `/api/admin/site-settings` | Admin | Ler configurações do operador |
+| `PATCH` | `/api/admin/site-settings` | Admin | Atualizar configurações do operador |
+| `GET` | `/api/admin/audit-log` | Admin | Log de auditoria paginado (50/página) |
+| `GET` | `/api/admin/audit-log/export` | Admin | Baixar log de auditoria como CSV |
+| `GET` | `/api/site-settings` | — | Informações públicas do operador (para a página de privacidade) |
+
+---
+
+### Configurações do site (públicas)
+
+```json
+GET /api/site-settings
+{
+  "operatorName": "Musterfirma GmbH",
+  "operatorAddress": "Musterstr. 1, 12345 Musterstadt",
+  "operatorEmail": "datenschutz@example.com",
+  "cloudflareAnalytics": false,
+  "fileRetentionDays": 365,
+  "encryptionAtRest": false,
+  "sessionDurationDays": 7
+}
+```
+
+---
+
+## 8. API WebSocket
+
+**Conexão:** `wss://example.com/ws` (somente para usuários conectados, cookie de sessão obrigatório)
+
+### Protocolo
+
+**Cliente → Servidor (Requisição):**
+```json
+{ "id": "req-abc123", "action": "file:list", "payload": { "type": "image", "page": 1 } }
+```
+
+**Servidor → Cliente (Resposta):**
+```json
+{ "id": "req-abc123", "data": { ... } }
+```
+
+**Servidor → Cliente (Erro):**
+```json
+{ "id": "req-abc123", "error": "Forbidden", "status": 403 }
+```
+
+**Servidor → Cliente (Broadcast):**
+```json
+{ "event": "file:uploaded", "data": { "shortId": "a1b2c3d4", "uploaderId": "..." } }
+```
+
+### Ações disponíveis
+
+| Ação | Auth | Descrição |
+|---|---|---|
+| `site-settings:get` | — | Configurações públicas do site |
+| `auth:me` | Usuário | Dados do usuário conectado |
+| `file:get` | Usuário | Detalhes do arquivo (incrementa visualizações) |
+| `file:list` | Usuário | Lista de arquivos com filtro/paginação |
+| `file:delete` | Usuário | Excluir arquivo |
+| `user:get-key` | Usuário | Prefixo da chave API |
+| `user:regen-key` | Usuário | Regenerar chave API |
+| `user:change-password` | Usuário | Alterar senha |
+| `user:change-username` | Usuário | Alterar nome de usuário |
+| `user:change-email` | Usuário | Alterar e-mail |
+| `user:change-language` | Usuário | Definir idioma |
+| `user:change-embed-mode` | Usuário | Definir modo de incorporação |
+| `user:resend-verification` | Usuário | Reenviar e-mail de verificação |
+| `user:export` | Usuário | Exportação de dados |
+| `user:delete-account` | Usuário | Excluir conta |
+| `admin:stats` | Admin | Estatísticas do painel |
+| `admin:settings:get` | Admin | Ler configurações do site |
+| `admin:settings:update` | Admin | Atualizar configurações do site |
+| `admin:users:list` | Admin | Todos os usuários |
+| `admin:users:create` | Admin | Criar usuário |
+| `admin:users:toggle` | Admin | Ativar/desativar usuário |
+| `admin:users:role` | Admin | Alterar papel do usuário |
+| `admin:users:delete` | Admin | Excluir usuário |
+| `admin:users:regen-key` | Admin | Regenerar chave API |
+| `admin:users:password` | Admin | Definir senha |
+| `admin:users:folder` | Admin | Alterar nome da pasta |
+| `admin:files:list` | Admin | Todos os arquivos |
+| `admin:audit-log:list` | Admin | Log de auditoria paginado |
+
+### Eventos de broadcast
+
+| Evento | Destinatários | Payload |
+|---|---|---|
+| `file:uploaded` | Quem fez o upload | `{ shortId, uploaderId }` |
+| `file:deleted` | Proprietário do arquivo | `{ shortId, uploaderId }` |
+| `file:view` | Todos | `{ shortId, views }` |
+| `user:created` | Admins | `{ id, username, role, ... }` |
+| `user:deleted` | Admins | `{ id }` |
+| `user:updated` | Admins | `{ id, ...campos alterados }` |
+| `audit:log` | Admins | Objeto AuditLog completo |
+| `settings:updated` | Admins | Objeto SiteSettings atualizado |
+| `stats:invalidate` | Admins | `{}` (aciona atualização de estatísticas) |
+
+---
+
+## 9. Rotas de serviço de arquivos
+
+### `/f/:shortId` — Visualizador de arquivos
+
+- **Requisição do navegador:** Passa para a React SPA (`index.html`) — a SPA renderiza o visualizador.
+- **Bot de redes sociais** (Discord, Telegram, Twitter, etc.): Retorna uma página HTML mínima com meta tags Open Graph / Twitter Card.
+  - `embedMode = 'embed'`: HTML OG com redirecionamento
+  - `embedMode = 'raw'` + imagem/vídeo/áudio: HTTP 302 → `/f/:shortId/raw`
+
+### `/f/:shortId/raw` — Acesso direto
+
+Serve o arquivo como resposta HTTP com suporte a requisições de intervalo (206 Partial Content). Imagens/vídeos/áudio: `Content-Disposition: inline`, outros: `attachment`.
+
+### `/f/:shortId/download` — Download forçado
+
+Como `/raw`, mas sempre `Content-Disposition: attachment`.
+
+### `/f/:shortId/thumb` — Miniatura
+
+Retorna a miniatura JPEG (para vídeos e PDFs). `Cache-Control: public, max-age=86400`.
+
+### `/f/:shortId/delete/:token` — Exclusão ShareX
+
+Exclui o arquivo sem sessão usando um token de exclusão único.
+
+### `/s/:token` — Serviço de arquivos via link de compartilhamento (`src/routes/shares.js`)
+
+Verifica a senha (via flag de sessão), a data de expiração e o limite de downloads, e então serve o arquivo.
+
+---
+
+## 10. Autenticação e segurança
+
+### Autenticação por sessão
+
+- Sessão Express com armazenamento MongoDB (`connect-mongo`)
+- Cookie de sessão: `httpOnly: true`, `sameSite: 'strict'`, `secure: true` em produção
+- Duração da sessão: configurável via `SiteSettings.sessionDurationDays` (padrão: 7 dias), com cache ao vivo de 60 segundos
+
+### Autenticação por chave API
+
+- As chaves API são armazenadas como hashes SHA-256, nunca em texto simples
+- Os primeiros 8 caracteres são armazenados como `apiKeyPrefix` (para exibição)
+- Busca: `User.findByApiKey(plaintext)` calcula o hash e busca em `apiKeyHash`
+- Ao baixar a configuração do ShareX, a chave é regenerada — o texto simples fica visível apenas naquele momento
+
+### Cadeia de middleware (`src/middleware/auth.js`)
+
+```
+requireLogin    → verifica req.session.user → 401 se não conectado
+requireAdmin    → como requireLogin, adicionalmente role === 'admin' → 403
+requireApiKey   → verifica o cabeçalho Authorization ou req.body.token
+```
+
+### Proteção CSRF
+
+`requireSameOrigin()` em `app.js` compara o cabeçalho `Origin` com o cabeçalho `Host` para todas as rotas da API. Complementa os cookies `sameSite: 'strict'`.
+
+### Política de Segurança de Conteúdo
+
+```
+default-src 'self';
+script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com;
+style-src 'self' 'unsafe-inline';
+img-src 'self' data: blob:;
+media-src 'self' blob:;
+connect-src 'self' https://cloudflareinsights.com;
+frame-ancestors 'self';
+```
+
+### Cabeçalhos de segurança
+
+- `X-Frame-Options: SAMEORIGIN`
+- `X-Content-Type-Options: nosniff`
+
+### Limitação de taxa
+
+| Endpoint | Limite | Janela |
+|---|---|---|
+| Upload (`/upload`, `/api/upload`, `/api/web-upload`) | 60 requisições | 15 minutos |
+| Auth (`/api/auth/login`, `/register`, etc.) | 10 requisições | 15 minutos |
+| Redefinição de senha | 5 requisições | 1 hora |
+
+### Lista de bloqueio de arquivos
+
+Os seguintes tipos MIME e extensões são rejeitados no upload:
+
+**Tipos MIME bloqueados:** `application/x-executable`, `application/x-sh`, `application/x-csh`, `application/x-bat`
+
+**Extensões bloqueadas:** `.bat`, `.cmd`, `.com`, `.ps1`, `.psm1`, `.psd1`, `.sh`, `.bash`, `.csh`, `.zsh`, `.fish`, `.vbs`, `.vbe`, `.jse`, `.scr`, `.pif`, `.application`, `.gadget`, `.hta`, `.php`, `.php3–5`, `.phtml`, `.asp`, `.aspx`, `.jsp`, `.jspx`, `.cfm`
+
+### Proteção contra path traversal
+
+Todos os acessos a arquivos via `resolveUploadPath()` verificam se o caminho resolvido está dentro de `UPLOAD_DIR`.
+
+---
+
+## 11. Sistema de upload
+
+### Upload padrão (Multer)
+
+- **Armazenamento:** `multer.diskStorage` → `uploads/{folderName}/{8hex}{.ext}`
+- **Nome do arquivo:** `crypto.randomBytes(4).hex() + extensão-original`
+- **Limite:** `MAX_FILE_SIZE_MB` (padrão: 100 MB)
+- **Localização:** Pasta específica do usuário (`user.folderName`)
+
+### Upload em partes (>250 MB)
+
+O cliente frontend muda automaticamente para o modo de partes para arquivos grandes.
+
+**Estrutura de diretórios no servidor:**
+```
+uploads/.chunks/{uploadId}/
+  meta.json          { filename, mimeType, totalSize, totalChunks, userId, createdAt }
+  chunk-0
+  chunk-1
+  ...
+  chunk-N
+```
+
+**Tamanho da parte:** 10–20 MB (máx. 51 MB aceito para compatibilidade com versões anteriores)  
+**Paralelismo:** 3–5 uploads de partes simultâneos  
+**Montagem:** Baseada em streams (sem carregamento completo na RAM)
+
+### Upload de avatar
+
+- **Armazenamento:** `multer.memoryStorage()` (sem buffer em disco)
+- **Localização:** `uploads/.avatars/{userId}{.ext}`
+- **Limite:** 2 MB
+- **Formatos:** JPEG, PNG, GIF, WebP
+
+---
+
+## 12. Geração de miniaturas
+
+As miniaturas são geradas de forma assíncrona após o upload (`.catch(() => {})` — erros são ignorados silenciosamente).
+
+### Miniaturas de vídeo (ffmpeg)
+
+```bash
+ffmpeg -y -i <file> -ss 00:00:01 -vframes 1 \
+  -vf "scale=320:320:force_original_aspect_ratio=increase,crop=320:320" \
+  -q:v 3 uploads/.thumbnails/<shortId>.jpg
+```
+
+### Miniaturas de PDF (Ghostscript)
+
+```bash
+gs -dNOPAUSE -dBATCH -dSAFER \
+  -sDEVICE=jpeg -dFirstPage=1 -dLastPage=1 \
+  -r72 -dJPEGQ=85 \
+  -sOutputFile=uploads/.thumbnails/<shortId>.jpg \
+  <file>
+```
+
+**Tempo limite:** 30 segundos por geração de miniatura  
+**Fallback:** Se ffmpeg/ghostscript não estiver disponível, a geração é ignorada silenciosamente.
+
+### Script de preenchimento retroativo
+
+```bash
+npm run migrate:thumbnails
+# ou no contêiner:
+docker exec -it <container> npm run migrate:thumbnails
+```
+
+---
+
+## 13. E-mail e SMTP
+
+### Configuração
+
+O SMTP é ativado quando `SMTP_HOST` está definido. `mailer.isConfigured()` verifica esse valor.
+
+### Templates de e-mail
+
+Todos os e-mails são enviados no idioma do usuário (8 idiomas). Os templates estão incorporados em `src/utils/mailer.js`.
+
+**Tipos de e-mails enviados:**
+
+| Tipo | Gatilho | Validade do token |
+|---|---|---|
+| Verificação de e-mail | Registro, alteração de e-mail | 24 horas |
+| Redefinição de senha | `POST /api/auth/forgot-password` | 1 hora |
+
+### Segurança dos tokens
+
+- Tokens: `crypto.randomBytes(32).hex()` (64 caracteres hexadecimais)
+- Armazenados: hash SHA-256 do token
+- O e-mail contém o token em texto simples como parâmetro de URL
+- Verificação: hash do token recebido comparado com o hash armazenado
+
+---
+
+## 14. Internacionalização
+
+**Biblioteca:** i18next + react-i18next + i18next-browser-languagedetector
+
+**Idiomas suportados:**
+
+| Código | Idioma |
+|---|---|
+| `en` | English |
+| `de` | Deutsch |
+| `fr` | Français |
+| `es` | Español |
+| `it` | Italiano |
+| `pt` | Português |
+| `ja` | 日本語 |
+| `zh` | 中文 |
+
+**Seleção de idioma:**
+1. Detecção do idioma do navegador (automática)
+2. Preferência do usuário no banco de dados (`user.language`)
+3. Persistência via `PATCH /api/user/language`
+
+Arquivos de tradução: `client/src/i18n/locales/{code}.json`
+
+---
+
+## 15. Frontend (React SPA)
+
+### Configuração do roteador (`client/src/App.jsx`)
+
+| Rota | Componente | Auth |
+|---|---|---|
+| `/` | Redirecionamento → `/gallery` | Não |
+| `/auth/login` | Login.jsx | Não |
+| `/auth/register` | Register.jsx | Não |
+| `/auth/forgot-password` | ForgotPassword.jsx | Não |
+| `/auth/reset-password` | ResetPassword.jsx | Não |
+| `/install` | Install.jsx | Não |
+| `/upload` | Upload.jsx | **Sim** |
+| `/gallery` | Gallery.jsx | **Sim** |
+| `/f/:shortId` | FileView.jsx | **Sim** |
+| `/collections` | Collections.jsx | **Sim** |
+| `/c/:id` | CollectionView.jsx | Não (público) |
+| `/s/:token` | ShareView.jsx | Não (público) |
+| `/settings` | Settings.jsx | **Sim** |
+| `/admin` | Dashboard.jsx | **Admin** |
+| `/admin/users` | Users.jsx | **Admin** |
+| `/admin/files` | Files.jsx | **Admin** |
+| `/admin/audit-log` | AuditLog.jsx | **Admin** |
+| `/admin/site-settings` | SiteSettings.jsx | **Admin** |
+| `/admin/import` | Import.jsx | **Admin** |
+| `/privacy` | PrivacyPolicy.jsx | Não |
+| `/terms` | TermsOfService.jsx | Não |
+
+### Contexto de autenticação (`client/src/context/AuthContext.jsx`)
+
+Estado global para o usuário conectado. Inicializado na inicialização do app via `GET /api/auth/me`.
+
+### Hook WebSocket (`client/src/hooks/useWebSocket.js`)
+
+Gerencia a conexão WS persistente. Fornece `sendMessage()` e registro de manipuladores de eventos. Lógica de reconexão em caso de queda da conexão.
+
+### Componentes UI
+
+Baseado em **shadcn/ui** (Radix UI Primitives + Tailwind CSS):
+
+- `Dialog`, `AlertDialog`, `DropdownMenu`, `ContextMenu`, `Popover`
+- `Select`, `Checkbox`, `Input`, `Textarea`, `Label`
+- `Card`, `Badge`, `Button`, `Separator`, `Tabs`, `Table`
+- `Toast` / `Toaster` para notificações
+- `Calendar` / `DateTimePicker` para seleção de data de expiração
+- `Pagination` para listas paginadas
+- `ScrollArea`, `Tooltip`
+
+---
+
+## 16. Painel de administração
+
+O painel de administração (`/admin/*`) é acessível apenas para usuários com `role: 'admin'`.
+
+### Painel de controle (`/admin`)
+
+- Número total de usuários, arquivos, uso de armazenamento
+- 10 arquivos carregados mais recentemente
+- Atualizações ao vivo via WebSocket (`stats:invalidate`)
+
+### Gerenciamento de usuários (`/admin/users`)
+
+- Todos os usuários com contagem de arquivos e uso de armazenamento
+- Criar usuários, ativar/desativar, alterar papel
+- Redefinir senha, regenerar chave API
+- Alterar nome da pasta (arquivos físicos são movidos no servidor)
+- Excluir usuário (todos os arquivos são excluídos)
+
+### Gerenciamento de arquivos (`/admin/files`)
+
+- Todos os arquivos de todos os usuários, paginado
+- Busca por nome de arquivo
+- Excluir arquivo
+
+### Log de auditoria (`/admin/audit-log`)
+
+- Log paginado de todas as ações (50/página)
+- Filtrar por nome de usuário e ação
+- Exportação CSV para fins regulatórios
+
+### Configurações do site (`/admin/site-settings`)
+
+- Informações do operador (nome, endereço, e-mail)
+- Ativar Cloudflare Analytics
+- Período de retenção de arquivos
+- Duração das sessões
+- Ativar/desativar registro de usuários
+
+### Importação XBackBone (`/admin/import`)
+
+- Pré-visualização e importação do banco de dados SQLite do XBackBone
+- Usuários são correspondidos pelo nome de usuário
+- Idempotente (arquivos já importados são ignorados)
+
+---
+
+## 17. LGPD / Privacidade
+
+| Funcionalidade | Artigo GDPR/LGPD |
+|---|---|
+| Política de privacidade (configurável) | Art. 13/14 – Transparência |
+| Página de termos de serviço (configurável) | Art. 13/14 – Transparência |
+| Exportação de dados (JSON com URLs) | Art. 20 – Portabilidade de dados |
+| Autoexclusão de conta (arquivos + dados) | Art. 17 – Direito ao apagamento |
+| Log de auditoria (TTL 90 dias via MongoDB) | Art. 5(2) – Responsabilidade |
+| Exportação CSV do log de auditoria | Art. 5(2) – Responsabilidade |
+| Retenção de arquivos configurável | Art. 5(1)(e) – Limitação da conservação |
+| Chaves API como hash SHA-256 | Art. 32 – Segurança |
+| Senhas como bcrypt (12 rounds) | Art. 32 – Segurança |
+| Consentimento de cookies para Cloudflare Analytics | Art. 13 – Transparência |
+| Anonimização na exclusão de conta | Art. 17 – Direito ao apagamento |
+
+### Fluxo de exclusão LGPD/GDPR
+
+Na exclusão da conta (`user:delete-account` / `DELETE /api/user/account`):
+1. Todos os arquivos do usuário são excluídos do disco
+2. As miniaturas são excluídas
+3. O avatar é excluído
+4. As entradas do log de auditoria são anonimizadas (`username: '[deleted]'`, `ip: null`, `userId: null`)
+5. O documento de usuário é excluído
+6. A sessão é destruída
+
+---
+
+## 18. Jobs em segundo plano
+
+### Limpeza por retenção (`src/jobs/retentionCleanup.js`)
+
+- **Execução:** Na inicialização e depois diariamente (`setInterval(runRetentionCleanup, 24h)`)
+- **Ação:** Se `SiteSettings.fileRetentionDays > 0`, os arquivos mais antigos que esse valor são excluídos
+- Exclui: arquivo em disco, miniatura, documento MongoDB
+- Transmite `stats:invalidate` para os admins
+
+### Índices TTL do MongoDB (automáticos)
+
+| Coleção | TTL | Gatilho |
+|---|---|---|
+| `AuditLog` | 90 dias | `timestamp` |
+| `Collection` | 7 dias após `expiresAt` | `expiresAt` |
+| `ShareLink` | 7 dias após `expiresAt` | `expiresAt` |
+
+---
+
+## 19. Implantação
+
+### Docker (recomendado)
+
+```bash
+git clone https://github.com/Christianoooooo/sharely.git
+cd sharely
+cp .env.example .env
+# Editar .env (SESSION_SECRET, senhas MONGO, BASE_URL)
+docker compose up -d
+```
+
+**Serviços:**
+- `app` — Aplicação Node.js (porta 3000)
+- `mongo` — MongoDB 7 (porta 127.0.0.1:27017, não acessível externamente)
+
+**Volumes:**
+- `uploads` — armazenamento persistente de arquivos
+- `mongo_data` — dados MongoDB
+
+**Verificações de saúde:** O app verifica HTTP 200 em `/`, o MongoDB verifica `db.adminCommand('ping')`.
+
+### Proxy reverso Nginx
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name files.example.com;
+
+    client_max_body_size 2100M;  # Pelo menos tão grande quanto a maior parte + buffer
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Suporte WebSocket
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+```
+
+> `BASE_URL` em `.env` deve corresponder ao domínio público.
+
+### Primeira inicialização
+
+O primeiro usuário registrado recebe automaticamente o papel `admin` (`User.countDocuments() === 0`).
+
+---
+
+## 20. Ambiente de desenvolvimento
+
+### Pré-requisitos
+
+- Node.js ≥ 18
+- MongoDB (local ou via Docker)
+- Opcional: ffmpeg, ghostscript (para miniaturas)
+
+### Configuração
+
+```bash
+# Backend
+npm install
+cp .env.example .env
+# Editar .env
+
+# Frontend
+cd client
+npm install
+```
+
+### Inicialização
+
+```bash
+# Backend (porta 3000, com nodemon)
+npm run dev
+
+# Frontend (porta 5173, terminal separado)
+cd client
+npm run dev
+```
+
+O servidor de desenvolvimento Vite faz proxy das requisições da API para `localhost:3000` automaticamente.
+
+### Build
+
+```bash
+npm run build   # Compila client/dist/, o backend permanece inalterado
+npm start       # Inicia o servidor Express de produção
+```
+
+---
+
+## 21. Migrações e scripts
+
+### Migrações automáticas (a cada inicialização)
+
+Essas migrações são executadas na inicialização do app em `app.js` e são idempotentes:
+
+| Migração | Arquivo | Função |
+|---|---|---|
+| Migração de pastas de usuário | `src/migrations/migrateUserFolders.js` | Move arquivos de `uploads/` para `uploads/{folderName}/` |
+| Migração de hashes de chaves API | `src/migrations/migrateApiKeyHashes.js` | Converte chaves API em texto simples para hashes SHA-256 |
+
+### Scripts manuais
+
+```bash
+# Gerar miniaturas para arquivos já existentes
+npm run migrate:thumbnails
+# ou:
+node scripts/generate-missing-thumbnails.js
+
+# Mover uploads para pastas de usuário (manual)
+npm run migrate:user-folders
+# ou:
+node scripts/migrate-uploads-to-user-folders.js
+```
+
+### Inicialização do banco de dados (Docker)
+
+`scripts/mongo-init.js` é executado na primeira inicialização do contêiner MongoDB e cria o usuário de aplicação com as permissões corretas.
+
+---
+
+## 22. Testes end-to-end
+
+**Framework:** Playwright (`@playwright/test`)
+
+### Arquivos de teste
+
+| Arquivo | Suite de testes |
+|---|---|
+| `e2e/upload.spec.js` | Fluxos de upload |
+| `e2e/gallery.spec.js` | Galeria e gerenciamento de arquivos |
+| `e2e/admin.spec.js` | Painel de administração |
+| `e2e/sharelink.spec.js` | Criação e uso de links de compartilhamento |
+| `e2e/tags.spec.js` | Gerenciamento de tags |
+| `e2e/bulk-actions-fixes.spec.js` | Ações em lote |
+
+### Execução
+
+```bash
+# Todos os testes
+npm run test:e2e
+
+# Com interface gráfica
+npm run test:e2e:ui
+```
+
+**Configuração Playwright:** `playwright.config.js`  
+**Configuração global:** `e2e/global-setup.js` (cria usuários de teste, admin, etc.)  
+**Utilitários:** `e2e/helpers.js` (funções auxiliares compartilhadas)
+
+---
+
+## Apêndice: Ações do log de auditoria
+
+| Ação | Gatilho |
+|---|---|
+| `login` | Login bem-sucedido |
+| `logout` | Logout |
+| `register` | Registro |
+| `upload` | Upload de arquivo |
+| `delete_file` | Arquivo excluído |
+| `delete_account` | Conta excluída |
+| `change_password` | Senha alterada |
+| `change_username` | Nome de usuário alterado |
+| `change_email` | E-mail alterado |
+| `verify_email` | E-mail verificado |
+| `forgot_password` | Redefinição de senha solicitada |
+| `reset_password` | Senha redefinida |
+| `regen_api_key` | Chave API regenerada |
+| `sharex_config` | Configuração ShareX baixada |
+| `export_data` | Exportação de dados |
+| `admin_create_user` | Admin: usuário criado |
+| `admin_delete_user` | Admin: usuário excluído |
+| `admin_toggle_user` | Admin: usuário ativado/desativado |
+| `admin_change_role` | Admin: papel do usuário alterado |
+| `admin_change_password` | Admin: senha definida |
+| `admin_regen_key` | Admin: chave API regenerada |
+
+---
+
+*Documentação gerada a partir do código-fonte de sharely v1.0.0*

--- a/docs/zh.md
+++ b/docs/zh.md
@@ -1,0 +1,1264 @@
+# Sharely — 技术文档
+
+> **版本：** 1.0.0 · **许可证：** MIT · **Node.js：** ≥ 18
+
+---
+
+## 目录
+
+1. [项目概述](#1-项目概述)
+2. [架构](#2-架构)
+3. [技术栈](#3-技术栈)
+4. [目录结构](#4-目录结构)
+5. [配置与环境变量](#5-配置与环境变量)
+6. [数据模型](#6-数据模型)
+7. [REST API](#7-rest-api)
+8. [WebSocket API](#8-websocket-api)
+9. [文件服务路由](#9-文件服务路由)
+10. [身份验证与安全](#10-身份验证与安全)
+11. [上传系统](#11-上传系统)
+12. [缩略图生成](#12-缩略图生成)
+13. [邮件与SMTP](#13-邮件与smtp)
+14. [国际化](#14-国际化)
+15. [前端（React SPA）](#15-前端react-spa)
+16. [管理后台](#16-管理后台)
+17. [GDPR / 隐私保护](#17-gdpr--隐私保护)
+18. [后台任务](#18-后台任务)
+19. [部署](#19-部署)
+20. [开发环境](#20-开发环境)
+21. [迁移与脚本](#21-迁移与脚本)
+22. [端到端测试](#22-端到端测试)
+
+---
+
+## 1. 项目概述
+
+Sharely 是一个**自托管文件共享平台**，提供简洁的 Web 界面、ShareX 集成和 API 访问。用户可上传截图、文件和媒体，并通过短链接即时分享。
+
+### 核心功能
+
+| 功能 | 描述 |
+|---|---|
+| Web 上传 | 拖放上传，单次最多支持 500 个文件 |
+| 分块上传 | 通过并行多部分上传支持最大 2GB 的文件 |
+| ShareX 集成 | 一键下载 `.sxcu` 配置文件 |
+| API 上传 | Bearer Token 认证，兼容 curl/wget |
+| 文件查看器 | 图片缩放、视频/音频流媒体（HTTP Range）、PDF 内联显示、代码语法高亮 |
+| 嵌入模式 | *embed*（OG/Twitter Card HTML）或 *raw*（直接重定向） |
+| 缩略图 | 自动为视频（ffmpeg）和 PDF（ghostscript）生成 JPEG 预览图 |
+| 集合 | 支持可选密码和过期日期的文件分组 |
+| 分享链接 | 带密码、过期时间和下载次数限制的文件专属链接 |
+| 实时 UI | 基于 WebSocket 的实时更新（上传、删除、访问计数、管理统计） |
+| 多语言支持 | 8 种语言：EN、DE、FR、ES、IT、PT、JA、ZH |
+| 管理后台 | 统计信息、用户管理、文件管理、审计日志（CSV 导出） |
+| GDPR 合规 | 符合欧盟 GDPR 的隐私功能（第 17、20、32 条等） |
+| XBackBone 导入 | 支持从现有 XBackBone 安装迁移数据 |
+| Docker 就绪 | `docker compose up -d` 即可启动完整环境 |
+
+---
+
+## 2. 架构
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Browser / Client                      │
+│            React 18 SPA  ·  Vite  ·  Tailwind CSS           │
+│   ┌──────────────────────────────────────────────────────┐   │
+│   │  HTTP REST (/api/*)            WebSocket (/ws)       │   │
+│   └──────────────────────────────────────────────────────┘   │
+└───────────────────────────┬────────────────────┬─────────────┘
+                            │ HTTP               │ WS
+┌───────────────────────────▼────────────────────▼─────────────┐
+│                    Express.js (app.js)                        │
+│                                                               │
+│  ┌──────────────┐  ┌───────────┐  ┌──────────┐  ┌────────┐  │
+│  │  /api/auth   │  │  /api/*   │  │   /f/*   │  │  /s/*  │  │
+│  │  /api/install│  │  routes   │  │  files   │  │ shares │  │
+│  └──────────────┘  └───────────┘  └──────────┘  └────────┘  │
+│                                                               │
+│  Middleware: session · rate-limit · CSRF · CSP · auth        │
+│                                                               │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌────────────┐  │
+│  │  multer  │  │  ws.js   │  │  mailer  │  │ retention  │  │
+│  │  upload  │  │ WebSocket│  │ nodemailer│  │  cleanup   │  │
+│  └──────────┘  └──────────┘  └──────────┘  └────────────┘  │
+└───────────────────────────┬───────────────────────────────────┘
+                            │
+┌───────────────────────────▼───────────────────────────────────┐
+│                      MongoDB (Mongoose)                        │
+│  User · File · Collection · ShareLink · SiteSettings          │
+│  AuditLog                                                      │
+└───────────────────────────────────────────────────────────────┘
+                            │
+              ┌─────────────▼───────────────┐
+              │     Dateisystem (uploads/)   │
+              │  {folderName}/  ·  .chunks/  │
+              │  .thumbnails/   ·  .avatars/ │
+              └─────────────────────────────┘
+```
+
+### 数据流：标准上传
+
+```
+Browser → POST /api/web-upload (multipart/form-data)
+       → multer: Datei in uploads/{folderName}/
+       → File.createUnique() → MongoDB
+       → generateThumbnail() (async, non-blocking)
+       → logAudit()
+       → broadcast('file:uploaded') via WebSocket
+       ← JSON: { files: [...] }
+```
+
+### 数据流：ShareX 上传
+
+```
+ShareX → POST /upload (token im Formular-Body)
+       → multer: Datei temporär in uploads/
+       → requireApiKey: Token-Lookup → User
+       → fs.renameSync → uploads/{folderName}/
+       → File.create() → MongoDB
+       ← JSON: { url, delete_url }
+```
+
+---
+
+## 3. 技术栈
+
+| 层级 | 技术 | 版本 |
+|---|---|---|
+| **运行时** | Node.js | ≥ 18 |
+| **后端框架** | Express.js | 4.x |
+| **数据库** | MongoDB + Mongoose | Mongo 7, Mongoose 8.x |
+| **会话管理** | express-session + connect-mongo | — |
+| **实时通信** | WebSocket (`ws`) | 8.x |
+| **文件上传** | Multer | 1.x |
+| **邮件** | Nodemailer | 8.x |
+| **密码哈希** | bcryptjs | 2.x（12 轮） |
+| **API 密钥哈希** | SHA-256（Node Crypto） | — |
+| **限流** | express-rate-limit | 8.x |
+| **XBackBone 导入** | sql.js | 1.x |
+| **前端框架** | React 18 | 18.3.x |
+| **前端路由** | React Router v6 | 6.x |
+| **构建工具** | Vite | 6.x |
+| **样式** | Tailwind CSS + Radix UI | 3.x |
+| **UI 组件** | shadcn/ui（Radix primitives） | — |
+| **图标** | FontAwesome | 6.x |
+| **i18n** | i18next + react-i18next | — |
+| **语法高亮** | highlight.js | 11.x |
+| **容器** | Docker + Docker Compose | — |
+| **测试** | Playwright（E2E） | 1.60.x |
+
+---
+
+## 4. 目录结构
+
+```
+sharely/
+├── app.js                          # Express 入口点，启动序列
+├── package.json
+├── .env.example                    # 所有环境变量的模板
+├── Dockerfile
+├── docker-compose.yml
+│
+├── src/
+│   ├── config/
+│   │   └── db.js                   # MongoDB 连接（Mongoose）
+│   ├── middleware/
+│   │   ├── auth.js                 # requireLogin / requireAdmin / requireApiKey
+│   │   └── upload.js               # Multer 配置，黑名单
+│   ├── models/
+│   │   ├── AuditLog.js             # 审计事件（TTL 90 天）
+│   │   ├── Collection.js           # 文件集合
+│   │   ├── File.js                 # 文件元数据
+│   │   ├── ShareLink.js            # 文件专属分享链接
+│   │   ├── SiteSettings.js         # 单例：运营者设置
+│   │   └── User.js                 # 用户账户 + API 密钥
+│   ├── routes/
+│   │   ├── api.js                  # 主 API（上传、相册、管理等）
+│   │   ├── auth.js                 # 登录 / 注册 / 密码重置
+│   │   ├── files.js                # 文件服务、OG 嵌入、Range 请求
+│   │   ├── import.js               # XBackBone 迁移
+│   │   ├── install.js              # 初始安装端点
+│   │   └── shares.js               # 分享链接文件服务
+│   ├── jobs/
+│   │   └── retentionCleanup.js     # 每日删除过期文件
+│   ├── migrations/
+│   │   ├── migrateApiKeyHashes.js  # 一次性：明文 → SHA-256 哈希
+│   │   └── migrateUserFolders.js   # 一次性：将文件移入用户文件夹
+│   ├── utils/
+│   │   ├── audit.js                # logAudit() 辅助函数
+│   │   ├── generateThumbnail.js    # ffmpeg / ghostscript 集成
+│   │   ├── mailer.js               # Nodemailer 封装 + i18n 邮件模板
+│   │   └── sanitizeFilename.js     # 文件名净化
+│   └── ws.js                       # WebSocket 服务器 + 动作调度器
+│
+├── client/                         # React 前端
+│   ├── index.html
+│   ├── package.json
+│   ├── vite.config.js
+│   ├── tailwind.config.js
+│   └── src/
+│       ├── main.jsx                # React 入口点
+│       ├── App.jsx                 # 路由配置
+│       ├── index.css               # 全局样式
+│       ├── context/
+│       │   └── AuthContext.jsx     # 全局认证状态
+│       ├── hooks/
+│       │   ├── use-toast.js        # Toast 通知 Hook
+│       │   └── useWebSocket.js     # WS 连接 + 事件处理器
+│       ├── components/
+│       │   ├── Layout.jsx          # 应用外壳（导航栏、侧边栏）
+│       │   ├── ProtectedRoute.jsx  # 认证守卫
+│       │   ├── ShareLinkDialog.jsx # 分享链接创建对话框
+│       │   ├── AddToCollectionDialog.jsx
+│       │   ├── CookieBanner.jsx
+│       │   ├── LanguageSelector.jsx
+│       │   ├── RequireEmailDialog.jsx
+│       │   ├── UserAvatar.jsx
+│       │   └── ui/                 # shadcn/ui 基础组件
+│       ├── pages/
+│       │   ├── Upload.jsx          # 上传页面
+│       │   ├── Gallery.jsx         # 文件相册
+│       │   ├── FileView.jsx        # 文件详情视图
+│       │   ├── Collections.jsx     # 集合概览
+│       │   ├── CollectionView.jsx  # 单个集合
+│       │   ├── ShareView.jsx       # 公开分享链接页面
+│       │   ├── Settings.jsx        # 用户设置
+│       │   ├── Login.jsx
+│       │   ├── Register.jsx
+│       │   ├── ForgotPassword.jsx
+│       │   ├── ResetPassword.jsx
+│       │   ├── Install.jsx         # 初始安装
+│       │   ├── PrivacyPolicy.jsx
+│       │   ├── TermsOfService.jsx
+│       │   └── admin/
+│       │       ├── Dashboard.jsx   # 管理员首页
+│       │       ├── Users.jsx       # 用户管理
+│       │       ├── Files.jsx       # 文件管理
+│       │       ├── AuditLog.jsx    # 审计日志视图
+│       │       ├── SiteSettings.jsx# 运营者设置
+│       │       └── Import.jsx      # XBackBone 导入
+│       ├── i18n/
+│       │   ├── index.js            # i18next 配置
+│       │   └── locales/
+│       │       ├── de.json
+│       │       ├── en.json
+│       │       ├── es.json
+│       │       ├── fr.json
+│       │       ├── it.json
+│       │       ├── ja.json
+│       │       ├── pt.json
+│       │       └── zh.json
+│       └── lib/
+│           └── utils.js            # Tailwind 工具函数（cn()）
+│
+├── scripts/
+│   ├── setup-db.js
+│   ├── mongo-init.js               # MongoDB 初始化脚本
+│   ├── migrate-uploads-to-user-folders.js
+│   └── generate-missing-thumbnails.js
+│
+├── e2e/                            # Playwright 测试
+│   ├── admin.spec.js
+│   ├── bulk-actions-fixes.spec.js
+│   ├── gallery.spec.js
+│   ├── sharelink.spec.js
+│   ├── tags.spec.js
+│   ├── upload.spec.js
+│   ├── helpers.js
+│   └── global-setup.js
+│
+├── uploads/                        # 文件上传（运行时）
+│   ├── .thumbnails/
+│   ├── .avatars/
+│   └── .chunks/                    # 临时分块
+│
+└── docs/assets/                    # 截图和 Logo
+```
+
+---
+
+## 5. 配置与环境变量
+
+所有变量均从 `.env` 文件加载（通过 `dotenv`）。`.env.example` 文件包含完整模板。
+
+### 必填字段
+
+| 变量 | 描述 |
+|---|---|
+| `SESSION_SECRET` | 会话加密密钥 — 长随机字符串，例如 `openssl rand -hex 32` |
+| `MONGO_ROOT_PASSWORD` | MongoDB root 密码（仅 Docker Compose 需要） |
+| `MONGO_APP_PASSWORD` | MongoDB 应用用户密码 |
+
+### 所有环境变量
+
+| 变量 | 默认值 | 描述 |
+|---|---|---|
+| `PORT` | `3000` | HTTP 服务器的 TCP 端口 |
+| `MONGODB_URI` | _（由 Docker Compose 构建）_ | 完整的 MongoDB 连接 URI |
+| `MONGO_ROOT_PASSWORD` | — | MongoDB root 密码 |
+| `MONGO_APP_USER` | `appuser` | MongoDB 应用用户名 |
+| `MONGO_APP_PASSWORD` | — | MongoDB 应用用户密码 |
+| `MONGO_DB_NAME` | `sharely` | MongoDB 数据库名称 |
+| `SESSION_SECRET` | — | **必填** — 会话加密密钥 |
+| `BASE_URL` | `http://localhost:3000` | 生成分享链接的公开基础 URL（末尾不含 `/`） |
+| `SITE_NAME` | `sharely` | Open Graph 嵌入中的站点名称 |
+| `MAX_FILE_SIZE_MB` | `100` | 标准上传的最大文件大小（MB）（分块上传独立支持最大 2GB） |
+| `ALLOW_REGISTRATION` | `true` | `false` 禁用公开注册 |
+| `SMTP_HOST` | — | SMTP 服务器主机名；留空则禁用邮件功能 |
+| `SMTP_PORT` | `587` | SMTP 端口 |
+| `SMTP_SECURE` | `false` | 隐式 TLS（端口 465）填 `true`，STARTTLS 填 `false` |
+| `SMTP_USER` | — | SMTP 用户名 |
+| `SMTP_PASS` | — | SMTP 密码 |
+| `SMTP_FROM` | _（SMTP_USER）_ | 外发邮件的发件人地址 |
+| `UPLOAD_DIR` | `./uploads` | 上传目录的绝对路径 |
+| `NODE_ENV` | — | `production` 启用安全 Cookie |
+
+---
+
+## 6. 数据模型
+
+### User（`src/models/User.js`）
+
+```
+{
+  username:                    String（3–32，唯一，字母数字 + _-）
+  password:                    String（bcrypt，12 轮）
+  role:                        'admin' | 'user'
+  apiKey:                      String（遗留，迁移后为空）
+  apiKeyHash:                  String（SHA-256，唯一，sparse）
+  apiKeyPrefix:                String（明文的前 8 个字符）
+  folderName:                  String（唯一，sparse，最大 64）
+  avatarExt:                   String | null（.jpg/.png/.gif/.webp）
+  embedMode:                   'embed' | 'raw'
+  isActive:                    Boolean
+  email:                       String（小写，唯一，sparse）
+  emailVerified:               Boolean
+  emailVerificationToken:      String | null（明文的 SHA-256 哈希）
+  emailVerificationExpires:    Date | null
+  passwordResetToken:          String | null（SHA-256 哈希）
+  passwordResetExpires:        Date | null
+  language:                    'en'|'de'|'fr'|'es'|'it'|'pt'|'ja'|'zh'
+  predefinedTags:              [String]（最多 100 个标签 × 50 个字符）
+  createdAt:                   Date
+}
+```
+
+**重要方法：**
+- `user.comparePassword(candidate)` — bcrypt 比较
+- `user.regenerateApiKey()` — 生成新明文，存储哈希，返回明文（仅显示一次）
+- `User.findByApiKey(plaintext)` — 通过 SHA-256 哈希查找，仅限活跃用户
+
+### File（`src/models/File.js`）
+
+```
+{
+  shortId:      String（8 个十六进制字符：6 位时间戳 + 2 位随机，唯一）
+  deleteToken:  String（32 个十六进制字符，唯一）
+  originalName: String（已净化）
+  storedName:   String（相对路径："folderName/8hex.ext"）
+  mimeType:     String
+  size:         Number（字节）
+  uploader:     ObjectId → User
+  views:        Number
+  tags:         [String]（最多 20 × 50 个字符）
+  createdAt:    Date
+}
+```
+
+**虚拟属性：**
+- `sizeHuman` — 人类可读的大小（B / KB / MB / GB）
+- `displayType` — 分类：`image|video|audio|pdf|code|text|file`
+
+**Short ID 算法：**
+```
+shortId = hex(seconds_since_2024-01-01, 6 chars) + randomBytes(2).hex()
+```
+
+### Collection（`src/models/Collection.js`）
+
+```
+{
+  shortId:     String（8 位十六进制，唯一）
+  name:        String（最大 100）
+  description: String（最大 500）
+  owner:       ObjectId → User
+  files:       [ObjectId → File]
+  password:    String | null（bcrypt）
+  expiresAt:   Date | null
+  createdAt:   Date
+}
+```
+
+> 过期的集合将在到期后 7 天由 MongoDB TTL 索引自动删除。
+
+### ShareLink（`src/models/ShareLink.js`）
+
+```
+{
+  token:         String（32 位十六进制，唯一）
+  file:          ObjectId → File
+  createdBy:     ObjectId → User
+  label:         String（最大 100）
+  password:      String | null（bcrypt）
+  expiresAt:     Date | null
+  downloadLimit: Number（-1 = 无限制）
+  downloadCount: Number
+  createdAt:     Date
+}
+```
+
+> 与集合相同：通过 TTL 索引在过期后享有 7 天宽限期。
+
+### SiteSettings（`src/models/SiteSettings.js`）
+
+单例文档（`_id: 'singleton'`）：
+
+```
+{
+  operatorName:        String
+  operatorAddress:     String
+  operatorEmail:       String
+  cloudflareAnalytics: Boolean
+  fileRetentionDays:   Number（0 = 禁用）
+  encryptionAtRest:    Boolean
+  sessionDurationDays: Number（默认：7）
+  allowRegistration:   Boolean
+}
+```
+
+### AuditLog（`src/models/AuditLog.js`）
+
+```
+{
+  timestamp: Date（TTL 索引：90 天）
+  userId:    ObjectId → User | null
+  username:  String | null
+  action:    String
+  ip:        String | null
+  meta:      Mixed（特定于操作的元数据）
+}
+```
+
+---
+
+## 7. REST API
+
+### 基础 URL：`/api`
+
+所有 JSON 端点均返回 `Content-Type: application/json`。错误格式：`{ "error": "消息" }`。
+
+---
+
+### 认证（`/api/auth`）
+
+| 方法 | 路径 | 认证 | 描述 |
+|---|---|---|---|
+| `GET` | `/me` | 会话 | 当前登录用户 |
+| `POST` | `/login` | — | 登录（限流：10 次/15 分钟） |
+| `POST` | `/register` | — | 注册（限流，第一个用户成为管理员） |
+| `POST` | `/logout` | — | 退出登录 |
+| `GET` | `/smtp-enabled` | — | 检查 SMTP 是否已配置 |
+| `GET` | `/verify-email?token=` | — | 验证邮箱地址 |
+| `GET` | `/verify-reset-token?token=` | — | 验证重置令牌 |
+| `POST` | `/forgot-password` | — | 发送密码重置邮件（限流：5 次/小时） |
+| `POST` | `/reset-password` | — | 设置新密码 |
+
+**登录请求：**
+```json
+POST /api/auth/login
+{ "username": "max", "password": "meinPasswort123" }
+```
+
+**登录响应：**
+```json
+{
+  "user": {
+    "id": "...", "username": "max", "role": "user",
+    "avatarUrl": null, "email": "max@example.com",
+    "emailVerified": true, "language": "de"
+  }
+}
+```
+
+---
+
+### 文件上传
+
+| 方法 | 路径 | 认证 | 描述 |
+|---|---|---|---|
+| `POST` | `/upload` | API 密钥 | ShareX 上传（`app.js` 中的遗留端点） |
+| `POST` | `/api/upload` | API 密钥 | ShareX/API 上传（字段：`file`） |
+| `POST` | `/api/web-upload` | 会话 | Web 上传（字段：`files[]`，最多 500） |
+| `POST` | `/api/chunk/init` | 会话 | 初始化分块上传 |
+| `POST` | `/api/chunk/:uploadId` | 会话 | 上传单个分块（字段：`chunk`） |
+| `POST` | `/api/chunk/:uploadId/complete` | 会话 | 合并分块 |
+| `DELETE` | `/api/chunk/:uploadId` | 会话 | 取消上传并清理 |
+
+**API 上传响应：**
+```json
+{
+  "url": "https://example.com/f/a1b2c3d4",
+  "raw": "https://example.com/f/a1b2c3d4/raw",
+  "delete_url": "https://example.com/api/delete/a1b2c3d4",
+  "short_id": "a1b2c3d4",
+  "filename": "screenshot.png",
+  "size": 102400
+}
+```
+
+#### 分块上传流程
+
+1. `POST /api/chunk/init` → `{ uploadId: "32hex" }`
+2. `POST /api/chunk/:uploadId`（Body：`chunkIndex=N`，文件：`chunk`）→ `{ received: N }`  
+   并行上传 3–5 个分块
+3. `POST /api/chunk/:uploadId/complete` → `{ files: [fileObject] }`
+
+---
+
+### 文件管理
+
+| 方法 | 路径 | 认证 | 描述 |
+|---|---|---|---|
+| `GET` | `/api/gallery` | 会话 | 自己的文件（管理员：所有文件），分页（24 个/页），筛选：`q`、`type`、`tag`、`page` |
+| `GET` | `/api/file/:shortId` | — | 文件元数据（递增访问计数） |
+| `PATCH` | `/api/file/:shortId` | 会话 | 更新标签/名称 |
+| `DELETE` | `/api/file/:shortId` | 会话 | 删除文件 |
+| `DELETE` | `/api/delete/:shortId` | API 密钥 | 删除文件（API 密钥认证） |
+| `POST` | `/api/files/bulk` | 会话 | 批量操作：`delete`、`tag`、`removeTag`、`addToCollection`、`moveToCollection` |
+| `GET` | `/api/tags` | 会话 | 用户的所有标签建议 |
+
+**相册查询参数：**
+- `q` — 在文件名中搜索（正则表达式安全）
+- `type` — `all|image|video|audio|pdf|code`
+- `tag` — 精确标签筛选
+- `page` — 页码（默认：1）
+
+---
+
+### 用户设置
+
+| 方法 | 路径 | 认证 | 描述 |
+|---|---|---|---|
+| `GET` | `/api/my-key` | 会话 | 显示 API 密钥前缀 |
+| `POST` | `/api/regen-key` | 会话 | 重新生成 API 密钥 |
+| `GET` | `/api/sharex-config` | 会话 | 下载 ShareX `.sxcu`（重新生成密钥） |
+| `PATCH` | `/api/user/username` | 会话 | 修改用户名（需要密码） |
+| `PATCH` | `/api/user/password` | 会话 | 修改密码 |
+| `PATCH` | `/api/user/email` | 会话 | 修改邮箱（发送验证邮件） |
+| `PATCH` | `/api/user/language` | 会话 | 设置界面语言 |
+| `PATCH` | `/api/user/embed-mode` | 会话 | 设置嵌入模式（`embed`/`raw`） |
+| `POST` | `/api/user/resend-verification` | 会话 | 重新发送验证邮件 |
+| `GET` | `/api/user/export` | 会话 | 数据导出（GDPR 第 20 条），JSON 格式 |
+| `DELETE` | `/api/user/account` | 会话 | 删除账户（GDPR 第 17 条，需要密码） |
+| `GET` | `/api/user/predefined-tags` | 会话 | 获取预定义标签 |
+| `PATCH` | `/api/user/predefined-tags` | 会话 | 更新预定义标签 |
+| `POST` | `/api/user/avatar` | 会话 | 上传头像（最大 2MB，JPEG/PNG/GIF/WebP） |
+| `DELETE` | `/api/user/avatar` | 会话 | 删除头像 |
+| `GET` | `/api/user/avatar/:userId` | — | 提供头像服务 |
+
+---
+
+### 分享链接
+
+| 方法 | 路径 | 认证 | 描述 |
+|---|---|---|---|
+| `GET` | `/api/file/:shortId/share-links` | 会话（所有者/管理员） | 文件的所有分享链接 |
+| `POST` | `/api/file/:shortId/share-links` | 会话（所有者/管理员） | 创建分享链接 |
+| `DELETE` | `/api/share-links/:token` | 会话（所有者/创建者/管理员） | 删除分享链接 |
+| `GET` | `/api/share-links/:token` | — | 分享链接元数据（公开） |
+| `POST` | `/api/share-links/:token/verify` | — | 验证分享链接密码 |
+
+**创建分享链接：**
+```json
+POST /api/file/a1b2c3d4/share-links
+{
+  "label": "给同事用",
+  "password": "密码",
+  "expiresAt": "2025-12-31T23:59:59Z",
+  "downloadLimit": 10
+}
+```
+
+---
+
+### 集合
+
+| 方法 | 路径 | 认证 | 描述 |
+|---|---|---|---|
+| `GET` | `/api/collections` | 会话 | 自己的集合（管理员：所有集合） |
+| `POST` | `/api/collections` | 会话 | 创建集合 |
+| `GET` | `/api/collections/:id` | — | 查看集合（公开，设置了密码则需要输入） |
+| `PATCH` | `/api/collections/:id` | 会话（所有者/管理员） | 更新集合 |
+| `DELETE` | `/api/collections/:id` | 会话（所有者/管理员） | 删除集合 |
+| `POST` | `/api/collections/:id/files` | 会话（所有者/管理员） | 向集合添加文件 |
+| `DELETE` | `/api/collections/:id/files/:fileShortId` | 会话（所有者/管理员） | 从集合中移除文件 |
+| `POST` | `/api/collections/:id/verify` | — | 验证集合密码 |
+
+---
+
+### 管理员端点
+
+| 方法 | 路径 | 认证 | 描述 |
+|---|---|---|---|
+| `GET` | `/api/admin/stats` | 管理员 | 仪表板统计信息 |
+| `GET` | `/api/admin/users` | 管理员 | 所有用户（含文件数量） |
+| `POST` | `/api/admin/users` | 管理员 | 创建用户 |
+| `PATCH` | `/api/admin/users/:id/toggle` | 管理员 | 启用/禁用用户 |
+| `PATCH` | `/api/admin/users/:id/role` | 管理员 | 修改用户角色 |
+| `DELETE` | `/api/admin/users/:id` | 管理员 | 删除用户 |
+| `POST` | `/api/admin/users/:id/regen-key` | 管理员 | 重新生成 API 密钥 |
+| `PATCH` | `/api/admin/users/:id/password` | 管理员 | 设置密码 |
+| `PATCH` | `/api/admin/users/:id/folder` | 管理员 | 修改文件夹名称（移动文件） |
+| `GET` | `/api/admin/files` | 管理员 | 所有文件，分页（30 个/页） |
+| `GET` | `/api/admin/site-settings` | 管理员 | 读取运营者设置 |
+| `PATCH` | `/api/admin/site-settings` | 管理员 | 更新运营者设置 |
+| `GET` | `/api/admin/audit-log` | 管理员 | 分页审计日志（50 条/页） |
+| `GET` | `/api/admin/audit-log/export` | 管理员 | 下载审计日志 CSV |
+| `GET` | `/api/site-settings` | — | 运营者公开信息（用于隐私政策页面） |
+
+---
+
+### 站点设置（公开）
+
+```json
+GET /api/site-settings
+{
+  "operatorName": "Musterfirma GmbH",
+  "operatorAddress": "Musterstr. 1, 12345 Musterstadt",
+  "operatorEmail": "datenschutz@example.com",
+  "cloudflareAnalytics": false,
+  "fileRetentionDays": 365,
+  "encryptionAtRest": false,
+  "sessionDurationDays": 7
+}
+```
+
+---
+
+## 8. WebSocket API
+
+**连接：** `wss://example.com/ws`（仅限已登录用户，需要会话 Cookie）
+
+### 协议
+
+**客户端 → 服务器（请求）：**
+```json
+{ "id": "req-abc123", "action": "file:list", "payload": { "type": "image", "page": 1 } }
+```
+
+**服务器 → 客户端（响应）：**
+```json
+{ "id": "req-abc123", "data": { ... } }
+```
+
+**服务器 → 客户端（错误）：**
+```json
+{ "id": "req-abc123", "error": "Forbidden", "status": 403 }
+```
+
+**服务器 → 客户端（广播）：**
+```json
+{ "event": "file:uploaded", "data": { "shortId": "a1b2c3d4", "uploaderId": "..." } }
+```
+
+### 可用操作
+
+| 操作 | 认证 | 描述 |
+|---|---|---|
+| `site-settings:get` | — | 站点公开设置 |
+| `auth:me` | 用户 | 当前用户数据 |
+| `file:get` | 用户 | 文件详情（递增访问次数） |
+| `file:list` | 用户 | 带筛选/分页的文件列表 |
+| `file:delete` | 用户 | 删除文件 |
+| `user:get-key` | 用户 | API 密钥前缀 |
+| `user:regen-key` | 用户 | 重新生成 API 密钥 |
+| `user:change-password` | 用户 | 修改密码 |
+| `user:change-username` | 用户 | 修改用户名 |
+| `user:change-email` | 用户 | 修改邮箱 |
+| `user:change-language` | 用户 | 设置语言 |
+| `user:change-embed-mode` | 用户 | 设置嵌入模式 |
+| `user:resend-verification` | 用户 | 重新发送验证邮件 |
+| `user:export` | 用户 | 数据导出 |
+| `user:delete-account` | 用户 | 删除账户 |
+| `admin:stats` | 管理员 | 仪表板统计信息 |
+| `admin:settings:get` | 管理员 | 读取站点设置 |
+| `admin:settings:update` | 管理员 | 更新站点设置 |
+| `admin:users:list` | 管理员 | 所有用户 |
+| `admin:users:create` | 管理员 | 创建用户 |
+| `admin:users:toggle` | 管理员 | 启用/禁用用户 |
+| `admin:users:role` | 管理员 | 修改用户角色 |
+| `admin:users:delete` | 管理员 | 删除用户 |
+| `admin:users:regen-key` | 管理员 | 重新生成 API 密钥 |
+| `admin:users:password` | 管理员 | 设置密码 |
+| `admin:users:folder` | 管理员 | 修改文件夹名称 |
+| `admin:files:list` | 管理员 | 所有文件 |
+| `admin:audit-log:list` | 管理员 | 分页审计日志 |
+
+### 广播事件
+
+| 事件 | 接收者 | 负载 |
+|---|---|---|
+| `file:uploaded` | 上传者 | `{ shortId, uploaderId }` |
+| `file:deleted` | 文件所有者 | `{ shortId, uploaderId }` |
+| `file:view` | 所有人 | `{ shortId, views }` |
+| `user:created` | 管理员 | `{ id, username, role, ... }` |
+| `user:deleted` | 管理员 | `{ id }` |
+| `user:updated` | 管理员 | `{ id, ...已更改字段 }` |
+| `audit:log` | 管理员 | 完整的 AuditLog 对象 |
+| `settings:updated` | 管理员 | 更新后的 SiteSettings 对象 |
+| `stats:invalidate` | 管理员 | `{}`（触发统计刷新） |
+
+---
+
+## 9. 文件服务路由
+
+### `/f/:shortId` — 文件查看器
+
+- **浏览器请求：** 转发到 React SPA（`index.html`）— SPA 渲染查看器。
+- **社交媒体机器人**（Discord、Telegram、Twitter 等）：返回带有 Open Graph / Twitter Card 元标签的最小 HTML 页面。
+  - `embedMode = 'embed'`：带重定向的 OG HTML
+  - `embedMode = 'raw'` + 图片/视频/音频：HTTP 302 → `/f/:shortId/raw`
+
+### `/f/:shortId/raw` — 直接访问
+
+以 HTTP 响应的形式提供文件，支持 Range 请求（206 Partial Content）。图片/视频/音频：`Content-Disposition: inline`，其他：`attachment`。
+
+### `/f/:shortId/download` — 强制下载
+
+与 `/raw` 相同，但始终使用 `Content-Disposition: attachment`。
+
+### `/f/:shortId/thumb` — 缩略图
+
+返回 JPEG 缩略图（适用于视频和 PDF）。`Cache-Control: public, max-age=86400`。
+
+### `/f/:shortId/delete/:token` — ShareX 删除
+
+通过唯一删除令牌无需会话即可删除文件。
+
+### `/s/:token` — 分享链接文件服务（`src/routes/shares.js`）
+
+验证密码（通过会话标志）、过期日期和下载限制，然后提供文件。
+
+---
+
+## 10. 身份验证与安全
+
+### 会话认证
+
+- 带 MongoDB 存储的 Express 会话（`connect-mongo`）
+- 会话 Cookie：`httpOnly: true`、`sameSite: 'strict'`，生产环境下 `secure: true`
+- 会话时长：通过 `SiteSettings.sessionDurationDays` 配置（默认：7 天），实时缓存 60 秒
+
+### API 密钥认证
+
+- API 密钥以 SHA-256 哈希形式存储，从不以明文存储
+- 前 8 个字符作为 `apiKeyPrefix` 存储（用于展示）
+- 查找：`User.findByApiKey(plaintext)` 计算哈希并在 `apiKeyHash` 中搜索
+- 下载 ShareX 配置时密钥会被重新生成 — 明文仅在那一刻可见
+
+### 中间件链（`src/middleware/auth.js`）
+
+```
+requireLogin    → 检查 req.session.user → 未登录返回 401
+requireAdmin    → 类似 requireLogin，额外要求 role === 'admin' → 403
+requireApiKey   → 检查 Authorization 请求头或 req.body.token
+```
+
+### CSRF 防护
+
+`app.js` 中的 `requireSameOrigin()` 对所有 API 路由比较 `Origin` 请求头与 `Host` 请求头。配合 `sameSite: 'strict'` Cookie 共同防护。
+
+### 内容安全策略
+
+```
+default-src 'self';
+script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com;
+style-src 'self' 'unsafe-inline';
+img-src 'self' data: blob:;
+media-src 'self' blob:;
+connect-src 'self' https://cloudflareinsights.com;
+frame-ancestors 'self';
+```
+
+### 安全响应头
+
+- `X-Frame-Options: SAMEORIGIN`
+- `X-Content-Type-Options: nosniff`
+
+### 限流
+
+| 端点 | 限制 | 时间窗口 |
+|---|---|---|
+| 上传（`/upload`、`/api/upload`、`/api/web-upload`） | 60 次请求 | 15 分钟 |
+| 认证（`/api/auth/login`、`/register` 等） | 10 次请求 | 15 分钟 |
+| 密码重置 | 5 次请求 | 1 小时 |
+
+### 文件黑名单
+
+以下 MIME 类型和扩展名在上传时将被拒绝：
+
+**被阻止的 MIME 类型：** `application/x-executable`、`application/x-sh`、`application/x-csh`、`application/x-bat`
+
+**被阻止的扩展名：** `.bat`、`.cmd`、`.com`、`.ps1`、`.psm1`、`.psd1`、`.sh`、`.bash`、`.csh`、`.zsh`、`.fish`、`.vbs`、`.vbe`、`.jse`、`.scr`、`.pif`、`.application`、`.gadget`、`.hta`、`.php`、`.php3–5`、`.phtml`、`.asp`、`.aspx`、`.jsp`、`.jspx`、`.cfm`
+
+### 路径遍历防护
+
+所有通过 `resolveUploadPath()` 的文件访问都会验证解析路径是否位于 `UPLOAD_DIR` 内。
+
+---
+
+## 11. 上传系统
+
+### 标准上传（Multer）
+
+- **存储方式：** `multer.diskStorage` → `uploads/{folderName}/{8hex}{.ext}`
+- **文件名：** `crypto.randomBytes(4).hex() + 原始扩展名`
+- **限制：** `MAX_FILE_SIZE_MB`（默认：100 MB）
+- **存储位置：** 用户专属文件夹（`user.folderName`）
+
+### 分块上传（>250 MB）
+
+前端客户端会自动为大文件切换到分块模式。
+
+**服务器端目录结构：**
+```
+uploads/.chunks/{uploadId}/
+  meta.json          { filename, mimeType, totalSize, totalChunks, userId, createdAt }
+  chunk-0
+  chunk-1
+  ...
+  chunk-N
+```
+
+**分块大小：** 10–20 MB（向后兼容最多接受 51 MB）  
+**并发数：** 3–5 个分块同时上传  
+**合并方式：** 基于流（不在 RAM 中完全加载）
+
+### 头像上传
+
+- **存储方式：** `multer.memoryStorage()`（无磁盘缓冲）
+- **存储位置：** `uploads/.avatars/{userId}{.ext}`
+- **限制：** 2 MB
+- **格式：** JPEG、PNG、GIF、WebP
+
+---
+
+## 12. 缩略图生成
+
+缩略图在上传后异步生成（`.catch(() => {})` — 错误会被静默忽略）。
+
+### 视频缩略图（ffmpeg）
+
+```bash
+ffmpeg -y -i <file> -ss 00:00:01 -vframes 1 \
+  -vf "scale=320:320:force_original_aspect_ratio=increase,crop=320:320" \
+  -q:v 3 uploads/.thumbnails/<shortId>.jpg
+```
+
+### PDF 缩略图（Ghostscript）
+
+```bash
+gs -dNOPAUSE -dBATCH -dSAFER \
+  -sDEVICE=jpeg -dFirstPage=1 -dLastPage=1 \
+  -r72 -dJPEGQ=85 \
+  -sOutputFile=uploads/.thumbnails/<shortId>.jpg \
+  <file>
+```
+
+**超时：** 每次缩略图生成 30 秒  
+**回退：** 如果 ffmpeg/ghostscript 不可用，生成将静默跳过。
+
+### 补充生成脚本
+
+```bash
+npm run migrate:thumbnails
+# 或在容器中：
+docker exec -it <container> npm run migrate:thumbnails
+```
+
+---
+
+## 13. 邮件与 SMTP
+
+### 配置
+
+设置 `SMTP_HOST` 后 SMTP 即被激活。`mailer.isConfigured()` 检查该值。
+
+### 邮件模板
+
+所有邮件均以用户的语言发送（8 种语言）。模板内嵌于 `src/utils/mailer.js`。
+
+**发送的邮件类型：**
+
+| 类型 | 触发器 | 令牌有效期 |
+|---|---|---|
+| 邮箱验证 | 注册、修改邮箱 | 24 小时 |
+| 密码重置 | `POST /api/auth/forgot-password` | 1 小时 |
+
+### 令牌安全
+
+- 令牌：`crypto.randomBytes(32).hex()`（64 个十六进制字符）
+- 存储形式：令牌的 SHA-256 哈希
+- 邮件中包含明文令牌作为 URL 参数
+- 验证方式：将收到令牌的哈希与存储的哈希进行比较
+
+---
+
+## 14. 国际化
+
+**库：** i18next + react-i18next + i18next-browser-languagedetector
+
+**支持的语言：**
+
+| 代码 | 语言 |
+|---|---|
+| `en` | English |
+| `de` | Deutsch |
+| `fr` | Français |
+| `es` | Español |
+| `it` | Italiano |
+| `pt` | Português |
+| `ja` | 日本語 |
+| `zh` | 中文 |
+
+**语言选择：**
+1. 浏览器语言检测（自动）
+2. 数据库中的用户偏好（`user.language`）
+3. 通过 `PATCH /api/user/language` 持久化
+
+翻译文件：`client/src/i18n/locales/{code}.json`
+
+---
+
+## 15. 前端（React SPA）
+
+### 路由配置（`client/src/App.jsx`）
+
+| 路由 | 组件 | 认证 |
+|---|---|---|
+| `/` | 重定向 → `/gallery` | 否 |
+| `/auth/login` | Login.jsx | 否 |
+| `/auth/register` | Register.jsx | 否 |
+| `/auth/forgot-password` | ForgotPassword.jsx | 否 |
+| `/auth/reset-password` | ResetPassword.jsx | 否 |
+| `/install` | Install.jsx | 否 |
+| `/upload` | Upload.jsx | **是** |
+| `/gallery` | Gallery.jsx | **是** |
+| `/f/:shortId` | FileView.jsx | **是** |
+| `/collections` | Collections.jsx | **是** |
+| `/c/:id` | CollectionView.jsx | 否（公开） |
+| `/s/:token` | ShareView.jsx | 否（公开） |
+| `/settings` | Settings.jsx | **是** |
+| `/admin` | Dashboard.jsx | **管理员** |
+| `/admin/users` | Users.jsx | **管理员** |
+| `/admin/files` | Files.jsx | **管理员** |
+| `/admin/audit-log` | AuditLog.jsx | **管理员** |
+| `/admin/site-settings` | SiteSettings.jsx | **管理员** |
+| `/admin/import` | Import.jsx | **管理员** |
+| `/privacy` | PrivacyPolicy.jsx | 否 |
+| `/terms` | TermsOfService.jsx | 否 |
+
+### 认证上下文（`client/src/context/AuthContext.jsx`）
+
+已登录用户的全局状态。应用启动时通过 `GET /api/auth/me` 初始化。
+
+### WebSocket Hook（`client/src/hooks/useWebSocket.js`）
+
+管理持久化的 WS 连接。提供 `sendMessage()` 和事件处理器注册。连接断开时的重连逻辑。
+
+### UI 组件
+
+基于 **shadcn/ui**（Radix UI Primitives + Tailwind CSS）：
+
+- `Dialog`、`AlertDialog`、`DropdownMenu`、`ContextMenu`、`Popover`
+- `Select`、`Checkbox`、`Input`、`Textarea`、`Label`
+- `Card`、`Badge`、`Button`、`Separator`、`Tabs`、`Table`
+- `Toast` / `Toaster` 用于通知
+- `Calendar` / `DateTimePicker` 用于选择过期日期
+- `Pagination` 用于分页列表
+- `ScrollArea`、`Tooltip`
+
+---
+
+## 16. 管理后台
+
+管理后台（`/admin/*`）仅限 `role: 'admin'` 的用户访问。
+
+### 仪表板（`/admin`）
+
+- 用户总数、文件数、存储使用量
+- 最近上传的 10 个文件
+- 通过 WebSocket 实时更新（`stats:invalidate`）
+
+### 用户管理（`/admin/users`）
+
+- 所有用户及其文件数量和存储使用量
+- 创建用户、启用/禁用、修改角色
+- 重置密码、重新生成 API 密钥
+- 修改文件夹名称（物理文件在服务器上移动）
+- 删除用户（所有文件将被删除）
+
+### 文件管理（`/admin/files`）
+
+- 所有用户的所有文件，分页显示
+- 按文件名搜索
+- 删除文件
+
+### 审计日志（`/admin/audit-log`）
+
+- 所有操作的分页日志（50 条/页）
+- 按用户名和操作类型筛选
+- CSV 导出（用于合规目的）
+
+### 站点设置（`/admin/site-settings`）
+
+- 运营者信息（名称、地址、邮箱）
+- 启用 Cloudflare Analytics
+- 文件保留时长
+- 会话时长
+- 启用/禁用用户注册
+
+### XBackBone 导入（`/admin/import`）
+
+- 从 XBackBone SQLite 数据库预览并导入
+- 按用户名匹配用户
+- 幂等性（已导入的文件将被跳过）
+
+---
+
+## 17. GDPR / 隐私保护
+
+| 功能 | GDPR 条款 |
+|---|---|
+| 隐私政策（可配置） | 第 13/14 条 – 透明度 |
+| 服务条款页面（可配置） | 第 13/14 条 – 透明度 |
+| 数据导出（含 URL 的 JSON） | 第 20 条 – 数据可携带性 |
+| 账户自删除（文件+数据） | 第 17 条 – 删除权 |
+| 审计日志（通过 MongoDB TTL 保留 90 天） | 第 5(2) 条 – 问责制 |
+| 审计日志 CSV 导出 | 第 5(2) 条 – 问责制 |
+| 可配置的文件保留期 | 第 5(1)(e) 条 – 存储限制 |
+| API 密钥以 SHA-256 哈希形式存储 | 第 32 条 – 安全性 |
+| 密码以 bcrypt（12 轮）形式存储 | 第 32 条 – 安全性 |
+| Cloudflare Analytics 的 Cookie 同意 | 第 13 条 – 透明度 |
+| 账户删除时匿名化 | 第 17 条 – 删除权 |
+
+### GDPR 删除流程
+
+删除账户时（`user:delete-account` / `DELETE /api/user/account`）：
+1. 用户的所有文件从磁盘删除
+2. 缩略图被删除
+3. 头像被删除
+4. 审计日志条目被匿名化（`username: '[deleted]'`、`ip: null`、`userId: null`）
+5. 用户文档被删除
+6. 会话被销毁
+
+---
+
+## 18. 后台任务
+
+### 保留期清理（`src/jobs/retentionCleanup.js`）
+
+- **执行时机：** 启动时以及之后每天执行（`setInterval(runRetentionCleanup, 24h)`）
+- **操作：** 若 `SiteSettings.fileRetentionDays > 0`，则删除超过该天数的文件
+- 删除内容：磁盘上的文件、缩略图、MongoDB 文档
+- 向管理员广播 `stats:invalidate`
+
+### MongoDB TTL 索引（自动）
+
+| 集合 | TTL | 触发字段 |
+|---|---|---|
+| `AuditLog` | 90 天 | `timestamp` |
+| `Collection` | `expiresAt` 后 7 天 | `expiresAt` |
+| `ShareLink` | `expiresAt` 后 7 天 | `expiresAt` |
+
+---
+
+## 19. 部署
+
+### Docker（推荐）
+
+```bash
+git clone https://github.com/Christianoooooo/sharely.git
+cd sharely
+cp .env.example .env
+# 编辑 .env（SESSION_SECRET、MONGO 密码、BASE_URL）
+docker compose up -d
+```
+
+**服务：**
+- `app` — Node.js 应用（端口 3000）
+- `mongo` — MongoDB 7（端口 127.0.0.1:27017，外部不可访问）
+
+**数据卷：**
+- `uploads` — 持久文件存储
+- `mongo_data` — MongoDB 数据
+
+**健康检查：** 应用检查 `/` 是否返回 HTTP 200，MongoDB 检查 `db.adminCommand('ping')`。
+
+### Nginx 反向代理
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name files.example.com;
+
+    client_max_body_size 2100M;  # 至少要大于最大分块大小加缓冲
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket 支持
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+```
+
+> `.env` 中的 `BASE_URL` 必须与公开域名一致。
+
+### 首次启动
+
+第一个注册的用户将自动获得 `admin` 角色（`User.countDocuments() === 0`）。
+
+---
+
+## 20. 开发环境
+
+### 前提条件
+
+- Node.js ≥ 18
+- MongoDB（本地或通过 Docker）
+- 可选：ffmpeg、ghostscript（用于缩略图）
+
+### 搭建环境
+
+```bash
+# 后端
+npm install
+cp .env.example .env
+# 编辑 .env
+
+# 前端
+cd client
+npm install
+```
+
+### 启动
+
+```bash
+# 后端（端口 3000，使用 nodemon）
+npm run dev
+
+# 前端（端口 5173，另开终端）
+cd client
+npm run dev
+```
+
+Vite 开发服务器会自动将 API 请求代理到 `localhost:3000`。
+
+### 构建
+
+```bash
+npm run build   # 构建 client/dist/，后端不变
+npm start       # 启动生产环境 Express 服务器
+```
+
+---
+
+## 21. 迁移与脚本
+
+### 自动迁移（每次启动时）
+
+这些迁移在 `app.js` 启动时运行，具有幂等性：
+
+| 迁移 | 文件 | 功能 |
+|---|---|---|
+| 用户文件夹迁移 | `src/migrations/migrateUserFolders.js` | 将文件从 `uploads/` 移动到 `uploads/{folderName}/` |
+| API 密钥哈希迁移 | `src/migrations/migrateApiKeyHashes.js` | 将明文 API 密钥转换为 SHA-256 哈希 |
+
+### 手动脚本
+
+```bash
+# 为已有文件生成缩略图
+npm run migrate:thumbnails
+# 或：
+node scripts/generate-missing-thumbnails.js
+
+# 将上传文件移动到用户文件夹（手动）
+npm run migrate:user-folders
+# 或：
+node scripts/migrate-uploads-to-user-folders.js
+```
+
+### 数据库初始化（Docker）
+
+`scripts/mongo-init.js` 在 MongoDB 容器首次启动时执行，以正确权限创建应用用户。
+
+---
+
+## 22. 端到端测试
+
+**框架：** Playwright（`@playwright/test`）
+
+### 测试文件
+
+| 文件 | 测试套件 |
+|---|---|
+| `e2e/upload.spec.js` | 上传流程 |
+| `e2e/gallery.spec.js` | 相册与文件管理 |
+| `e2e/admin.spec.js` | 管理后台 |
+| `e2e/sharelink.spec.js` | 分享链接的创建与使用 |
+| `e2e/tags.spec.js` | 标签管理 |
+| `e2e/bulk-actions-fixes.spec.js` | 批量操作 |
+
+### 运行测试
+
+```bash
+# 所有测试
+npm run test:e2e
+
+# 带 UI 界面
+npm run test:e2e:ui
+```
+
+**Playwright 配置：** `playwright.config.js`  
+**全局初始化：** `e2e/global-setup.js`（创建测试用户、管理员等）  
+**辅助函数：** `e2e/helpers.js`（共享辅助函数）
+
+---
+
+## 附录：审计日志操作列表
+
+| 操作 | 触发器 |
+|---|---|
+| `login` | 登录成功 |
+| `logout` | 退出登录 |
+| `register` | 注册 |
+| `upload` | 文件上传 |
+| `delete_file` | 文件已删除 |
+| `delete_account` | 账户已删除 |
+| `change_password` | 密码已修改 |
+| `change_username` | 用户名已修改 |
+| `change_email` | 邮箱已修改 |
+| `verify_email` | 邮箱已验证 |
+| `forgot_password` | 密码重置请求 |
+| `reset_password` | 密码已重置 |
+| `regen_api_key` | API 密钥已重新生成 |
+| `sharex_config` | ShareX 配置已下载 |
+| `export_data` | 数据导出 |
+| `admin_create_user` | 管理员：用户已创建 |
+| `admin_delete_user` | 管理员：用户已删除 |
+| `admin_toggle_user` | 管理员：用户已启用/禁用 |
+| `admin_change_role` | 管理员：用户角色已修改 |
+| `admin_change_password` | 管理员：密码已设置 |
+| `admin_regen_key` | 管理员：API 密钥已重新生成 |
+
+---
+
+*本文档由 sharely v1.0.0 源代码生成*

--- a/src/routes/docs.js
+++ b/src/routes/docs.js
@@ -198,15 +198,26 @@ router.get('/', (req, res) => {
   const host = (req.headers.host || '').split(':')[0];
   if (host !== DOCS_DOMAIN) return res.status(404).send('Not found');
 
-  let md;
-  try {
-    md = fs.readFileSync(path.resolve(__dirname, '../../DOCUMENTATION.md'), 'utf8');
-  } catch {
-    return res.status(500).send('Documentation not available');
-  }
-
   const lang = detectLang(req);
   const t    = I18N[lang];
+
+  // German → canonical DOCUMENTATION.md; all others → docs/{lang}.md → fallback to docs/en.md
+  let md;
+  const docRoot = path.resolve(__dirname, '../../');
+  const langFile = lang === 'de'
+    ? path.join(docRoot, 'DOCUMENTATION.md')
+    : path.join(docRoot, 'docs', `${lang}.md`);
+  const fallback = path.join(docRoot, 'docs', 'en.md');
+
+  try {
+    md = fs.readFileSync(langFile, 'utf8');
+  } catch {
+    try {
+      md = fs.readFileSync(fallback, 'utf8');
+    } catch {
+      return res.status(500).send('Documentation not available');
+    }
+  }
   const body = mdToHtml(md);
 
   // Language switcher options


### PR DESCRIPTION
Adds docs/{en,fr,es,it,pt,ja,zh}.md — complete translations of DOCUMENTATION.md (de). The docs route now loads docs/{lang}.md per detected language, falls back to docs/en.md, and uses DOCUMENTATION.md directly for German. Dockerfile updated to copy docs/*.md into the image.

https://claude.ai/code/session_01PQkLzovdCw5kytPV6nZtwS