### PR TITLE
Refactor README documentation link formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
   <img src="docs/assets/logo.png" alt="Logo">
 </p>
 
-<p align="center">
-  <a href="https://sharely.christian.pizza/docs"><strong>📖 Documentation →</strong></a>
-</p>
-
-A self-hosted file sharing platform with a clean web interface, ShareX integration, and API access. Upload screenshots, files, and media — then instantly share them via short links.
+A self-hosted file sharing platform with a clean web interface, ShareX integration, and API access. Upload screenshots, files, and media — then instantly share them via short links. Full documentation is available at [sharely.christian.pizza/docs](https://sharely.christian.pizza/docs).
 
 ![Gallery](docs/assets/gallery.png)
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
   <img src="docs/assets/logo.png" alt="Logo">
 </p>
 
-A self-hosted file sharing platform with a clean web interface, ShareX integration, and API access. Upload screenshots, files, and media — then instantly share them via short links.
+<p align="center">
+  <a href="https://sharely.christian.pizza/docs"><strong>📖 Documentation →</strong></a>
+</p>
 
-**[Documentation →](https://sharely.christian.pizza/docs)**
+A self-hosted file sharing platform with a clean web interface, ShareX integration, and API access. Upload screenshots, files, and media — then instantly share them via short links.
 
 ![Gallery](docs/assets/gallery.png)
 


### PR DESCRIPTION
## Summary
Updated the README.md to improve the documentation link presentation by integrating it into the main description paragraph rather than displaying it as a separate call-to-action button.

## Changes
- Consolidated the documentation link into the main description text
- Changed from a separate `**[Documentation →](url)**` line to an inline link within the paragraph
- Maintains the same destination URL while improving readability and flow

## Details
This is a minor documentation formatting change that makes the README more concise while keeping all information accessible. The documentation link is now naturally integrated into the opening description rather than standing alone as a separate element.

https://claude.ai/code/session_01VVLn8zMqgQqRrytuAFQ4BN